### PR TITLE
Add a check to avoid JENKINS-38664

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketBuildStatusNotifications.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketBuildStatusNotifications.java
@@ -46,10 +46,13 @@ import hudson.scm.SCM;
 import hudson.scm.SCMRevisionState;
 import java.io.File;
 import java.io.IOException;
+import java.net.URI;
+import java.lang.IllegalStateException;
 import jenkins.scm.api.SCMHead;
 import jenkins.scm.api.SCMSource;
 import jenkins.scm.api.SCMSourceOwner;
 import org.jenkinsci.plugins.displayurlapi.DisplayURLProvider;
+
 
 /**
  * This class encapsulates all Bitbucket notifications logic.
@@ -69,7 +72,11 @@ public class BitbucketBuildStatusNotifications {
             String url;
             try {
                 url = DisplayURLProvider.get().getRunURL(build);
-            } catch (IllegalStateException e) {
+                URI testURI = new URI(url);
+                if (!testURI.getHost().contains(".")) {
+                    throw new IllegalStateException("Jenkins RootURL not a FQDN");
+                }
+            } catch (IllegalStateException|java.net.URISyntaxException e) {
                 listener.getLogger().println("Can not determine Jenkins root URL. Commit status notifications are disabled until a root URL is configured in Jenkins global configuration.");
                 return;
             }


### PR DESCRIPTION
This PR adds a check to ensure the Jenkins RootURL is configured and if it is not to skip the status notifier, rather than failing the build.

This mitigates JENKINS-38664 since it no longer causes the build to fail if the admin hasn't explicitly configured the Jenkins root URL.

The log results in this instead of the failure in the issue:

```
[Bitbucket] Notifying commit build result
Can not determine Jenkins root URL. Commit status notifications are disabled until a root URL is configured in Jenkins global configuration.
```
