### PR TITLE
Use `SCMRevision` instead of `BuildData` to determine revision to notify

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketBuildStatusNotifications.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketBuildStatusNotifications.java
@@ -40,13 +40,16 @@ import hudson.model.TaskListener;
 import hudson.model.listeners.RunListener;
 import hudson.model.listeners.SCMListener;
 import hudson.plugins.git.Revision;
-import hudson.plugins.git.util.BuildData;
 import hudson.plugins.mercurial.MercurialTagAction;
 import hudson.scm.SCM;
 import hudson.scm.SCMRevisionState;
 import java.io.File;
 import java.io.IOException;
+
+import jenkins.plugins.git.AbstractGitSCMSource;
 import jenkins.scm.api.SCMHead;
+import jenkins.scm.api.SCMRevision;
+import jenkins.scm.api.SCMRevisionAction;
 import jenkins.scm.api.SCMSource;
 import jenkins.scm.api.SCMSourceOwner;
 import org.jenkinsci.plugins.displayurlapi.DisplayURLProvider;
@@ -97,11 +100,10 @@ public class BitbucketBuildStatusNotifications {
     @CheckForNull
     private static String extractRevision(Run<?, ?> build) {
         String revision = null;
-        BuildData gitBuildData = build.getAction(BuildData.class);
-        if (gitBuildData != null) {
-            Revision lastBuiltRevision = gitBuildData.getLastBuiltRevision();
-            if (lastBuiltRevision != null) {
-                revision = lastBuiltRevision.getSha1String();
+        SCMRevision scmRevision = SCMRevisionAction.getRevision(build);
+        if (scmRevision != null) {
+            if (scmRevision instanceof AbstractGitSCMSource.SCMRevisionImpl) {
+                revision = ((AbstractGitSCMSource.SCMRevisionImpl) scmRevision).getHash();
             }
         } else {
             MercurialTagAction action = build.getAction(MercurialTagAction.class);


### PR DESCRIPTION
When using a Global library that also comes from Bitbucket the notification will sometimes go to that library rather than the revision that the build is running for.
This is because there are multiple `BuildData` actions when retrieving the library.
This change hopes to fix that for Git libraries by retrieving the `SCMRevision` instead of the `BuildData`.

issue: https://issues.jenkins-ci.org/browse/JENKINS-41996
issue: https://issues.jenkins-ci.org/browse/JENKINS-42878
