### PR TITLE
JENKINS-41190 Use new API endpoint instead of deprecated endpoint

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/BitbucketCloudApiClient.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/BitbucketCloudApiClient.java
@@ -87,9 +87,9 @@ import org.codehaus.jackson.map.ObjectMapper;
 
 public class BitbucketCloudApiClient implements BitbucketApi {
     private static final Logger LOGGER = Logger.getLogger(BitbucketCloudApiClient.class.getName());
-    private static final String V1_API_BASE_URL = "https://bitbucket.org/api/1.0/repositories/";
-    private static final String V2_API_BASE_URL = "https://bitbucket.org/api/2.0/repositories/";
-    private static final String V2_TEAMS_API_BASE_URL = "https://bitbucket.org/api/2.0/teams/";
+    private static final String V1_API_BASE_URL = "https://api.bitbucket.org/1.0/repositories/";
+    private static final String V2_API_BASE_URL = "https://api.bitbucket.org/2.0/repositories/";
+    private static final String V2_TEAMS_API_BASE_URL = "https://api.bitbucket.org/2.0/teams/";
     private static final int MAX_PAGES = 100;
     private HttpClient client;
     private static final MultiThreadedHttpConnectionManager connectionManager = new MultiThreadedHttpConnectionManager();


### PR DESCRIPTION
Atlassian told us back in January that:

> This plugin uses https://bitbucket.org/api/.. as it's base URL. This is not a valid or even supported URL on Bitbucket. It currently happens to work, but won't in the future.
> As per the documentation, Bitbucket's API lives on https://api.bitbucket.org

See the [developer docs](https://confluence.atlassian.com/bitbucket/use-the-bitbucket-cloud-rest-apis-222724129.html#UsetheBitbucketCloudRESTAPIs-URIStructureandMethods).

PTAL @stephenc 