### PR TITLE
[Fixed JENKINS-43664] hg branch URI encoding

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,7 @@
     <properties>
         <jenkins.version>1.642.3</jenkins.version>
         <scm-api.version>2.0.4</scm-api.version>
+        <powermock.version>1.6.5</powermock.version>
     </properties>
 
     <scm>
@@ -135,7 +136,18 @@
           <classifier>tests</classifier>
           <scope>test</scope>
         </dependency>
-
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-api-mockito</artifactId>
+            <version>${powermock.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-module-junit4</artifactId>
+            <version>${powermock.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
      <repositories>

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource.java
@@ -88,6 +88,7 @@ import jenkins.scm.api.metadata.ObjectMetadataAction;
 import jenkins.scm.api.metadata.PrimaryInstanceMetadataAction;
 import jenkins.scm.impl.ChangeRequestSCMHeadCategory;
 import jenkins.scm.impl.UncategorizedSCMHeadCategory;
+import org.apache.commons.httpclient.util.URIUtil;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.WordUtils;
 import org.eclipse.jgit.lib.Constants;
@@ -731,8 +732,8 @@ public class BitbucketSCMSource extends SCMSource {
                         URLEncoder.encode(Constants.R_HEADS + head.getName(), "UTF-8");
                 title = null;
             }
-            result.add(new BitbucketLink("icon-bitbucket-branch", serverUrl + "/" + branchUrl));
-            result.add(new ObjectMetadataAction(title, null, serverUrl+"/"+branchUrl));
+            result.add(new BitbucketLink("icon-bitbucket-branch", serverUrl + "/" + URIUtil.encodePath(branchUrl)));
+            result.add(new ObjectMetadataAction(title, null, serverUrl + "/" + URIUtil.encodePath(branchUrl)));
         } else {
             String branchUrl;
             String title;
@@ -748,8 +749,8 @@ public class BitbucketSCMSource extends SCMSource {
                 branchUrl = repoOwner + "/" + repository + "/branch/" + head.getName();
                 title = null;
             }
-            result.add(new BitbucketLink("icon-bitbucket-branch", serverUrl + "/" + branchUrl));
-            result.add(new ObjectMetadataAction(title, null, serverUrl + "/" + branchUrl));
+            result.add(new BitbucketLink("icon-bitbucket-branch", serverUrl + "/" + URIUtil.encodePath(branchUrl)));
+            result.add(new ObjectMetadataAction(title, null, serverUrl + "/" + URIUtil.encodePath(branchUrl)));
         }
         SCMSourceOwner owner = getOwner();
         if (owner instanceof Actionable) {

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/BitbucketCloudApiClient.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/BitbucketCloudApiClient.java
@@ -272,7 +272,8 @@ public class BitbucketCloudApiClient implements BitbucketApi {
      */
     @Override
     public boolean checkPathExists(@NonNull String branch, @NonNull String path) throws IOException, InterruptedException {
-        int status = getRequestStatus(V1_API_BASE_URL + owner + "/" + repositoryName + "/raw/" + branch + "/" + path);
+        int status = getRequestStatus(V1_API_BASE_URL + owner + "/" + repositoryName + "/raw/" +
+                branch.replaceAll(" ", "%20") + "/" + path);
         return status == HttpStatus.SC_OK;
     }
 

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/BitbucketCloudApiClient.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/BitbucketCloudApiClient.java
@@ -58,8 +58,6 @@ import java.net.InetSocketAddress;
 import java.net.Proxy;
 import java.net.URLEncoder;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.logging.Logger;
 import jenkins.model.Jenkins;
@@ -273,8 +271,6 @@ public class BitbucketCloudApiClient implements BitbucketApi {
      */
     @Override
     public boolean checkPathExists(@NonNull String branch, @NonNull String path) throws IOException, InterruptedException {
-        if (branch.contains(":"))
-            throw new IllegalArgumentException("The character ':' cannot be used in a named branch");
         int status = getRequestStatus(V1_API_BASE_URL + owner + "/" + repositoryName + "/raw/" +
                 URIUtil.encodePath(branch) + "/" + path);
         return status == HttpStatus.SC_OK;

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/BitbucketCloudApiClient.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/BitbucketCloudApiClient.java
@@ -78,6 +78,7 @@ import org.apache.commons.httpclient.methods.DeleteMethod;
 import org.apache.commons.httpclient.methods.GetMethod;
 import org.apache.commons.httpclient.methods.PostMethod;
 import org.apache.commons.httpclient.methods.StringRequestEntity;
+import org.apache.commons.httpclient.util.URIUtil;
 import org.apache.commons.lang.StringUtils;
 import org.codehaus.jackson.JsonGenerationException;
 import org.codehaus.jackson.JsonNode;
@@ -272,8 +273,10 @@ public class BitbucketCloudApiClient implements BitbucketApi {
      */
     @Override
     public boolean checkPathExists(@NonNull String branch, @NonNull String path) throws IOException, InterruptedException {
+        if (branch.contains(":"))
+            throw new IllegalArgumentException("The character ':' cannot be used in a named branch");
         int status = getRequestStatus(V1_API_BASE_URL + owner + "/" + repositoryName + "/raw/" +
-                branch.replaceAll(" ", "%20") + "/" + path);
+                URIUtil.encodePath(branch) + "/" + path);
         return status == HttpStatus.SC_OK;
     }
 

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketClientRequestMockTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketClientRequestMockTest.java
@@ -1,0 +1,55 @@
+package com.cloudbees.jenkins.plugins.bitbucket;
+
+import com.cloudbees.jenkins.plugins.bitbucket.client.BitbucketCloudApiClient;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Creates a BitbucketCloudApiClient with mock Bitbucket client API response status'
+ * @author Alex Johnson
+ */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(BitbucketCloudApiClient.class)
+public class BitbucketClientRequestMockTest {
+
+    /** The mocked BitBucketApiClient */
+    private BitbucketCloudApiClient api;
+
+    /**
+     * Initializes the mocked BitbucketCloudApiClient class.
+     */
+    @Before
+    public void setUp() throws Exception {
+        api = PowerMockito.spy(new BitbucketCloudApiClient("alexbrjo", "repo1", null));
+        String correctUrl = "https://bitbucket.org/api/1.0/repositories/alexbrjo/repo1/raw/";
+
+        // mock api response for branch 'name with spaces'
+        PowerMockito.doThrow(new IllegalArgumentException("Invalid uri"))
+                .when(api, "getRequestStatus",correctUrl + "name with spaces/Jenkinsfile");
+        PowerMockito.doReturn(200)
+                .when(api, "getRequestStatus",correctUrl + "name%20with%20spaces/Jenkinsfile");
+        // mock api response for branch '~`!@#$%^&*()_+=[]{}\|;"<>,./\?a'
+        PowerMockito.doThrow(new IllegalArgumentException("Invalid uri"))
+                .when(api, "getRequestStatus",correctUrl + "~`!@#$%^&*()_+=[]{}\\|;\"<>,./\\?a/Jenkinsfile");
+        PowerMockito.doReturn(200)
+                .when(api, "getRequestStatus",correctUrl + "~%60!@%23$%25%5E&*()_%2B=%5B%5D%7B%7D%5C%7C;%22%3C%3E,./%5C%3Fa/Jenkinsfile");
+    }
+
+    /**
+     * Tests scanning of hg and git repos that have a branch name with characters that need to be uri encoded. Testing
+     * with no cred access.
+     */
+    @Test
+    public void testBranchNameUriEncoding () throws Exception {
+        // branch with spaces in the names can be used
+        assertTrue(api.checkPathExists("name with spaces", "Jenkinsfile"));
+        // branch other characters in the name can be used
+        assertTrue(api.checkPathExists("~`!@#$%^&*()_+=[]{}\\|;\"<>,./\\?a", "Jenkinsfile"));
+    }
+}

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/BranchScanningTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/BranchScanningTest.java
@@ -23,9 +23,11 @@
  */
 package com.cloudbees.jenkins.plugins.bitbucket;
 
+import static com.cloudbees.jenkins.plugins.bitbucket.BitbucketClientMockUtils.getAPIClientMock;
 import static org.junit.Assert.*;
 import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.*;
+import static org.powermock.api.support.membermodification.MemberMatcher.method;
 
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketRepositoryType;
 import hudson.model.TaskListener;
@@ -52,7 +54,11 @@ import org.junit.Test;
 import com.cloudbees.jenkins.plugins.bitbucket.client.BitbucketCloudApiClient;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
+import org.junit.runner.RunWith;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 
 public class BranchScanningTest {
 
@@ -133,25 +139,6 @@ public class BranchScanningTest {
         assertTrue("SCM must be an instance of MercurialSCM", scm instanceof MercurialSCM);
     }
 
-    /**
-     * Tests scanning of Mercurial repos that have a branch name with characters that need to be uri encoded. Testing
-     * with no cred access
-     */
-    @Test
-    public void mercurialBranchNameUriEncodingTest () throws Exception {
-        BitbucketCloudApiClient api = new BitbucketCloudApiClient("alexjo", "bugrep-forest", null);
-        // branch with spaces in the names can be used
-        assertTrue(api.checkPathExists("name with spaces", "Jenkinsfile"));
-        // branch other characters in the name can be used
-        assertTrue(api.checkPathExists("~`!@#$%^&*()_+=[]{}\\|;\"<>,./\\?a", "Jenkinsfile"));
-        // ':' is an invalid hg branch name character
-        try {
-            api.checkPathExists("branch:dev-12345", "Jenkinsfile");
-        } catch (IllegalArgumentException e) {
-            assertEquals("The character ':' cannot be used in a named branch", e.getMessage());
-        }
-    }
-
     private SCM scmBuild(BitbucketRepositoryType type) throws IOException, InterruptedException {
         BitbucketSCMSource source = getBitbucketSCMSourceMock(type);
         return source.build(new BranchSCMHead("branch1", type));
@@ -159,7 +146,7 @@ public class BranchScanningTest {
 
     private BitbucketSCMSource getBitbucketSCMSourceMock(BitbucketRepositoryType type, boolean includePullRequests)
             throws IOException, InterruptedException {
-        BitbucketCloudApiClient mock = BitbucketClientMockUtils.getAPIClientMock(type, includePullRequests);
+        BitbucketCloudApiClient mock = getAPIClientMock(type, includePullRequests);
         BitbucketMockApiFactory.add(null, mock);
 
         BitbucketSCMSource source = new BitbucketSCMSource(null, "amuniz", "test-repos");
@@ -205,4 +192,5 @@ public class BranchScanningTest {
             return branches;
         }
     }
+
 }

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/BranchScanningTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/BranchScanningTest.java
@@ -134,12 +134,22 @@ public class BranchScanningTest {
     }
 
     /**
-     * Tests scanning of Mercurial repos that have a branch name with spaces. Testing with no cred access
+     * Tests scanning of Mercurial repos that have a branch name with characters that need to be uri encoded. Testing
+     * with no cred access
      */
     @Test
-    public void mercurialBranchNameWithSpacesTest () throws Exception {
+    public void mercurialBranchNameUriEncodingTest () throws Exception {
         BitbucketCloudApiClient api = new BitbucketCloudApiClient("alexjo", "bugrep-forest", null);
+        // branch with spaces in the names can be used
         assertTrue(api.checkPathExists("name with spaces", "Jenkinsfile"));
+        // branch other characters in the name can be used
+        assertTrue(api.checkPathExists("~`!@#$%^&*()_+=[]{}\\|;\"<>,./\\?a", "Jenkinsfile"));
+        // ':' is an invalid hg branch name character
+        try {
+            api.checkPathExists("branch:dev-12345", "Jenkinsfile");
+        } catch (IllegalArgumentException e) {
+            assertEquals("The character ':' cannot be used in a named branch", e.getMessage());
+        }
     }
 
     private SCM scmBuild(BitbucketRepositoryType type) throws IOException, InterruptedException {

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/BranchScanningTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/BranchScanningTest.java
@@ -66,13 +66,13 @@ public class BranchScanningTest {
     @Test
     public void uriResolverTest() throws Exception {
         BitbucketSCMSource source = getBitbucketSCMSourceMock(BitbucketRepositoryType.GIT);
-        String remote = source.getRemote("amuniz", "test", source.getRepositoryType());
+        String remote = source.getRemote(repoOwner, repoName, source.getRepositoryType());
 
         // When there is no checkout credentials set, https must be resolved
         assertEquals("https://bitbucket.org/amuniz/test.git", remote);
 
         source = getBitbucketSCMSourceMock(BitbucketRepositoryType.MERCURIAL);
-        remote = source.getRemote("amuniz", "test", source.getRepositoryType());
+        remote = source.getRemote(repoOwner, repoName, source.getRepositoryType());
 
         // Resolve URL for Mercurial repositories
         assertEquals("https://bitbucket.org/amuniz/test", remote);
@@ -131,6 +131,15 @@ public class BranchScanningTest {
     public void mercurialSCMTest() throws Exception {
         SCM scm = scmBuild(BitbucketRepositoryType.MERCURIAL);
         assertTrue("SCM must be an instance of MercurialSCM", scm instanceof MercurialSCM);
+    }
+
+    /**
+     * Tests scanning of Mercurial repos that have a branch name with spaces. Testing with no cred access
+     */
+    @Test
+    public void mercurialBranchNameWithSpacesTest () throws Exception {
+        BitbucketCloudApiClient api = new BitbucketCloudApiClient("alexjo", "bugrep-forest", null);
+        assertTrue(api.checkPathExists("name with spaces", "Jenkinsfile"));
     }
 
     private SCM scmBuild(BitbucketRepositoryType type) throws IOException, InterruptedException {


### PR DESCRIPTION
Added support for scanning Mercurial repositories with spaces in branch names.

https://issues.jenkins-ci.org/browse/JENKINS-43664

@reviewbybees 