### PR TITLE
[JENKINS-33701] Set scm browser on mercurial and git repos

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,11 @@
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>credentials</artifactId>
+            <version>2.1.12</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>branch-api</artifactId>
             <version>2.0.6</version>
             <scope>test</scope>
@@ -115,7 +120,7 @@
           <version>1.3</version>
           <scope>test</scope>
         </dependency>
-        <dependency> 
+        <dependency>
           <groupId>org.jenkins-ci.plugins</groupId>
           <artifactId>git</artifactId>
           <version>2.6.5</version>
@@ -125,14 +130,21 @@
         <dependency>
           <groupId>org.jenkins-ci.plugins.workflow</groupId>
           <artifactId>workflow-multibranch</artifactId>
-          <version>2.11</version>
+          <version>2.12</version>
           <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-scm-step</artifactId>
+            <version>2.4</version>
+            <classifier>tests</classifier>
+            <scope>test</scope>
         </dependency>
         <dependency>
           <groupId>org.jenkins-ci.plugins.workflow</groupId>
           <artifactId>workflow-aggregator</artifactId>
-          <version>1.15</version>
-          <classifier>tests</classifier>
+          <version>2.5</version>
+          <!--<classifier>tests</classifier>-->
           <scope>test</scope>
         </dependency>
 

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource.java
@@ -48,12 +48,14 @@ import hudson.plugins.git.BranchSpec;
 import hudson.plugins.git.GitSCM;
 import hudson.plugins.git.SubmoduleConfig;
 import hudson.plugins.git.UserRemoteConfig;
+import hudson.plugins.git.browser.BitbucketWeb;
 import hudson.plugins.git.extensions.GitSCMExtension;
 import hudson.plugins.git.extensions.impl.BuildChooserSetting;
 import hudson.plugins.git.util.BuildChooser;
 import hudson.plugins.git.util.DefaultBuildChooser;
 import hudson.plugins.mercurial.MercurialSCM;
 import hudson.plugins.mercurial.MercurialSCM.RevisionType;
+import hudson.plugins.mercurial.browser.BitBucket;
 import hudson.scm.SCM;
 import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
@@ -522,50 +524,69 @@ public class BitbucketSCMSource extends SCMSource {
                 }
             }
         }
+        String browserUrl = buildBitbucketClient().getRepositoryUri(repositoryType, BitbucketRepositoryProtocol.HTTP, null, repoOwner, repository);
         if (head instanceof PullRequestSCMHead) {
             PullRequestSCMHead h = (PullRequestSCMHead) head;
             if (repositoryType == BitbucketRepositoryType.MERCURIAL) {
                 MercurialSCM scm = new MercurialSCM(getRemote(h.getRepoOwner(), h.getRepository(),
                         BitbucketRepositoryType.MERCURIAL));
                 // If no revision specified the branch name will be used as revision
-                scm.setRevision(revision instanceof MercurialRevision
-                        ? ((MercurialRevision) revision).getHash()
-                        : h.getBranchName()
-                );
-                scm.setRevisionType(RevisionType.BRANCH);
+                if (revision instanceof MercurialRevision) {
+                    scm.setRevision(((MercurialRevision) revision).getHash());
+                    scm.setRevisionType(RevisionType.CHANGESET);
+                } else {
+                    scm.setRevision(h.getBranchName());
+                    scm.setRevisionType(RevisionType.BRANCH);
+                }
                 scm.setCredentialsId(getCheckoutEffectiveCredentials());
+                try {
+                    scm.setBrowser(new BitBucket(browserUrl));
+                } catch (MalformedURLException e) {
+                    LOGGER.log(Level.WARNING, "Could not set repository browser: ", e);
+                }
                 return scm;
             } else {
                 // Defaults to Git
                 BuildChooser buildChooser = revision instanceof AbstractGitSCMSource.SCMRevisionImpl
                         ? new SpecificRevisionBuildChooser((AbstractGitSCMSource.SCMRevisionImpl) revision)
                         : new DefaultBuildChooser();
-                return new GitSCM(getGitRemoteConfigs(h),
+                GitSCM scm = new GitSCM(getGitRemoteConfigs(h),
                         Collections.singletonList(new BranchSpec(h.getBranchName())),
                         false, Collections.<SubmoduleConfig>emptyList(),
                         null, null, Collections.<GitSCMExtension>singletonList(new BuildChooserSetting(buildChooser)));
+                scm.setBrowser(new BitbucketWeb(browserUrl));
+                return scm;
             }
         }
         // head instanceof BranchSCMHead
         if (repositoryType == BitbucketRepositoryType.MERCURIAL) {
             MercurialSCM scm = new MercurialSCM(getRemote(repoOwner, repository, BitbucketRepositoryType.MERCURIAL));
             // If no revision specified the branch name will be used as revision
-            scm.setRevision(revision instanceof MercurialRevision
-                    ? ((MercurialRevision) revision).getHash()
-                    : head.getName()
-            );
-            scm.setRevisionType(RevisionType.BRANCH);
+            if (revision instanceof MercurialRevision) {
+                scm.setRevision(((MercurialRevision) revision).getHash());
+                scm.setRevisionType(RevisionType.CHANGESET);
+            } else {
+                scm.setRevision(head.getName());
+                scm.setRevisionType(RevisionType.BRANCH);
+            }
             scm.setCredentialsId(getCheckoutEffectiveCredentials());
+            try {
+                scm.setBrowser(new BitBucket(browserUrl));
+            } catch (MalformedURLException e) {
+                LOGGER.log(Level.WARNING, "Could not set repository browser: ", e);
+            }
             return scm;
         } else {
             // Defaults to Git
             BuildChooser buildChooser = revision instanceof AbstractGitSCMSource.SCMRevisionImpl
                     ? new SpecificRevisionBuildChooser((AbstractGitSCMSource.SCMRevisionImpl) revision)
                     : new DefaultBuildChooser();
-            return new GitSCM(getGitRemoteConfigs((BranchSCMHead)head),
+            GitSCM scm = new GitSCM(getGitRemoteConfigs((BranchSCMHead) head),
                     Collections.singletonList(new BranchSpec(head.getName())),
                     false, Collections.<SubmoduleConfig>emptyList(),
                     null, null, Collections.<GitSCMExtension>singletonList(new BuildChooserSetting(buildChooser)));
+            scm.setBrowser(new BitbucketWeb(browserUrl));
+            return scm;
         }
     }
 


### PR DESCRIPTION
I also found an issue that builds against mercurial repos
didn't generate a changelog due to the way revision and revisionType
where set when creating the mercurial scm instance.

Also fixed the dependencies so that hpi:run actually could work
since the original dependencies produced a garbled runtime with missing classes/plugins

@reviewbybees