### PR TITLE
Option to skip pull requests during branch & pullrequests discovery

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource.java
@@ -119,6 +119,11 @@ public class BitbucketSCMSource extends SCMSource {
     private String excludes = "";
 
     /**
+     * Whether to skip discovered pull requests.
+     */
+    private boolean skipPullRequests;
+
+    /**
      * If true, a webhook will be auto-registered in the repository managed by this source.
      */
     private boolean autoRegisterHook = false;
@@ -192,6 +197,15 @@ public class BitbucketSCMSource extends SCMSource {
     public void setExcludes(@NonNull String excludes) {
         Pattern.compile(getPattern(excludes));
         this.excludes = excludes;
+    }
+
+    public boolean isSkipPullRequests() {
+        return skipPullRequests;
+    }
+
+    @DataBoundSetter
+    public void setSkipPullRequests(boolean skipPullRequests) {
+        this.skipPullRequests = skipPullRequests;
     }
 
     public String getRepoOwner() {
@@ -277,8 +291,10 @@ public class BitbucketSCMSource extends SCMSource {
 
         // Search branches
         retrieveBranches(observer, listener);
-        // Search pull requests
-        retrievePullRequests(observer, listener);
+        if (!isSkipPullRequests()) {
+            // Search pull requests
+            retrievePullRequests(observer, listener);
+        }
     }
 
     private void retrievePullRequests(SCMHeadObserver observer, final TaskListener listener) throws IOException {

--- a/src/main/resources/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource/config-detail.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource/config-detail.jelly
@@ -20,6 +20,9 @@
     <f:entry title="${%Exclude branches}" field="excludes">
       <f:textbox/>
     </f:entry>
+    <f:entry field="skipPullRequests">
+      <f:checkbox title="${%Skip pull requests}" />
+    </f:entry>
     <f:entry title="${%Checkout Credentials}" field="checkoutCredentialsId">
       <c:select default="${descriptor.SAME}"/>
     </f:entry>

--- a/src/main/resources/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource/help-skipPullRequests.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource/help-skipPullRequests.jelly
@@ -1,0 +1,8 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout">
+  <l:ajax>
+    <div>
+      Whether or not to create jobs for discovered pull requests.
+    </div>
+  </l:ajax>
+</j:jelly>


### PR DESCRIPTION
Currently bitbucket source plugin when using with multibranch pipeline can create jobs for pull requests and target branches. In that case the same revision will be built twice - for the first time for the source branch of pull request, and for the second time - for the pull request itself.

This pullrequest adds an option to skip pull request discovery.
