### PR TITLE
Add options for scanning branches/PRs

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource.java
@@ -133,6 +133,16 @@ public class BitbucketSCMSource extends SCMSource {
     private String excludes = "";
 
     /**
+     * If true, branches are included when scanning in the retrieve process.
+     */
+    private boolean scanBranches = true;
+    
+    /**
+     * If true, pull requests are included when scanning in the retrieve process.
+     */
+    private boolean scanPullRequests = true;
+    
+    /**
      * If true, a webhook will be auto-registered in the repository managed by this source.
      */
     private boolean autoRegisterHook = false;
@@ -212,6 +222,24 @@ public class BitbucketSCMSource extends SCMSource {
     public void setExcludes(@NonNull String excludes) {
         Pattern.compile(getPattern(excludes));
         this.excludes = excludes;
+    }
+    
+    @DataBoundSetter
+    public void setScanBranches(boolean scanBranches) {
+        this.scanBranches = scanBranches;
+    }
+    
+    public boolean getScanBranches() {
+        return scanBranches;
+    }
+       
+    @DataBoundSetter
+    public void setScanPullRequests(boolean scanPullRequests) {
+        this.scanPullRequests = scanPullRequests;
+    }
+    
+    public boolean getScanPullRequests() {
+        return scanPullRequests;
     }
 
     public String getRepoOwner() {
@@ -304,9 +332,13 @@ public class BitbucketSCMSource extends SCMSource {
         }
 
         // Search branches
-        retrieveBranches(criteria, observer, listener);
+        if (getScanBranches()) {
+            retrieveBranches(criteria, observer, listener);
+        }
         // Search pull requests
-        retrievePullRequests(criteria, observer, listener);
+        if (getScanPullRequests()) {
+            retrievePullRequests(criteria, observer, listener);
+        }
     }
 
     private void retrievePullRequests(SCMSourceCriteria criteria, SCMHeadObserver observer, final TaskListener listener)

--- a/src/main/resources/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource/config-detail.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource/config-detail.jelly
@@ -20,6 +20,12 @@
     <f:entry title="${%Exclude branches}" field="excludes">
       <f:textbox/>
     </f:entry>
+    <f:entry field="scanBranches">
+        <f:checkbox title="${%Scan branches}" default="true"/>
+    </f:entry>
+    <f:entry field="scanPullRequests">
+        <f:checkbox title="${%Scan pull requests}" default="true"/>
+    </f:entry>
     <f:entry title="${%Checkout Credentials}" field="checkoutCredentialsId">
       <c:select default="${descriptor.SAME}"/>
     </f:entry>

--- a/src/main/resources/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource/help-scanBranches.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource/help-scanBranches.jelly
@@ -1,0 +1,11 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout">
+  <l:ajax>
+    <div>
+      <p>
+        If this option is activated, branches are included for scanning. Deactivate
+        it if only pull requests should be returned by scanning.
+      </p>
+    </div>
+  </l:ajax>
+</j:jelly>

--- a/src/main/resources/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource/help-scanPullRequests.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource/help-scanPullRequests.jelly
@@ -1,0 +1,11 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout">
+  <l:ajax>
+    <div>
+      <p>
+        If this option is activated, pull requests are included for scanning. 
+        Deactivate it if pull request should should not be returned by scanning.
+      </p>
+    </div>
+  </l:ajax>
+</j:jelly>

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/BranchScanningTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/BranchScanningTest.java
@@ -114,6 +114,30 @@ public class BranchScanningTest {
         assertEquals("branch1", observer.getBranches().get(0));
         assertEquals("PR-23", observer.getBranches().get(1));
     }
+    
+    @Test
+    public void scanTestDeactivatedPullRequests() throws IOException, InterruptedException {
+        BitbucketSCMSource source = getBitbucketSCMSourceMock(RepositoryType.GIT, true);
+        source.setScanPullRequests(false);
+        SCMHeadObserverImpl observer = new SCMHeadObserverImpl();
+        source.fetch(observer, BitbucketClientMockUtils.getTaskListenerMock());
+       
+        // Only branch1 must be observed
+        assertEquals(1, observer.getBranches().size());
+        assertEquals("branch1", observer.getBranches().get(0));
+    }
+
+    @Test
+    public void scanTestDeactivatedBranches() throws IOException, InterruptedException {
+        BitbucketSCMSource source = getBitbucketSCMSourceMock(RepositoryType.GIT, true);
+        source.setScanBranches(false);
+        SCMHeadObserverImpl observer = new SCMHeadObserverImpl();
+        source.fetch(observer, BitbucketClientMockUtils.getTaskListenerMock());
+       
+        // Only my-feature-branch PR must be observed
+        assertEquals(1, observer.getBranches().size());
+        assertEquals("PR-23", observer.getBranches().get(0));
+    }
 
     @Test
     public void gitSCMTest() {


### PR DESCRIPTION
In addition to #9, this adds individual options for deactivating the retrieval of branches or pull requests if having two builds for one branch is not an option.
Further this provides an easy way to create jobs for pull requests only.