### PR TITLE
[JENKINS-34071] Added the possiblity to filter using the Bitbucket Cloud project name

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMNavigator.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMNavigator.java
@@ -60,6 +60,7 @@ public class BitbucketSCMNavigator extends SCMNavigator {
     private final String credentialsId;
     private final String checkoutCredentialsId;
     private String pattern = ".*";
+    private String project = ".*";
     private boolean autoRegisterHooks = false;
     private String bitbucketServerUrl;
     private int sshPort = -1;
@@ -69,17 +70,23 @@ public class BitbucketSCMNavigator extends SCMNavigator {
      */
     private transient BitbucketApiConnector bitbucketConnector;
 
-    @DataBoundConstructor 
+    @DataBoundConstructor
     public BitbucketSCMNavigator(String repoOwner, String credentialsId, String checkoutCredentialsId) {
         this.repoOwner = repoOwner;
         this.credentialsId = Util.fixEmpty(credentialsId);
         this.checkoutCredentialsId = checkoutCredentialsId;
     }
 
-    @DataBoundSetter 
+    @DataBoundSetter
     public void setPattern(String pattern) {
         Pattern.compile(pattern);
         this.pattern = pattern;
+    }
+
+    @DataBoundSetter
+    public void setProject(String project) {
+        Pattern.compile(project);
+        this.project = project;
     }
 
     @DataBoundSetter
@@ -103,6 +110,10 @@ public class BitbucketSCMNavigator extends SCMNavigator {
 
     public String getPattern() {
         return pattern;
+    }
+
+    public String getProject() {
+        return project;
     }
 
     public boolean isAutoRegisterHooks() {
@@ -178,7 +189,8 @@ public class BitbucketSCMNavigator extends SCMNavigator {
 
     private void add(TaskListener listener, SCMSourceObserver observer, BitbucketRepository repo) throws InterruptedException {
         String name = repo.getRepositoryName();
-        if (!Pattern.compile(pattern).matcher(name).matches()) {
+        String projectName = repo.getProjectName();
+        if (!Pattern.compile(pattern).matcher(name).matches() || !Pattern.compile(project).matcher(projectName).matches()) {
             listener.getLogger().format("Ignoring %s%n", name);
             return;
         }
@@ -198,7 +210,7 @@ public class BitbucketSCMNavigator extends SCMNavigator {
         projectObserver.complete();
     }
 
-    @Extension 
+    @Extension
     public static class DescriptorImpl extends SCMNavigatorDescriptor {
 
         public static final String ANONYMOUS = BitbucketSCMSource.DescriptorImpl.ANONYMOUS;

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/BitbucketRepository.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/BitbucketRepository.java
@@ -58,4 +58,9 @@ public interface BitbucketRepository {
      */
     boolean isPrivate();
 
+    /**
+     * @return the project containing the repository
+     */
+    String getProjectName();
+
 }

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/repository/BitbucketCloudProject.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/repository/BitbucketCloudProject.java
@@ -1,0 +1,28 @@
+package com.cloudbees.jenkins.plugins.bitbucket.client.repository;
+
+import org.codehaus.jackson.annotate.JsonIgnoreProperties;
+
+/**
+ * Created by saiimons on 08/08/2016.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class BitbucketCloudProject {
+    private String key;
+    private String name;
+
+    public String getKey() {
+        return key;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setKey(String key) {
+        this.key = key;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/repository/BitbucketCloudRepository.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/repository/BitbucketCloudRepository.java
@@ -108,7 +108,7 @@ public class BitbucketCloudRepository implements BitbucketRepository {
         if (this.project != null) {
             return project.getName();
         }
-        return null;
+        return "";
     }
 
     @JsonProperty("is_private")

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/repository/BitbucketCloudRepository.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/repository/BitbucketCloudRepository.java
@@ -23,7 +23,6 @@
  */
 package com.cloudbees.jenkins.plugins.bitbucket.client.repository;
 
-import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketProject;
 import org.codehaus.jackson.annotate.JsonIgnoreProperties;
 import org.codehaus.jackson.annotate.JsonProperty;
 

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/repository/BitbucketCloudRepository.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/repository/BitbucketCloudRepository.java
@@ -23,6 +23,7 @@
  */
 package com.cloudbees.jenkins.plugins.bitbucket.client.repository;
 
+import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketProject;
 import org.codehaus.jackson.annotate.JsonIgnoreProperties;
 import org.codehaus.jackson.annotate.JsonProperty;
 
@@ -44,6 +45,8 @@ public class BitbucketCloudRepository implements BitbucketRepository {
 
     // JSON mapping added in setter because the field can not be called "private"
     private Boolean priv;
+
+    private BitbucketCloudProject project;
 
     @Override
     public String getScm() {
@@ -76,6 +79,10 @@ public class BitbucketCloudRepository implements BitbucketRepository {
         this.updatedOn = updatedOn;
     }
 
+    public void setProject(BitbucketCloudProject project) {
+        this.project = project;
+    }
+
     @Override
     public String getOwnerName() {
         if (this.fullName != null) {
@@ -97,9 +104,19 @@ public class BitbucketCloudRepository implements BitbucketRepository {
         return priv;
     }
 
+    @Override
+    public String getProjectName() {
+        if (this.project != null) {
+            return project.getName();
+        }
+        return null;
+    }
+
     @JsonProperty("is_private")
     public void setPrivate(Boolean priv) {
         this.priv = priv;
     }
+
+
 
 }

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/repository/BitbucketServerRepository.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/repository/BitbucketServerRepository.java
@@ -77,6 +77,11 @@ public class BitbucketServerRepository implements BitbucketRepository {
         return !publc;
     }
 
+    @Override
+    public String getProjectName() {
+        return project.getName();
+    }
+
     @JsonProperty("public")
     public void setPublic(Boolean publc) {
         this.publc = publc;

--- a/src/main/resources/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMNavigator/config.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMNavigator/config.jelly
@@ -10,6 +10,9 @@
     <f:entry title="${%Repository name pattern}" field="pattern">
         <f:textbox default=".*"/>
     </f:entry>
+    <f:entry title="${%Project name pattern}" field="project">
+        <f:textbox default=".*"/>
+    </f:entry>
     <f:entry field="autoRegisterHooks">
         <f:checkbox title="${%Auto-register webhooks}" />
     </f:entry>

--- a/src/main/resources/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMNavigator/help-project.html
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMNavigator/help-project.html
@@ -1,0 +1,3 @@
+<div>
+    <p>Regular expression to specify what projects one wants to include</p>
+</div>


### PR DESCRIPTION
I added the possibility to match the Bitbucket Cloud project when scanning repositories.

Although, "project" seems to be used differently on Bitbucket Server, and I don't have any experience with it, I am not sure the implementation will be working correctly.
