### PR TITLE
[JENKINS-33507] Add support for the Bitbucket server.

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/BitbucketPushEvent.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/BitbucketPushEvent.java
@@ -1,0 +1,12 @@
+package com.cloudbees.jenkins.plugins.bitbucket.api;
+
+/**
+ * Represents a push event coming from Bitbucket (webhooks).
+ */
+public interface BitbucketPushEvent
+{
+	/**
+	 * @return the destination repository that the push points to.
+	 */
+	BitbucketRepository getRepository();
+}

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/BitbucketPushEvent.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/BitbucketPushEvent.java
@@ -3,10 +3,9 @@ package com.cloudbees.jenkins.plugins.bitbucket.api;
 /**
  * Represents a push event coming from Bitbucket (webhooks).
  */
-public interface BitbucketPushEvent
-{
-	/**
-	 * @return the destination repository that the push points to.
-	 */
-	BitbucketRepository getRepository();
+public interface BitbucketPushEvent {
+    /**
+     * @return the destination repository that the push points to.
+     */
+    BitbucketRepository getRepository();
 }

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/events/BitbucketCloudPushEvent.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/events/BitbucketCloudPushEvent.java
@@ -1,0 +1,45 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.cloudbees.jenkins.plugins.bitbucket.client.events;
+
+import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketPushEvent;
+import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketRepository;
+import com.cloudbees.jenkins.plugins.bitbucket.client.repository.BitbucketCloudRepository;
+import org.codehaus.jackson.annotate.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class BitbucketCloudPushEvent implements BitbucketPushEvent
+{
+
+    private BitbucketCloudRepository repository;
+
+    public BitbucketRepository getRepository() {
+        return repository;
+    }
+
+    public void setRepository(BitbucketCloudRepository repository) {
+        this.repository = repository;
+    }
+
+}

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/events/BitbucketCloudPushEvent.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/events/BitbucketCloudPushEvent.java
@@ -29,8 +29,7 @@ import com.cloudbees.jenkins.plugins.bitbucket.client.repository.BitbucketCloudR
 import org.codehaus.jackson.annotate.JsonIgnoreProperties;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class BitbucketCloudPushEvent implements BitbucketPushEvent
-{
+public class BitbucketCloudPushEvent implements BitbucketPushEvent {
 
     private BitbucketCloudRepository repository;
 

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/BitbucketSCMSourcePushHookReceiver.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/BitbucketSCMSourcePushHookReceiver.java
@@ -96,14 +96,14 @@ public class BitbucketSCMSourcePushHookReceiver extends CrumbExclusion implement
             return HttpResponses.error(HttpServletResponse.SC_BAD_REQUEST, "X-Event-Key HTTP header invalid: " + eventKey);
         }
 
-		String bitbucketKey = req.getHeader("X-Bitbucket-Type");
+        String bitbucketKey = req.getHeader("X-Bitbucket-Type");
         BitbucketType instanceType = null;
         if (bitbucketKey != null) {
-			instanceType = BitbucketType.fromString(bitbucketKey);
-		}
-		if(instanceType == null){
-			LOGGER.info("No bitbucket type found, must be cloud!");
-			instanceType = BitbucketType.CLOUD;
+            instanceType = BitbucketType.fromString(bitbucketKey);
+        }
+        if(instanceType == null){
+            LOGGER.info("No bitbucket type found, must be cloud!");
+            instanceType = BitbucketType.CLOUD;
         }
 
         type.getProcessor().process(body, instanceType);

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/BitbucketType.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/BitbucketType.java
@@ -1,0 +1,31 @@
+package com.cloudbees.jenkins.plugins.bitbucket.hooks;
+
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+
+public enum BitbucketType
+{
+	CLOUD("cloud"),
+	SERVER("server"),
+	;
+	private String key;
+
+	BitbucketType(String key)
+	{
+		this.key = key;
+	}
+
+	public String getKey()
+	{
+		return key;
+	}
+
+	@CheckForNull
+	public static BitbucketType fromString(String key) {
+		for (BitbucketType value : BitbucketType.values()) {
+			if (value.getKey().equals(key)) {
+				return value;
+			}
+		}
+		return null;
+	}
+}

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/BitbucketType.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/BitbucketType.java
@@ -2,30 +2,29 @@ package com.cloudbees.jenkins.plugins.bitbucket.hooks;
 
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 
-public enum BitbucketType
-{
-	CLOUD("cloud"),
-	SERVER("server"),
-	;
-	private String key;
+public enum BitbucketType {
 
-	BitbucketType(String key)
-	{
-		this.key = key;
-	}
+    CLOUD("cloud"),
 
-	public String getKey()
-	{
-		return key;
-	}
+    SERVER("server");
 
-	@CheckForNull
-	public static BitbucketType fromString(String key) {
-		for (BitbucketType value : BitbucketType.values()) {
-			if (value.getKey().equals(key)) {
-				return value;
-			}
-		}
-		return null;
-	}
+    private String key;
+
+    BitbucketType(String key) {
+        this.key = key;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    @CheckForNull
+    public static BitbucketType fromString(String key) {
+        for (BitbucketType value : BitbucketType.values()) {
+            if (value.getKey().equals(key)) {
+                return value;
+            }
+        }
+        return null;
+    }
 }

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/HookProcessor.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/HookProcessor.java
@@ -70,14 +70,9 @@ public abstract class HookProcessor {
                     List<SCMSource> sources = scmOwner.getSCMSources();
                     for (SCMSource source : sources) {
                         // Search for the correct SCM source
-                        if (source instanceof BitbucketSCMSource)
-                        {
-                            LOGGER.info(String.format("Owners %s , %s", ((BitbucketSCMSource) source).getRepoOwner(), owner));
-                            LOGGER.info(String.format("Repos %s , %s", ((BitbucketSCMSource) source).getRepository(), repository));
-                            if (((BitbucketSCMSource) source).getRepoOwner().equals(owner) && ((BitbucketSCMSource) source).getRepository().equals(repository))
-                            {
-                                scmOwner.onSCMSourceUpdated(source);
-                            }
+                        if (source instanceof BitbucketSCMSource && ((BitbucketSCMSource) source).getRepoOwner().equals(owner)
+                                && ((BitbucketSCMSource) source).getRepository().equals(repository)) {
+                            scmOwner.onSCMSourceUpdated(source);
                         }
                     }
                 }

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/PullRequestHookProcessor.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/PullRequestHookProcessor.java
@@ -37,13 +37,10 @@ public class PullRequestHookProcessor extends HookProcessor {
     public void process(String payload, BitbucketType instanceType) {
         if (payload != null) {
             BitbucketPullRequestEvent pull;
-            switch (instanceType)
-            {
-            case SERVER:
+            if (instanceType == BitbucketType.SERVER) {
                 pull = BitbucketServerWebhookPayload.pullRequestEventFromPayload(payload);
-                break;
-            case CLOUD:
-            default:
+
+            } else {
                 pull = BitbucketCloudWebhookPayload.pullRequestEventFromPayload(payload);
             }
 

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/PullRequestHookProcessor.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/PullRequestHookProcessor.java
@@ -23,20 +23,30 @@
  */
 package com.cloudbees.jenkins.plugins.bitbucket.hooks;
 
-import java.util.logging.Logger;
-
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketPullRequestEvent;
 import com.cloudbees.jenkins.plugins.bitbucket.client.BitbucketCloudWebhookPayload;
+import com.cloudbees.jenkins.plugins.bitbucket.server.client.BitbucketServerWebhookPayload;
+
+import java.util.logging.Logger;
 
 public class PullRequestHookProcessor extends HookProcessor {
 
     private static final Logger LOGGER = Logger.getLogger(PullRequestHookProcessor.class.getName());
 
     @Override
-    public void process(String payload) {
+    public void process(String payload, BitbucketType instanceType) {
         if (payload != null) {
-            // TODO: generalize this for BB server
-            BitbucketPullRequestEvent pull = BitbucketCloudWebhookPayload.pullRequestEventFromPayload(payload);
+            BitbucketPullRequestEvent pull;
+            switch (instanceType)
+            {
+            case SERVER:
+                pull = BitbucketServerWebhookPayload.pullRequestEventFromPayload(payload);
+                break;
+            case CLOUD:
+            default:
+                pull = BitbucketCloudWebhookPayload.pullRequestEventFromPayload(payload);
+            }
+
             if (pull != null) {
                 String owner = pull.getRepository().getOwnerName();
                 String repository = pull.getRepository().getRepositoryName();

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/PushHookProcessor.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/PushHookProcessor.java
@@ -23,20 +23,30 @@
  */
 package com.cloudbees.jenkins.plugins.bitbucket.hooks;
 
-import java.util.logging.Logger;
-
+import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketPushEvent;
 import com.cloudbees.jenkins.plugins.bitbucket.client.BitbucketCloudWebhookPayload;
-import com.cloudbees.jenkins.plugins.bitbucket.client.events.BitbucketPushEvent;
+import com.cloudbees.jenkins.plugins.bitbucket.server.client.BitbucketServerWebhookPayload;
+
+import java.util.logging.Logger;
 
 public class PushHookProcessor extends HookProcessor {
 
     private static final Logger LOGGER = Logger.getLogger(PushHookProcessor.class.getName());
 
     @Override
-    public void process(String payload) {
+    public void process(String payload, BitbucketType instanceType) {
         if (payload != null) {
             // TODO: generalize this for BB server
-            BitbucketPushEvent push = BitbucketCloudWebhookPayload.pushEventFromPayload(payload);
+            BitbucketPushEvent push;
+            switch (instanceType)
+            {
+            case SERVER:
+                push = BitbucketServerWebhookPayload.pushEventFromPayload(payload);
+                break;
+            case CLOUD:
+            default:
+                push = BitbucketCloudWebhookPayload.pushEventFromPayload(payload);
+            }
             if (push != null) {
                 String owner = push.getRepository().getOwnerName();
                 String repository = push.getRepository().getRepositoryName();

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/PushHookProcessor.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/PushHookProcessor.java
@@ -36,25 +36,19 @@ public class PushHookProcessor extends HookProcessor {
     @Override
     public void process(String payload, BitbucketType instanceType) {
         if (payload != null) {
-            // TODO: generalize this for BB server
             BitbucketPushEvent push;
-            switch (instanceType)
-            {
-            case SERVER:
+            if (instanceType == BitbucketType.SERVER) {
                 push = BitbucketServerWebhookPayload.pushEventFromPayload(payload);
-                break;
-            case CLOUD:
-            default:
+            } else {
                 push = BitbucketCloudWebhookPayload.pushEventFromPayload(payload);
             }
             if (push != null) {
                 String owner = push.getRepository().getOwnerName();
                 String repository = push.getRepository().getRepositoryName();
 
-                LOGGER.info(String.format("Received hook from Bitbucket. Processing push event on %s/%s", owner, repository)); 
+                LOGGER.info(String.format("Received hook from Bitbucket. Processing push event on %s/%s", owner, repository));
                 scmSourceReIndex(owner, repository);
             }
         }
     }
-
 }

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/BitbucketServerWebhookPayload.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/BitbucketServerWebhookPayload.java
@@ -35,8 +35,8 @@ import java.io.IOException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-public class BitbucketServerWebhookPayload
-{
+public class BitbucketServerWebhookPayload {
+
     private static final Logger LOGGER = Logger.getLogger(BitbucketServerWebhookPayload.class.getName());
 
     @CheckForNull

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/BitbucketServerWebhookPayload.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/BitbucketServerWebhookPayload.java
@@ -21,12 +21,12 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package com.cloudbees.jenkins.plugins.bitbucket.client;
+package com.cloudbees.jenkins.plugins.bitbucket.server.client;
 
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketPullRequestEvent;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketPushEvent;
-import com.cloudbees.jenkins.plugins.bitbucket.client.events.BitbucketCloudPullRequestEvent;
-import com.cloudbees.jenkins.plugins.bitbucket.client.events.BitbucketCloudPushEvent;
+import com.cloudbees.jenkins.plugins.bitbucket.server.events.BitbucketServerPullRequestEvent;
+import com.cloudbees.jenkins.plugins.bitbucket.server.events.BitbucketServerPushEvent;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import org.codehaus.jackson.map.ObjectMapper;
@@ -35,14 +35,14 @@ import java.io.IOException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-public class BitbucketCloudWebhookPayload {
-
-    private static final Logger LOGGER = Logger.getLogger(BitbucketCloudWebhookPayload.class.getName());
+public class BitbucketServerWebhookPayload
+{
+    private static final Logger LOGGER = Logger.getLogger(BitbucketServerWebhookPayload.class.getName());
 
     @CheckForNull
     public static BitbucketPushEvent pushEventFromPayload(@NonNull String payload) {
         try {
-            return parse(payload, BitbucketCloudPushEvent.class);
+            return parse(payload, BitbucketServerPushEvent.class);
         } catch (IOException e) {
             LOGGER.log(Level.SEVERE, "Can not read hook payload", e);
         }
@@ -52,7 +52,7 @@ public class BitbucketCloudWebhookPayload {
     @CheckForNull
     public static BitbucketPullRequestEvent pullRequestEventFromPayload(@NonNull String payload) {
         try {
-            return parse(payload, BitbucketCloudPullRequestEvent.class);
+            return parse(payload, BitbucketServerPullRequestEvent.class);
         } catch (IOException e) {
             LOGGER.log(Level.SEVERE, "Can not read hook payload", e);
         }

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/events/BitbucketServerPullRequestEvent.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/events/BitbucketServerPullRequestEvent.java
@@ -1,0 +1,58 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.cloudbees.jenkins.plugins.bitbucket.server.events;
+
+import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketPullRequestEvent;
+import com.cloudbees.jenkins.plugins.bitbucket.server.client.pullrequest.BitbucketServerPullRequest;
+import com.cloudbees.jenkins.plugins.bitbucket.server.client.repository.BitbucketServerRepository;
+import org.codehaus.jackson.annotate.JsonIgnoreProperties;
+import org.codehaus.jackson.annotate.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class BitbucketServerPullRequestEvent implements BitbucketPullRequestEvent {
+
+    @JsonProperty("pullrequest")
+    private BitbucketServerPullRequest pullRequest;
+
+    private BitbucketServerRepository repository;
+
+    @Override
+    public BitbucketServerPullRequest getPullRequest() {
+        return pullRequest;
+    }
+
+    public void setPullRequest(BitbucketServerPullRequest pullRequest) {
+        this.pullRequest = pullRequest;
+    }
+
+    @Override
+    public BitbucketServerRepository getRepository() {
+        return repository;
+    }
+
+    public void setRepository(BitbucketServerRepository repository) {
+        this.repository = repository;
+    }
+
+}

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/events/BitbucketServerPushEvent.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/events/BitbucketServerPushEvent.java
@@ -25,19 +25,19 @@ package com.cloudbees.jenkins.plugins.bitbucket.server.events;
 
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketPushEvent;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketRepository;
-import com.cloudbees.jenkins.plugins.bitbucket.client.repository.BitbucketCloudRepository;
+import com.cloudbees.jenkins.plugins.bitbucket.server.client.repository.BitbucketServerRepository;
 import org.codehaus.jackson.annotate.JsonIgnoreProperties;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class BitbucketServerPushEvent implements BitbucketPushEvent{
 
-    private BitbucketCloudRepository repository;
+    private BitbucketServerRepository repository;
 
     public BitbucketRepository getRepository() {
         return repository;
     }
 
-    public void setRepository(BitbucketCloudRepository repository) {
+    public void setRepository(BitbucketServerRepository repository) {
         this.repository = repository;
     }
 

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/events/BitbucketServerPushEvent.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/events/BitbucketServerPushEvent.java
@@ -21,15 +21,15 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package com.cloudbees.jenkins.plugins.bitbucket.client.events;
+package com.cloudbees.jenkins.plugins.bitbucket.server.events;
 
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
-
+import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketPushEvent;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketRepository;
 import com.cloudbees.jenkins.plugins.bitbucket.client.repository.BitbucketCloudRepository;
+import org.codehaus.jackson.annotate.JsonIgnoreProperties;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class BitbucketPushEvent {
+public class BitbucketServerPushEvent implements BitbucketPushEvent{
 
     private BitbucketCloudRepository repository;
 


### PR DESCRIPTION
[JENKINS-33507](https://issues.jenkins-ci.org/browse/JENKINS-33507)

I made some changes to the code to enable more support for Bitbucket server.
I also made a plugin for Bitbucket which is currently submitted for approval. When both installed Bitbucket can successfully send events to the jenkins machine. 

See [bitbucket-webhooks-plugin](https://github.com/topicusfinan/bitbucket-webhooks-plugin) repo for more information about the Bitbucket plugin.
[The plugin is also accepted by atlassian.](https://marketplace.atlassian.com/plugins/nl.topicus.bitbucket.bitbucket-webhooks/server/overview)

@reviewbybees