### PR TITLE
JENKINS-39392 don't disable pull request scanning for bitbucket server instances

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource.java
@@ -80,7 +80,7 @@ import jenkins.scm.api.SCMSourceOwner;
 
 /**
  * SCM source implementation for Bitbucket.
- * 
+ *
  * It provides a way to discover/retrieve branches and pull requests through the Bitbuclet REST API
  * which is much faster than the plain Git SCM source implementation.
  */
@@ -329,9 +329,15 @@ public class BitbucketSCMSource extends SCMSource {
     }
 
     private void observe(SCMHeadObserver observer, final TaskListener listener,
-            final String owner, final String repositoryName, 
+            final String owner, final String repositoryName,
             final String branchName, final String hash, BitbucketPullRequest pr) throws IOException {
-        if (isExcluded(branchName)) {
+
+        String branchNameForExclusionTest = branchName;
+        if (pr != null) {
+             branchNameForExclusionTest = String.format("PR-%s %s", pr.getId(), pr.getSource().getBranch().getName());
+         }
+
+        if (isExcluded(branchNameForExclusionTest)) {
             return;
         }
         final BitbucketApi bitbucket = getBitbucketConnector().create(owner, repositoryName, getScanCredentials());
@@ -455,7 +461,7 @@ public class BitbucketSCMSource extends SCMSource {
 
     /**
      * Returns true if the branchName isn't matched by includes or is matched by excludes.
-     * 
+     *
      * @param branchName
      * @return true if branchName is excluded or is not included
      */
@@ -465,9 +471,9 @@ public class BitbucketSCMSource extends SCMSource {
     }
 
     /**
-     * Returns the pattern corresponding to the branches containing wildcards. 
-     * 
-     * @param branches space separated list of expressions. 
+     * Returns the pattern corresponding to the branches containing wildcards.
+     *
+     * @param branches space separated list of expressions.
      *        For example "*" which would match all branches and branch* would match branch1, branch2, etc.
      * @return pattern corresponding to the branches containing wildcards (ready to be used by {@link Pattern})
      */

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource.java
@@ -286,7 +286,7 @@ public class BitbucketSCMSource extends SCMSource {
         listener.getLogger().println("Looking up " + fullName + " for pull requests");
 
         final BitbucketApi bitbucket = getBitbucketConnector().create(repoOwner, repository, getScanCredentials());
-        if (bitbucket.isPrivate()) {
+        if (bitbucket.isPrivate() || bitbucketServerUrl != "https://bitbucket.org") {
             List<? extends BitbucketPullRequest> pulls = bitbucket.getPullRequests();
             for (final BitbucketPullRequest pull : pulls) {
                 listener.getLogger().println(


### PR DESCRIPTION
As per https://issues.jenkins-ci.org/browse/JENKINS-39392: 

Currently the plugin checks if the repo is public, and doesn't allow building PRs, "Skipping pull requests for public repositories." While I assume this is for security purposes for Bitbucket.org, it is a problematic limitation for private Bitbucket Server instances that use a PR-based flow and have the repo "Public", which only means it can be viewed and cloned. Only authenticated users can push and create pull requests and we need to be able to discover and test these effectively private pull requests.

I'm not sure if this behavior is intentional even for Bitbucket Server instances; if so, there should be a configuration option to enable this or, if "PR*" is in the branch pattern, it should be enabled since it is specifically requested.