### PR TITLE
Update to use DisplayURLProvider

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,11 @@
             <version>1.9.13</version>
         </dependency>
         <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>display-url-api</artifactId>
+            <version>0.2</version>
+        </dependency>
+        <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-multibranch</artifactId>
             <version>1.11</version>

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketBuildStatusNotifications.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketBuildStatusNotifications.java
@@ -48,6 +48,7 @@ import java.io.File;
 import jenkins.scm.api.SCMHead;
 import jenkins.scm.api.SCMSource;
 import jenkins.scm.api.SCMSourceOwner;
+import org.jenkinsci.plugins.displayurlapi.DisplayURLProvider;
 
 /**
  * This class encapsulates all Bitbucket notifications logic.
@@ -63,12 +64,7 @@ public class BitbucketBuildStatusNotifications {
         String revision = extractRevision(build);
         if (revision != null) {
             Result result = build.getResult();
-            String url;
-            try {
-                url = build.getAbsoluteUrl();
-            } catch (IllegalStateException ise) {
-                url = "http://unconfigured-jenkins-location/" + build.getUrl();
-            }
+            String url = DisplayURLProvider.get().getRunURL(build);
             BitbucketBuildStatus status = null;
             if (Result.SUCCESS.equals(result)) {
                 status = new BitbucketBuildStatus(revision, "This commit looks good", "SUCCESSFUL", url, build.getParent().getName(), build.getDisplayName());


### PR DESCRIPTION
 @amuniz this updates the Build Status notifier to use the urls generated from the `DisplayURLProvider`. This is needed for Blue Ocean compatibility.

See https://github.com/jenkinsci/display-url-api-plugin

@jenkinsci/code-reviewers 