### PR TITLE
generated checkout url ignore base context path

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/BitbucketServerAPIClient.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/BitbucketServerAPIClient.java
@@ -213,6 +213,7 @@ public class BitbucketServerAPIClient implements BitbucketApi {
                         } else {
                             result.append(url.getAuthority());
                         }
+                        result.append(url.getPath());
                         result.append("/scm/");
                         result.append(owner);
                         result.append('/');


### PR DESCRIPTION
When specifying a 'Bitbucket Server URL' with a base path, the base path is currently ignored when generating the checkout repository urls. End result is all your repositories fail to find any repos.

e.g. if you specify 'https://xxx.corp.com/stash' you receive

```
stderr: fatal: repository 'https://xxx.corp.com/scm/project/repo.git/' not found
```

as the correct git url is https://xxx.corp.com/stash/scm/project/repo.git/