### PR TITLE
Fix getBranches to allow for more than 25 branches to be returned

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -6,7 +6,7 @@ test:
   pre:
     - mvn package
     - mkdir $CIRCLE_ARTIFACTS/plugin
-    - mv "bitbucket-branch-source-plugin/target/*.hpi" $CIRCLE_ARTIFACTS/plugin
-    - mv "bitbucket-branch-source-plugin/target/*.jar" $CIRCLE_ARTIFACTS/plugin
+    - mv "~/bitbucket-branch-source-plugin/target/*.hpi" $CIRCLE_ARTIFACTS/plugin
+    - mv "~/bitbucket-branch-source-plugin/target/*.jar" $CIRCLE_ARTIFACTS/plugin
   override:
     - mvn test

--- a/circle.yml
+++ b/circle.yml
@@ -5,8 +5,8 @@ machine:
 test:
   pre:
     - mvn package
-  post:
     - mkdir $CIRCLE_ARTIFACTS/plugin
     - mv "target/*.hpi" $CIRCLE_ARTIFACTS/plugin
     - mv "target/*.jar" $CIRCLE_ARTIFACTS/plugin
-
+  override:
+    - mvn test

--- a/circle.yml
+++ b/circle.yml
@@ -2,9 +2,10 @@ machine:
   environment:
     AWS_REGION: 'ap-northeast-1'
 
-dependencies:
-  pre:
-    - apt-get install -y maven
+test:
+  override:
+    - mvn test:
+        timeout: 600
 
 general:
   artifacts:

--- a/circle.yml
+++ b/circle.yml
@@ -5,9 +5,9 @@ machine:
 test:
   override:
     - mvn test:
-        timeout: 600
+        timeout: 1200
 
-general:
-  artifacts:
-    - "target/*hpi" # relative to the build directory
+#general:
+#  artifacts:
+#    - "target/*hpi" # relative to the build directory
 

--- a/circle.yml
+++ b/circle.yml
@@ -6,7 +6,7 @@ test:
   pre:
     - mvn package
     - mkdir $CIRCLE_ARTIFACTS/plugin
-    - mv "target/*.hpi" $CIRCLE_ARTIFACTS/plugin
-    - mv "target/*.jar" $CIRCLE_ARTIFACTS/plugin
+    - mv "bitbucket-branch-source-plugin/target/*.hpi" $CIRCLE_ARTIFACTS/plugin
+    - mv "bitbucket-branch-source-plugin/target/*.jar" $CIRCLE_ARTIFACTS/plugin
   override:
     - mvn test

--- a/circle.yml
+++ b/circle.yml
@@ -4,7 +4,7 @@ machine:
 
 dependencies:
   pre:
-    - apt-get install -y maven=3.0.5
+    - sudo apt-get install -y maven=3.0.5
 
 test:
   override:

--- a/circle.yml
+++ b/circle.yml
@@ -7,7 +7,7 @@ test:
     - mvn test:
         timeout: 1200
 
-#general:
-#  artifacts:
-#    - "target/*hpi" # relative to the build directory
+general:
+  artifacts:
+    - "target" # relative to the build directory
 

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,12 @@
+machine:
+  environment:
+    AWS_REGION: 'ap-northeast-1'
+
+dependencies:
+  pre:
+    - apt-get install -y maven
+
+general:
+  artifacts:
+    - "target/*hpi" # relative to the build directory
+

--- a/circle.yml
+++ b/circle.yml
@@ -3,10 +3,10 @@ machine:
     AWS_REGION: 'ap-northeast-1'
 
 test:
-  override:
-    - mvn test:
-        timeout: 1200
+  pre:
+    - mvn package
   post:
     - mkdir $CIRCLE_ARTIFACTS/plugin
-    - mv target/* $CIRCLE_ARTIFACTS/plugin
+    - mv "target/*.hpi" $CIRCLE_ARTIFACTS/plugin
+    - mv "target/*.jar" $CIRCLE_ARTIFACTS/plugin
 

--- a/circle.yml
+++ b/circle.yml
@@ -6,6 +6,10 @@ test:
   pre:
     - mvn package
     - mkdir $CIRCLE_ARTIFACTS/plugin
+    - ls "~/bitbucket-branch-source-plugin/target/"
+    - ls "~/bitbucket-branch-source-plugin/target/"
+    - ls "/home/ubuntu/bitbucket-branch-source-plugin/target/"
+    - ls "/home/ubuntu/bitbucket-branch-source-plugin/target/"
     - mv "~/bitbucket-branch-source-plugin/target/*.hpi" $CIRCLE_ARTIFACTS/plugin
     - mv "~/bitbucket-branch-source-plugin/target/*.jar" $CIRCLE_ARTIFACTS/plugin
   override:

--- a/circle.yml
+++ b/circle.yml
@@ -2,10 +2,6 @@ machine:
   environment:
     AWS_REGION: 'ap-northeast-1'
 
-dependencies:
-  pre:
-    - sudo apt-get install -y maven=3.0.5
-
 test:
   override:
     - mvn test:

--- a/circle.yml
+++ b/circle.yml
@@ -6,8 +6,7 @@ test:
   override:
     - mvn test:
         timeout: 1200
-
-general:
-  artifacts:
-    - "target" # relative to the build directory
+  post:
+    - mkdir $CIRCLE_ARTIFACTS/plugin
+    - mv target/* $CIRCLE_ARTIFACTS/plugin
 

--- a/circle.yml
+++ b/circle.yml
@@ -2,6 +2,10 @@ machine:
   environment:
     AWS_REGION: 'ap-northeast-1'
 
+dependencies:
+  pre:
+    - apt-get install -y maven=3.0.5
+
 test:
   override:
     - mvn test:

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
     </parent>
 
     <artifactId>cloudbees-bitbucket-branch-source</artifactId>
-    <version>1.6-SNAPSHOT</version>
+    <version>1.6-unifio</version>
     <packaging>hpi</packaging>
 
     <name>Bitbucket Branch Source Plugin</name>

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/BitbucketServerAPIClient.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/BitbucketServerAPIClient.java
@@ -260,7 +260,7 @@ public class BitbucketServerAPIClient implements BitbucketApi {
             branches.addAll(page.getValues());
             while (!page.isLastPage() && pageNumber < MAX_PAGES) {
                 pageNumber++;
-                response = getRequest(String.format(API_PULL_REQUESTS_PATH, getUserCentricOwner(), repositoryName, page.getNextPageStart()));
+                response = getRequest(String.format(API_BRANCHES_PATH, getUserCentricOwner(), repositoryName, page.getNextPageStart()));
                 page = parse(response, BitbucketServerBranches.class);
                 branches.addAll(page.getValues());
             }


### PR DESCRIPTION
There is a bug in the getBranches function.  It currently returns repository branches in pages.  This returns 25 branches at a time.  However, when it attempts to read the next page, it is requesting API_PULL_REQUEST_PATH rather than API_BRANCHES_PATH.  The result is that the plugin only processes the first 25 branches in a repository.  As branches are added, the plugin will start removing the jobs from branches that are not returned.

This update corrects this.
