### PR TITLE
[FIXED JENKINS-34365] Not able to resolve hash of the revision

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource.java
@@ -384,6 +384,14 @@ public class BitbucketSCMSource extends SCMSource {
         List<? extends BitbucketBranch> branches = bitbucket.getBranches();
         for (BitbucketBranch b : branches) {
             if (b.getName().equals(bbHead.getBranchName())) {
+                if (b.getRawNode() == null) {
+                    if (getBitbucketServerUrl() == null) {
+                        listener.getLogger().format("Cannot resolve the hash of the revision in branch %s", b.getName());
+                    } else {
+                        listener.getLogger().format("Cannot resolve the hash of the revision in branch %s. Perhaps you are using Bitbucket Server previous to 4.x", b.getName());
+                    }
+                    return null;
+                }
                 if (getRepositoryType() == RepositoryType.MERCURIAL) {
                     return new MercurialRevision(head, b.getRawNode());
                 } else {


### PR DESCRIPTION
`revision.getHash()` is null when using v3.x.x of the server

The following stacktrace happens in this case:

```
Started by user xxxxx (xxxx) 
java.lang.NullPointerException 
at org.eclipse.jgit.lib.ObjectId.fromString(ObjectId.java:231) 
at jenkins.plugins.git.AbstractGitSCMSource$SpecificRevisionBuildChooser.<init>(AbstractGitSCMSource.java:388) 
at com.cloudbees.jenkins.plugins.bitbucket.BitbucketSCMSource.build(BitbucketSCMSource.java:411) 
at org.jenkinsci.plugins.workflow.multibranch.SCMBinder.create(SCMBinder.java:80) 
at org.jenkinsci.plugins.workflow.job.WorkflowRun.run(WorkflowRun.java:206) 
at hudson.model.ResourceController.execute(ResourceController.java:98) 
at hudson.model.Executor.run(Executor.java:410) 
Finished: FAILURE 
```

https://issues.jenkins-ci.org/browse/JENKINS-34365

@reviewbybees esp @amuniz @escoem