### PR TITLE
JENKINS-45836 Allow Contributors to select repositories to build

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource.java
@@ -1156,7 +1156,7 @@ public class BitbucketSCMSource extends SCMSource {
                 BitbucketApi bitbucket = BitbucketApiFactory.newInstance(serverUrl, credentials, repoOwner, null);
                 BitbucketTeam team = bitbucket.getTeam();
                 List<? extends BitbucketRepository> repositories =
-                        bitbucket.getRepositories(team != null ? null : UserRoleInRepository.OWNER);
+                        bitbucket.getRepositories(team != null ? null : UserRoleInRepository.CONTRIBUTOR);
                 if (repositories.isEmpty()) {
                     throw new FillErrorResponse(Messages.BitbucketSCMSource_NoMatchingOwner(repoOwner), true);
                 }


### PR DESCRIPTION
Previously, if you were not on a team for a repository you had to be the owner to select it as the build source in Jenkins. I can't compile this to test, but this should let you select repositories you're also a contributor on instead.