### PR TITLE
Added JWT support for authentication to bitbucket connect

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/BitbucketConnectJwtAuthScheme.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/BitbucketConnectJwtAuthScheme.java
@@ -1,0 +1,55 @@
+package com.cloudbees.jenkins.plugins.bitbucket.client;
+
+import org.apache.commons.httpclient.Credentials;
+import org.apache.commons.httpclient.HttpMethod;
+import org.apache.commons.httpclient.auth.AuthenticationException;
+import org.apache.commons.httpclient.auth.RFC2617Scheme;
+
+/**
+ * JWT HTTP authentication scheme.
+ *
+ * Bitbucket Connect specific JWT authentication based scheme.
+ *
+ * @author Vivek Pandey
+ */
+public class BitbucketConnectJwtAuthScheme extends RFC2617Scheme {
+    public static final String scheme="jwt";
+    private boolean complete;
+
+    public BitbucketConnectJwtAuthScheme() {
+        super();
+        this.complete = false;
+    }
+
+    @Override
+    public String getSchemeName() {
+        return scheme;
+    }
+
+    @Override
+    public boolean isConnectionBased() {
+        return false;
+    }
+
+    @Override
+    public boolean isComplete() {
+        return complete;
+    }
+
+    @Override
+    public String authenticate(Credentials credentials, String method, String uri) throws AuthenticationException {
+        return auth(credentials);
+    }
+
+    @Override
+    public String authenticate(Credentials credentials, HttpMethod method) throws AuthenticationException {
+        return auth(credentials);
+    }
+
+    private String auth(Credentials credentials){
+        if(!(credentials instanceof JwtHttpClientCredentials)){
+            throw new IllegalArgumentException("Must be JwtCredentials instance");
+        }
+        return  "JWT " + ((JwtHttpClientCredentials) credentials).getJwtToken();
+    }
+}

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/BitbucketConnectJwtCredentials.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/BitbucketConnectJwtCredentials.java
@@ -1,0 +1,59 @@
+package com.cloudbees.jenkins.plugins.bitbucket.client;
+
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
+import com.cloudbees.plugins.credentials.impl.BaseStandardCredentials;
+import hudson.util.Secret;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+
+/**
+ * Bitbucket Cloud JWT Credentials.
+ *
+ * Reference document: https://developer.atlassian.com/cloud/bitbucket/authentication-for-apps/
+ *
+ * @author Vivek Pandey
+ */
+public abstract class BitbucketConnectJwtCredentials extends BaseStandardCredentials
+        implements StandardUsernamePasswordCredentials {
+    /**
+     * Constructor
+     *
+     * @param scope scope of credentials
+     * @param id credentials id
+     * @param description description
+     */
+    public BitbucketConnectJwtCredentials(@CheckForNull CredentialsScope scope, @CheckForNull String id,
+                                          @CheckForNull String description) {
+        super(scope, id, description);
+    }
+
+    /**
+     * Bitbucket team name.
+     *
+     * @return team name
+     */
+    public abstract @Nonnull String getTeamName();
+
+    /**
+     * JWT token.
+     *
+     * @return jwt token
+     */
+    public abstract @Nonnull String getJwtToken();
+
+    /**
+     * Bitbucket Connect client key.
+     *
+     * @return client key
+     */
+    public abstract @Nonnull Secret clientKey();
+
+    /**
+     * Bitbucket Connect shared secret.
+     *
+     * @return shared secret
+     */
+    public abstract @Nonnull Secret sharedSecret();
+}

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/JwtHttpClientCredentials.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/JwtHttpClientCredentials.java
@@ -1,0 +1,22 @@
+package com.cloudbees.jenkins.plugins.bitbucket.client;
+
+import org.apache.commons.httpclient.Credentials;
+
+import javax.annotation.Nonnull;
+
+/**
+ * JWT specific HttpClient Credentials implementation
+ *
+ * @author Vivek Pandey
+ */
+public class JwtHttpClientCredentials implements Credentials{
+    private final String jwtToken;
+
+    public JwtHttpClientCredentials(@Nonnull String jwtToken) {
+        this.jwtToken = jwtToken;
+    }
+
+    public @Nonnull String getJwtToken(){
+        return jwtToken;
+    }
+}


### PR DESCRIPTION
Bitbucket connect require JWT token based authentication. This change will enable Blueocean to configure bitbucket branch source to use JWT specific credentials to authenticate with Bitbucket connect.

See https://issues.jenkins-ci.org/browse/JENKINS-46656
Related BlueOcean PR https://github.com/jenkinsci/blueocean-plugin/pull/1463