### PR TITLE
Prevent rate limiting

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     </parent>
 
     <artifactId>cloudbees-bitbucket-branch-source</artifactId>
-    <version>2.1.2</version>
+    <version>2.1.2-ratelimit-3</version>
     <packaging>hpi</packaging>
 
     <name>Bitbucket Branch Source Plugin</name>
@@ -49,6 +49,7 @@
     <properties>
         <jenkins.version>1.642.3</jenkins.version>
         <scm-api.version>2.0.4</scm-api.version>
+        <java.level>8</java.level>
     </properties>
 
     <scm>
@@ -94,7 +95,6 @@
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>branch-api</artifactId>
             <version>2.0.6</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
This change prevents repositories from being scanned when a job already exists for the repository.

There are a few gaps though:

1. When a repository doesn't have a working webhook, it will always be skipped from scanning, so no automatic builds will ever happen. This is not a problem when there is no pre-existing job for the repository or when webhooks are explicitly turned off in Jenkins.

1. Jobs that already exist while scanning, are considered stale/orphan and will be deleted. Our workaround is to configure the plugin to never delete orphan jobs (Days to keep old items = 999). Consequently jobs for deleted repositories are never deleted.