### PR TITLE
Fix on the refs for builded job

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource.java
@@ -431,7 +431,7 @@ public class BitbucketSCMSource extends SCMSource {
     protected List<UserRemoteConfig> getGitRemoteConfigs(SCMHeadWithOwnerAndRepo head) {
         List<UserRemoteConfig> result = new ArrayList<UserRemoteConfig>();
         String remote = getRemote(head.getRepoOwner(), head.getRepoName());
-        result.add(new UserRemoteConfig(remote, getRemoteName(), "+refs/heads/" + head.getBranchName(), getCheckoutEffectiveCredentials()));
+        result.add(new UserRemoteConfig(remote, getRemoteName(), "+refs/heads/" + head.getBranchName() + ":refs/remotes/origin/" + head.getBranchName(), getCheckoutEffectiveCredentials()));
         return result;
     }
 

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/BranchScanningTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/BranchScanningTest.java
@@ -77,7 +77,7 @@ public class BranchScanningTest {
         BitbucketSCMSource source = getBitbucketSCMSourceMock(RepositoryType.GIT);
         List<UserRemoteConfig> remoteConfigs = source.getGitRemoteConfigs(new SCMHeadWithOwnerAndRepo("amuniz", "test-repos", "branch1"));
         assertEquals(1, remoteConfigs.size());
-        assertEquals("+refs/heads/branch1", remoteConfigs.get(0).getRefspec());
+        assertEquals("+refs/heads/branch1:refs/remotes/origin/branch1", remoteConfigs.get(0).getRefspec());
     }
 
     @Test


### PR DESCRIPTION
New commits on a already generated job referring to a branch doesn't build the proper commit.

Job are currently generated with the ref pointing to:
`+refs/heads/branch1`
The branch specified to build is «branch1».
So it doesn't update is tracking ref to the local branch.

This fix propose to alter the refs to:
`+refs/heads/branch1:refs/remotes/origin/branch1`
So local branch is able to properly track new commits.
