### PR TITLE
Jenkins 40958 - Allow pullrequest approved in webhooks for bitbucket multibranch projects

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/HookEventType.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/HookEventType.java
@@ -54,7 +54,12 @@ public enum HookEventType {
     /**
      * See <a href="https://confluence.atlassian.com/bitbucket/event-payloads-740262817.html#EventPayloads-Declined">EventPayloads-Declined</a>
      */
-    PULL_REQUEST_DECLINED("pullrequest:rejected", PullRequestHookProcessor.class);
+    PULL_REQUEST_DECLINED("pullrequest:rejected", PullRequestHookProcessor.class),
+
+    /**
+     * See <a href="https://confluence.atlassian.com/bitbucket/event-payloads-740262817.html#EventPayloads-Approved">EventPayloads-Approved</a>
+     */
+    PULL_REQUEST_APPROVED("pullrequest:approved", PullRequestHookProcessor.class);
 
     private String key;
     private Class<?> clazz;

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/WebhookAutoRegisterListener.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/WebhookAutoRegisterListener.java
@@ -65,7 +65,8 @@ public class WebhookAutoRegisterListener extends ItemListener {
             HookEventType.PULL_REQUEST_CREATED.getKey(),
             HookEventType.PULL_REQUEST_UPDATED.getKey(),
             HookEventType.PULL_REQUEST_MERGED.getKey(),
-            HookEventType.PULL_REQUEST_DECLINED.getKey()
+            HookEventType.PULL_REQUEST_DECLINED.getKey(),
+            HookEventType.PULL_REQUEST_APPROVED.getKey()
     ));
 
     private static ExecutorService executorService;

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/client/events/BitbucketCloudPullRequestEventTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/client/events/BitbucketCloudPullRequestEventTest.java
@@ -502,4 +502,68 @@ public class BitbucketCloudPullRequestEventTest {
                 anyOf(is("a72355f35fde"), is("a72355f35fde2ad4f5724a279b970ef7b6729131")));
     }
 
+    @Test
+    public void approvedPayload() throws Exception {
+        BitbucketPullRequestEvent event = BitbucketCloudWebhookPayload.pullRequestEventFromPayload(payload);
+        assertThat(event.getRepository(), notNullValue());
+        assertThat(event.getRepository().getScm(), is("git"));
+        assertThat(event.getRepository().getFullName(), is("cloudbeers/temp"));
+        assertThat(event.getRepository().getOwner().getDisplayName(), is("cloudbeers"));
+        assertThat(event.getRepository().getOwner().getUsername(), is("cloudbeers"));
+        assertThat(event.getRepository().getRepositoryName(), is("temp"));
+        assertThat(event.getRepository().isPrivate(), is(true));
+        assertThat(event.getRepository().getLinks(), notNullValue());
+        assertThat(event.getRepository().getLinks().get("self"), notNullValue());
+        assertThat(event.getRepository().getLinks().get("self").getHref(),
+                is("https://api.bitbucket.org/2.0/repositories/cloudbeers/temp"));
+
+        assertThat(event.getPullRequest(), notNullValue());
+        assertThat(event.getPullRequest().getTitle(), is("README.md edited online with Bitbucket"));
+        assertThat(event.getPullRequest().getAuthorLogin(), is("stephenc"));
+        assertThat(event.getPullRequest().getLink(),
+                is("https://bitbucket.org/cloudbeers/temp/pull-requests/2"));
+
+        assertThat(event.getPullRequest().getDestination(), notNullValue());
+        assertThat(event.getPullRequest().getDestination().getRepository(), notNullValue());
+        assertThat(event.getPullRequest().getDestination().getRepository().getScm(), is("git"));
+        assertThat(event.getPullRequest().getDestination().getRepository().getFullName(), is("cloudbeers/temp"));
+        assertThat(event.getPullRequest().getDestination().getRepository().getOwner().getDisplayName(),
+                is("cloudbeers"));
+        assertThat(event.getPullRequest().getDestination().getRepository().getOwner().getUsername(), is("cloudbeers"));
+        assertThat(event.getPullRequest().getDestination().getRepository().getRepositoryName(), is("temp"));
+        assertThat(event.getPullRequest().getDestination().getRepository().isPrivate(), is(true));
+        assertThat(event.getPullRequest().getDestination().getRepository().getLinks(), notNullValue());
+        assertThat(event.getPullRequest().getDestination().getRepository().getLinks().get("self"), notNullValue());
+        assertThat(event.getPullRequest().getDestination().getRepository().getLinks().get("self").getHref(),
+                is("https://api.bitbucket.org/2.0/repositories/cloudbeers/temp"));
+        assertThat(event.getPullRequest().getDestination().getBranch(), notNullValue());
+        assertThat(event.getPullRequest().getDestination().getBranch().getName(), is("master"));
+        assertThat(event.getPullRequest().getDestination().getBranch().getRawNode(),
+                anyOf(is("f612156eff2c"), is("f612156eff2c958f52f8e6e20c71f396aeaeaff4")));
+        assertThat(event.getPullRequest().getDestination().getCommit(), notNullValue());
+        assertThat(event.getPullRequest().getDestination().getCommit().getHash(),
+                anyOf(is("f612156eff2c"), is("f612156eff2c958f52f8e6e20c71f396aeaeaff4")));
+
+        assertThat(event.getPullRequest().getSource(), notNullValue());
+        assertThat(event.getPullRequest().getSource().getRepository(), notNullValue());
+        assertThat(event.getPullRequest().getSource().getRepository().getScm(), is("git"));
+        assertThat(event.getPullRequest().getSource().getRepository().getFullName(), is("cloudbeers/temp"));
+        assertThat(event.getPullRequest().getSource().getRepository().getOwner().getDisplayName(), is("cloudbeers"));
+        assertThat(event.getPullRequest().getSource().getRepository().getOwner().getUsername(), is("cloudbeers"));
+        assertThat(event.getPullRequest().getSource().getRepository().getRepositoryName(), is("temp"));
+        assertThat(event.getPullRequest().getSource().getRepository().isPrivate(), is(true));
+        assertThat(event.getPullRequest().getSource().getRepository().getLinks(), notNullValue());
+        assertThat(event.getPullRequest().getSource().getRepository().getLinks().get("self"), notNullValue());
+        assertThat(event.getPullRequest().getSource().getRepository().getLinks().get("self").getHref(),
+                is("https://api.bitbucket.org/2.0/repositories/cloudbeers/temp"));
+
+        assertThat(event.getPullRequest().getSource().getBranch(), notNullValue());
+        assertThat(event.getPullRequest().getSource().getBranch().getName(), is("foo"));
+        assertThat(event.getPullRequest().getSource().getBranch().getRawNode(),
+                anyOf(is("a72355f35fde"), is("a72355f35fde2ad4f5724a279b970ef7b6729131")));
+        assertThat(event.getPullRequest().getSource().getCommit(), notNullValue());
+        assertThat(event.getPullRequest().getSource().getCommit().getHash(),
+                anyOf(is("a72355f35fde"), is("a72355f35fde2ad4f5724a279b970ef7b6729131")));
+    }
+
 }

--- a/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/client/events/BitbucketCloudPullRequestEventTest/approvedPayload.json
+++ b/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/client/events/BitbucketCloudPullRequestEventTest/approvedPayload.json
@@ -1,0 +1,242 @@
+{
+  "approval": {
+    "date": "2017-04-16T04:56:59.454824+00:00",
+    "user": {
+      "username": "stephenc",
+      "type": "user",
+      "display_name": "Stephen Connolly",
+      "uuid": "{f70f195e-ade1-4961-9f89-547541377b80}",
+      "links": {
+        "self": {
+          "href": "https://api.bitbucket.org/2.0/users/stephenc"
+        },
+        "html": {
+          "href": "https://bitbucket.org/stephenc/"
+        },
+        "avatar": {
+          "href": "https://bitbucket.org/account/stephenc/avatar/32/"
+        }
+      }
+    }
+  },
+  "pullrequest": {
+    "description": "",
+    "links": {
+      "decline": {
+        "href": "https://api.bitbucket.org/2.0/repositories/cloudbeers/temp/pullrequests/1/decline"
+      },
+      "commits": {
+        "href": "https://api.bitbucket.org/2.0/repositories/cloudbeers/temp/pullrequests/1/commits"
+      },
+      "self": {
+        "href": "https://api.bitbucket.org/2.0/repositories/cloudbeers/temp/pullrequests/1"
+      },
+      "comments": {
+        "href": "https://api.bitbucket.org/2.0/repositories/cloudbeers/temp/pullrequests/1/comments"
+      },
+      "merge": {
+        "href": "https://api.bitbucket.org/2.0/repositories/cloudbeers/temp/pullrequests/1/merge"
+      },
+      "html": {
+        "href": "https://bitbucket.org/cloudbeers/temp/pull-requests/2"
+      },
+      "activity": {
+        "href": "https://api.bitbucket.org/2.0/repositories/cloudbeers/temp/pullrequests/1/activity"
+      },
+      "diff": {
+        "href": "https://api.bitbucket.org/2.0/repositories/cloudbeers/temp/pullrequests/1/diff"
+      },
+      "approve": {
+        "href": "https://api.bitbucket.org/2.0/repositories/cloudbeers/temp/pullrequests/1/approve"
+      },
+      "statuses": {
+        "href": "https://api.bitbucket.org/2.0/repositories/cloudbeers/temp/pullrequests/1/statuses"
+      }
+    },
+    "author": {
+      "username": "stephenc",
+      "display_name": "Stephen Connolly",
+      "type": "user",
+      "uuid": "{f70f195e-ade1-4961-9f89-547541377b80}",
+      "links": {
+        "self": {
+          "href": "https://api.bitbucket.org/2.0/users/stephenc"
+        },
+        "html": {
+          "href": "https://bitbucket.org/stephenc/"
+        },
+        "avatar": {
+          "href": "https://bitbucket.org/account/stephenc/avatar/32/"
+        }
+      }
+    },
+    "close_source_branch": false,
+    "reviewers": [],
+    "destination": {
+      "commit": {
+        "hash": "f612156eff2c",
+        "links": {
+          "self": {
+            "href": "https://api.bitbucket.org/2.0/repositories/cloudbeers/temp/commit/f612156eff2c"
+          }
+        }
+      },
+      "branch": {
+        "name": "master"
+      },
+      "repository": {
+        "links": {
+          "self": {
+            "href": "https://api.bitbucket.org/2.0/repositories/cloudbeers/temp"
+          },
+          "html": {
+            "href": "https://bitbucket.org/cloudbeers/temp"
+          },
+          "avatar": {
+            "href": "https://bitbucket.org/cloudbeers/temp/avatar/32/"
+          }
+        },
+        "type": "repository",
+        "name": "temp",
+        "full_name": "cloudbeers/temp",
+        "uuid": "{0c97528b-3b80-4f83-9281-ec961f622185}"
+      }
+    },
+    "participants": [
+      {
+        "type": "participant",
+        "role": "PARTICIPANT",
+        "approved": true,
+        "user": {
+          "username": "stephenc",
+          "type": "user",
+          "display_name": "Stephen Connolly",
+          "uuid": "{f70f195e-ade1-4961-9f89-547541377b80}",
+          "links": {
+            "self": {
+              "href": "https://api.bitbucket.org/2.0/users/stephenc"
+            },
+            "html": {
+              "href": "https://bitbucket.org/stephenc/"
+            },
+            "avatar": {
+              "href": "https://bitbucket.org/account/stephenc/avatar/32/"
+            }
+          }
+        }
+      }
+    ],
+    "id": 1,
+    "source": {
+      "commit": {
+        "hash": "a72355f35fde",
+        "links": {
+          "self": {
+            "href": "https://api.bitbucket.org/2.0/repositories/cloudbeers/temp/commit/f612156eff2c"
+          }
+        }
+      },
+      "branch": {
+        "name": "foo"
+      },
+      "repository": {
+        "links": {
+          "self": {
+            "href": "https://api.bitbucket.org/2.0/repositories/cloudbeers/temp"
+          },
+          "html": {
+            "href": "https://bitbucket.org/cloudbeers/temp"
+          },
+          "avatar": {
+            "href": "https://bitbucket.org/cloudbeers/temp/avatar/32/"
+          }
+        },
+        "type": "repository",
+        "name": "temp",
+        "full_name": "cloudbeers/temp",
+        "uuid": "{0c97528b-3b80-4f83-9281-ec961f622185}"
+      }
+    },
+    "state": "OPEN",
+    "comment_count": 0,
+    "title": "README.md edited online with Bitbucket",
+    "task_count": 0,
+    "created_on": "2017-04-16T04:56:32.716470+00:00",
+    "type": "pullrequest",
+    "reason": "",
+    "updated_on": "2017-04-16T04:56:59.460633+00:00",
+    "merge_commit": null,
+    "closed_by": null
+  },
+  "actor": {
+    "username": "stephenc",
+    "type": "user",
+    "display_name": "Stephen Connolly",
+    "uuid": "{f70f195e-ade1-4961-9f89-547541377b80}",
+    "links": {
+      "self": {
+        "href": "https://api.bitbucket.org/2.0/users/stephenc"
+      },
+      "html": {
+        "href": "https://bitbucket.org/stephenc/"
+      },
+      "avatar": {
+        "href": "https://bitbucket.org/account/stephenc/avatar/32/"
+      }
+    }
+  },
+  "repository": {
+    "scm": "git",
+    "website": "",
+    "uuid": "{0c97528b-3b80-4f83-9281-ec961f622185}",
+    "links": {
+      "self": {
+        "href": "https://api.bitbucket.org/2.0/repositories/cloudbeers/temp"
+      },
+      "html": {
+        "href": "https://bitbucket.org/cloudbeers/temp"
+      },
+      "avatar": {
+        "href": "https://bitbucket.org/cloudbeers/temp/avatar/32/"
+      }
+    },
+    "project": {
+      "key": "DUB",
+      "type": "project",
+      "name": "Tests",
+      "links": {
+        "self": {
+          "href": "https://api.bitbucket.org/2.0/teams/cloudbeers/projects/DUB"
+        },
+        "html": {
+          "href": "https://bitbucket.org/account/user/cloudbeers/projects/DUB"
+        },
+        "avatar": {
+          "href": "https://bitbucket.org/account/user/cloudbeers/projects/DUB/avatar/32"
+        }
+      },
+      "uuid": "{973a1231-e39b-438c-a984-07d4c0b941b7}"
+    },
+    "full_name": "cloudbeers/temp",
+    "owner": {
+      "username": "cloudbeers",
+      "type": "team",
+      "display_name": "cloudbeers",
+      "uuid": "{8bb5fe5d-f95b-41fd-92dd-af263cc10074}",
+      "links": {
+        "self": {
+          "href": "https://api.bitbucket.org/2.0/teams/cloudbeers"
+        },
+        "html": {
+          "href": "https://bitbucket.org/cloudbeers/"
+        },
+        "avatar": {
+          "href": "https://bitbucket.org/account/cloudbeers/avatar/32/"
+        }
+      }
+    },
+    "type": "repository",
+    "is_private": true,
+    "name": "temp"
+  }
+}


### PR DESCRIPTION
I have a use case where I need to wait until a pull request has been approved before kicking off a build and I noticed this improvement was logged as JENKINS-40958 so I figured I would offer my change. Simply added it as a recognized request type and from that point it gets treated as an update request and successfully kicks off the build. 