### PR TITLE
Enable plugin to pull sync submodules (if present)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,7 @@
 properties([[$class: 'BuildDiscarderProperty',
                 strategy: [$class: 'LogRotator', numToKeepStr: '10']]])
 
-node ("maven") {
+node ("master") {
   stage 'Checkout'
   checkout scm
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,5 @@
+ node ('maven'){
+  stage 'Build and Test'
+  checkout scm
+  sh 'mvn clean package'
+ }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,49 @@
- node ('maven'){
-  stage 'Build and Test'
+#!groovy
+
+/* Only keep the 10 most recent builds. */
+properties([[$class: 'BuildDiscarderProperty',
+                strategy: [$class: 'LogRotator', numToKeepStr: '10']]])
+
+node ("maven") {
+  stage 'Checkout'
   checkout scm
-  sh 'mvn -B clean package'
- }
+
+  stage 'Build'
+
+  /* Call the maven build. */
+  mvn "clean install -B -V -U -e -Dsurefire.useFile=false -Dmaven.test.failure.ignore=true"
+
+  /* Save Results. */
+  stage 'Results'
+
+  /* Archive the test results */
+  step([$class: 'JUnitResultArchiver', testResults: '**/target/surefire-reports/TEST-*.xml'])
+
+  /* Archive the build artifacts */
+  step([$class: 'ArtifactArchiver', artifacts: 'target/*.hpi,target/*.jpi'])
+}
+
+/* Run maven from tool "mvn" */
+void mvn(def args) {
+  /* Get jdk tool. */
+  String jdktool = '/usr' //tool name: "jdk7", type: 'hudson.model.JDK'
+
+  /* Get the maven tool. */
+  def mvnHome = '/usr'
+
+  /* Set JAVA_HOME, and special PATH variables. */
+  List javaEnv = [
+    "PATH+JDK=${jdktool}/bin", "JAVA_HOME=${jdktool}",
+  ]
+
+  /* Call maven tool with java envVars. */
+  withEnv(javaEnv) {
+    timeout(time: 45, unit: 'MINUTES') {
+      if (isUnix()) {
+        sh "${mvnHome}/bin/mvn ${args}"
+      } else {
+        bat "${mvnHome}\\bin\\mvn ${args}"
+      }
+    }
+  }
+}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
  node ('maven'){
   stage 'Build and Test'
   checkout scm
-  sh 'mvn clean package'
+  sh 'mvn -B clean package'
  }

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>git</artifactId>
-            <version>2.3.5</version>
+            <version>2.5.3</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.httpcomponents</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>git</artifactId>
-            <version>2.5.3</version>
+            <version>3.0.0-beta2</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.httpcomponents</groupId>

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource.java
@@ -424,7 +424,7 @@ public class BitbucketSCMSource extends SCMSource {
                         (AbstractGitSCMSource.SCMRevisionImpl) revision) : new DefaultBuildChooser();
 
                 extensions.add(new BuildChooserSetting(buildChooser));
-                extensions.add(new SubmoduleOption(false, false, false, "HEAD", 10000));
+                extensions.add(new SubmoduleOption(false, false, false, "", 10000, true));
 
                 return new GitSCM(
                         getGitRemoteConfigs(h),

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource.java
@@ -424,7 +424,7 @@ public class BitbucketSCMSource extends SCMSource {
                         (AbstractGitSCMSource.SCMRevisionImpl) revision) : new DefaultBuildChooser();
 
                 extensions.add(new BuildChooserSetting(buildChooser));
-                extensions.add(new SubmoduleOption(false, false, false, "", 10000, true));
+                extensions.add(new SubmoduleOption(false, true, false, "", 10000, true));
 
                 return new GitSCM(
                         getGitRemoteConfigs(h),

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource.java
@@ -28,6 +28,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -61,6 +62,7 @@ import hudson.plugins.git.SubmoduleConfig;
 import hudson.plugins.git.UserRemoteConfig;
 import hudson.plugins.git.extensions.GitSCMExtension;
 import hudson.plugins.git.extensions.impl.BuildChooserSetting;
+import hudson.plugins.git.extensions.impl.SubmoduleOption;
 import hudson.plugins.git.util.BuildChooser;
 import hudson.plugins.git.util.DefaultBuildChooser;
 import hudson.plugins.mercurial.MercurialSCM;
@@ -416,13 +418,19 @@ public class BitbucketSCMSource extends SCMSource {
                 return scm;
             } else {
                 // Defaults to Git
+                List<GitSCMExtension> extensions = new LinkedList<GitSCMExtension>();
+
                 BuildChooser buildChooser = revision instanceof AbstractGitSCMSource.SCMRevisionImpl ? new SpecificRevisionBuildChooser(
                         (AbstractGitSCMSource.SCMRevisionImpl) revision) : new DefaultBuildChooser();
+
+                extensions.add(new BuildChooserSetting(buildChooser));
+                extensions.add(new SubmoduleOption(false, false, false, 10000));
+
                 return new GitSCM(
                         getGitRemoteConfigs(h),
                         Collections.singletonList(new BranchSpec(h.getBranchName())),
                         false, Collections.<SubmoduleConfig>emptyList(),
-                        null, null, Collections.<GitSCMExtension>singletonList(new BuildChooserSetting(buildChooser)));
+                        null, null, extensions);
             }
         }
         throw new IllegalArgumentException("An SCMHeadWithOwnerAndRepo required as parameter");

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource.java
@@ -424,7 +424,7 @@ public class BitbucketSCMSource extends SCMSource {
                         (AbstractGitSCMSource.SCMRevisionImpl) revision) : new DefaultBuildChooser();
 
                 extensions.add(new BuildChooserSetting(buildChooser));
-                extensions.add(new SubmoduleOption(false, false, false, 10000));
+                extensions.add(new SubmoduleOption(false, false, false, "", 10000));
 
                 return new GitSCM(
                         getGitRemoteConfigs(h),

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource.java
@@ -424,7 +424,7 @@ public class BitbucketSCMSource extends SCMSource {
                         (AbstractGitSCMSource.SCMRevisionImpl) revision) : new DefaultBuildChooser();
 
                 extensions.add(new BuildChooserSetting(buildChooser));
-                extensions.add(new SubmoduleOption(false, false, false, "", 10000));
+                extensions.add(new SubmoduleOption(false, false, false, "HEAD", 10000));
 
                 return new GitSCM(
                         getGitRemoteConfigs(h),


### PR DESCRIPTION
FYI: I've included a Jenkinsfile in this PR, so please don't feel compelled to pull it.

The bulk of the changes for this PR are in BitbucketSCMSource.java.  A SubmoduleOption with some relatively sane default values is instantiated and then passed to the GitSCM constructor.  This enables any repo with submodules (even recursive ones) to automatically sync the submodules on checkout during pipeline execution.

I'm not super excited that submodules are enabled by default.  On the other hand, now that the jenkins git plugin has released 3.0.0, I think its a good time to start evaluating this approach.  I would prefer to see this as a "Property Strategy" to incorporate in a multibranch pipeline job configuration.
