### PR TITLE
Allow exclusions to be specified at the start of the branch name

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource.java
@@ -635,7 +635,7 @@ public class BitbucketSCMSource extends SCMSource {
      * @param branchName
      * @return true if branchName is excluded or is not included
      */
-    private boolean isExcluded(String branchName) {
+    boolean isExcluded(String branchName) {
         return !Pattern.matches(getPattern(getIncludes()), branchName)
                 || Pattern.matches(getPattern(getExcludes()), branchName);
     }
@@ -652,7 +652,7 @@ public class BitbucketSCMSource extends SCMSource {
         for (String wildcard : branches.split(" ")) {
             StringBuilder quotedBranch = new StringBuilder();
             for (String branch : wildcard.split("\\*")) {
-                if (wildcard.startsWith("*") || quotedBranches.length() > 0) {
+                if (wildcard.startsWith("*") || quotedBranch.length() > 0) {
                     quotedBranch.append(".*");
                 }
                 quotedBranch.append(Pattern.quote(branch));

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSourceTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSourceTest.java
@@ -1,0 +1,25 @@
+package com.cloudbees.jenkins.plugins.bitbucket;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class BitbucketSCMSourceTest {
+
+    public BitbucketSCMSource bitbucketSCMSource;
+
+    @Before
+    public void setUp() throws Exception {
+        bitbucketSCMSource = new BitbucketSCMSource("1", "owner", "repo");
+    }
+
+    @Test
+    public void shouldAllowExclusionsAtStartOfBranchName() throws Exception {
+        String includes = "master branch-*";
+        bitbucketSCMSource.setIncludes(includes);
+        assertFalse("Should not exclude branch-* at start of name", bitbucketSCMSource.isExcluded("branch-1.0.0"));
+        assertTrue("Should exclude branch in the middle of the branch name", bitbucketSCMSource.isExcluded("FOO_branch-1.0.0"));
+    }
+}


### PR DESCRIPTION
Hi all - we were trying to setup some includes within BitBucket to only scan particular branches in a repo and came across what looks like a small bug. The code in getPattern() was prepending a .* to the second and subsequent patterns in the input. 
Eg, input of:
`master branch`
would result in trying to match:
`master *branch`
which would then incorrectly match a branch name of:
`TEST-branch`
whereas we only would expect it to match:
`branch`
in that case.

Note that the visibility change on isExcluded is just for the purposes of testing - not required for the actual fix.

See what you think, happy to discuss or change if you'd like more info.

Kind regards,
Andrew