### PR TITLE
Create a ChangeRequestAction so the CHANGE_ID is filled when building

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource.java
@@ -372,7 +372,7 @@ public class BitbucketSCMSource extends SCMSource {
         return true;
     }
 
-    private void observe(SCMHeadObserver observer,
+    private synchronized void observe(SCMHeadObserver observer,
                          SCMHead head, final String hash) throws IOException {
         SCMRevision revision;
         if (getRepositoryType() == RepositoryType.MERCURIAL) {

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource.java
@@ -33,7 +33,13 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
 
-import com.cloudbees.jenkins.plugins.bitbucket.api.*;
+import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketApi;
+import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketBranch;
+import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketCommit;
+import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketPullRequest;
+import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketPullRequestSource;
+import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketRepository;
+import com.cloudbees.jenkins.plugins.sshcredentials.SSHUserPrivateKey;
 import com.cloudbees.plugins.credentials.CredentialsNameProvider;
 import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.AncestorInPath;
@@ -76,7 +82,7 @@ import jenkins.scm.api.SCMSourceOwner;
 
 /**
  * SCM source implementation for Bitbucket.
- *
+ * <p>
  * It provides a way to discover/retrieve branches and pull requests through the Bitbuclet REST API
  * which is much faster than the plain Git SCM source implementation.
  */
@@ -373,7 +379,7 @@ public class BitbucketSCMSource extends SCMSource {
     }
 
     private synchronized void observe(SCMHeadObserver observer,
-                         SCMHead head, final String hash) throws IOException {
+                                      SCMHead head, final String hash) throws IOException {
         SCMRevision revision;
         if (getRepositoryType() == RepositoryType.MERCURIAL) {
             revision = new MercurialRevision(head, hash);
@@ -456,7 +462,7 @@ public class BitbucketSCMSource extends SCMSource {
     }
 
     public String getRemoteName() {
-      return "origin";
+        return "origin";
     }
 
     /**
@@ -474,7 +480,7 @@ public class BitbucketSCMSource extends SCMSource {
      * Returns the pattern corresponding to the branches containing wildcards.
      *
      * @param branches space separated list of expressions.
-     *        For example "*" which would match all branches and branch* would match branch1, branch2, etc.
+     *                 For example "*" which would match all branches and branch* would match branch1, branch2, etc.
      * @return pattern corresponding to the branches containing wildcards (ready to be used by {@link Pattern})
      */
     private String getPattern(String branches) {
@@ -554,7 +560,7 @@ public class BitbucketSCMSource extends SCMSource {
             try {
                 new URL(bitbucketServerUrl);
             } catch (MalformedURLException e) {
-                return FormValidation.error("Invalid URL: " +  e.getMessage());
+                return FormValidation.error("Invalid URL: " + e.getMessage());
             }
             return FormValidation.ok();
         }

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/PullRequestAction.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/PullRequestAction.java
@@ -1,0 +1,27 @@
+package com.cloudbees.jenkins.plugins.bitbucket;
+
+import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketPullRequest;
+import jenkins.scm.api.actions.ChangeRequestAction;
+
+final class PullRequestAction extends ChangeRequestAction {
+
+    private static final long serialVersionUID = 1L;
+
+    private final String number;
+    private final String title;
+
+    PullRequestAction(BitbucketPullRequest pr) {
+        number = pr.getId();
+        title = pr.getTitle();
+    }
+
+    @Override
+    public String getId() {
+        return number;
+    }
+
+    @Override
+    public String getTitle() {
+        return title;
+    }
+}

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/PullrequestSCMHead.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/PullrequestSCMHead.java
@@ -9,6 +9,7 @@ import java.util.List;
 
 public class PullrequestSCMHead extends SCMHeadWithOwnerAndRepo {
 
+    private static final long serialVersionUID = 1L;
     private static final String PR_BRANCH_PREFIX = "PR-";
 
     private final PullRequestAction metatdata;
@@ -23,7 +24,7 @@ public class PullrequestSCMHead extends SCMHeadWithOwnerAndRepo {
     @NonNull
     @Override
     public String getName() {
-        return PR_BRANCH_PREFIX + metatdata.getId() + ": " + metatdata.getTitle();
+        return PR_BRANCH_PREFIX + metatdata.getId();
     }
 
     @NonNull

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/PullrequestSCMHead.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/PullrequestSCMHead.java
@@ -1,0 +1,36 @@
+package com.cloudbees.jenkins.plugins.bitbucket;
+
+import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketPullRequest;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.model.Action;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class PullrequestSCMHead extends SCMHeadWithOwnerAndRepo {
+
+    private static final String PR_BRANCH_PREFIX = "PR-";
+
+    private final PullRequestAction metatdata;
+
+    public PullrequestSCMHead(BitbucketPullRequest pullRequest) {
+        super(pullRequest.getSource().getRepository().getOwnerName(),
+                pullRequest.getSource().getRepository().getRepositoryName(),
+                pullRequest.getSource().getBranch().getName());
+        this.metatdata = new PullRequestAction(pullRequest);
+    }
+
+    @NonNull
+    @Override
+    public String getName() {
+        return PR_BRANCH_PREFIX + metatdata.getId() + ": " + metatdata.getTitle();
+    }
+
+    @NonNull
+    @Override
+    public List<? extends Action> getAllActions() {
+        List<Action> actions = new ArrayList<>(super.getAllActions());
+        actions.add(metatdata);
+        return actions;
+    }
+}

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/SCMHeadWithOwnerAndRepo.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/SCMHeadWithOwnerAndRepo.java
@@ -23,7 +23,6 @@
  */
 package com.cloudbees.jenkins.plugins.bitbucket;
 
-import edu.umd.cs.findbugs.annotations.CheckForNull;
 import jenkins.scm.api.SCMHead;
 
 /**
@@ -31,11 +30,7 @@ import jenkins.scm.api.SCMHead;
  * <ul>
  *   <li>{@link #repoOwner}: the repository owner</li>
  *   <li>{@link #repoName}: the repository name</li>
- *   <li>{@link #pullRequestId}: the pull request ID (if it is representing a PR, null otherwise)</li>
  * </ul>
- * This information is required in this plugin since {@link BitbucketSCMSource} is processing pull requests
- * and they are managed as separate repositories in Bitbucket without any reference to them in the destination
- * repository.
  */
 public class SCMHeadWithOwnerAndRepo extends SCMHead {
 
@@ -45,19 +40,10 @@ public class SCMHeadWithOwnerAndRepo extends SCMHead {
 
     private final String repoName;
 
-    private final Integer pullRequestId;
-
-    private static final String PR_BRANCH_PREFIX = "PR-";
-
-    public SCMHeadWithOwnerAndRepo(String repoOwner, String repoName, String branchName, Integer pullRequestId) {
+    public SCMHeadWithOwnerAndRepo(String repoOwner, String repoName, String branchName) {
         super(branchName);
         this.repoOwner = repoOwner;
         this.repoName = repoName;
-        this.pullRequestId = pullRequestId;
-    }
-
-    public SCMHeadWithOwnerAndRepo(String repoOwner, String repoName, String branchName) {
-        this(repoOwner, repoName, branchName, null);
     }
 
     public String getRepoOwner() {
@@ -69,24 +55,9 @@ public class SCMHeadWithOwnerAndRepo extends SCMHead {
     }
 
     /**
-     * @return the original branch name without the "PR-owner-" part.
+     * @return the original branch name.
      */
     public String getBranchName() {
         return super.getName();
     }
-
-    /**
-     * Returns the prettified branch name by adding "PR-[ID]" if the branch is coming from a PR.
-     * Use {@link #getBranchName()} to get the real branch name.
-     */
-    @Override
-    public String getName() {
-        return pullRequestId != null ? PR_BRANCH_PREFIX + pullRequestId : getBranchName();
-    }
-
-    @CheckForNull
-    public Integer getPullRequestId() {
-        return pullRequestId;
-    }
-
 }

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/BitbucketPullRequest.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/BitbucketPullRequest.java
@@ -39,4 +39,8 @@ public interface BitbucketPullRequest {
      */
     String getId();
 
+    /**
+     * @return pull request Title as provided by Bitbucket. It will be used for the job name.
+     */
+    String getTitle();
 }

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/pullrequest/BitbucketPullRequestValue.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/pullrequest/BitbucketPullRequestValue.java
@@ -32,6 +32,7 @@ import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketPullRequestSource;
 public class BitbucketPullRequestValue implements BitbucketPullRequest {
     private BitbucketPullRequestValueRepository source;
     private String id;
+    private String title;
 
     public BitbucketPullRequestSource getSource() {
         return source;
@@ -49,4 +50,11 @@ public class BitbucketPullRequestValue implements BitbucketPullRequest {
         this.id = id;
     }
 
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
 }

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/pullrequest/BitbucketServerPullRequest.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/pullrequest/BitbucketServerPullRequest.java
@@ -34,6 +34,8 @@ public class BitbucketServerPullRequest implements BitbucketPullRequest {
 
     private String id;
 
+    private String title;
+
     @JsonProperty("fromRef")
     private BitbucketServerPullRequestSource source;
 
@@ -55,4 +57,12 @@ public class BitbucketServerPullRequest implements BitbucketPullRequest {
         this.id = id;
     }
 
+    @Override
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
 }

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketClientMockUtils.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketClientMockUtils.java
@@ -64,7 +64,7 @@ public class BitbucketClientMockUtils {
         }
 
         if (includePullRequests) {
-            when(bitbucket.getPullRequests()).thenReturn(Collections.singletonList(getPullRequest()));
+            when(bitbucket.getPullRequests()).thenReturn(Arrays.asList(getPullRequest()));
             when(bitbucket.checkPathExists("my-feature-branch", "markerfile.txt")).thenReturn(true);
             when(bitbucket.resolveSourceFullHash(any(BitbucketPullRequestValue.class)))
                     .thenReturn("e851558f77c098d21af6bb8cc54a423f7cf12147");

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketClientMockUtils.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketClientMockUtils.java
@@ -64,7 +64,7 @@ public class BitbucketClientMockUtils {
         }
 
         if (includePullRequests) {
-            when(bitbucket.getPullRequests()).thenReturn(Arrays.asList(getPullRequest()));
+            when(bitbucket.getPullRequests()).thenReturn(Collections.singletonList(getPullRequest()));
             when(bitbucket.checkPathExists("my-feature-branch", "markerfile.txt")).thenReturn(true);
             when(bitbucket.resolveSourceFullHash(any(BitbucketPullRequestValue.class)))
                     .thenReturn("e851558f77c098d21af6bb8cc54a423f7cf12147");
@@ -159,6 +159,7 @@ public class BitbucketClientMockUtils {
         pr.setSource(source);
 
         pr.setId("23");
+        pr.setTitle("Title");
         return pr;
     }
 

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/BranchScanningTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/BranchScanningTest.java
@@ -112,7 +112,7 @@ public class BranchScanningTest {
         // Only branch1 and my-feature-branch PR must be observed
         assertEquals(2, observer.getBranches().size());
         assertEquals("branch1", observer.getBranches().get(0));
-        assertEquals("PR-23", observer.getBranches().get(1));
+        assertEquals("PR-23: Title", observer.getBranches().get(1));
     }
 
     @Test

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/BranchScanningTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/BranchScanningTest.java
@@ -112,7 +112,7 @@ public class BranchScanningTest {
         // Only branch1 and my-feature-branch PR must be observed
         assertEquals(2, observer.getBranches().size());
         assertEquals("branch1", observer.getBranches().get(0));
-        assertEquals("PR-23: Title", observer.getBranches().get(1));
+        assertEquals("PR-23", observer.getBranches().get(1));
     }
 
     @Test


### PR DESCRIPTION
When building a PR we can fill the CHANGE_ID by adding an action to the SCMHead.
I tried to make it somewhat identical to the [Github version](https://github.com/jenkinsci/github-branch-source-plugin/blob/master/src/main/java/org/jenkinsci/plugins/github_branch_source/PullRequestSCMHead.java)

@reviewbybees