### PR TITLE
[JENKINS-47124] - change getBranches method to use Bitbucket API 2.0

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/BitbucketCloudApiClient.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/BitbucketCloudApiClient.java
@@ -317,12 +317,12 @@ public class BitbucketCloudApiClient implements BitbucketApi {
      */
     @NonNull
     @Override
-    public List<? extends BitbucketBranch> getBranches() throws IOException, InterruptedException {
+    public List<BitbucketBranch> getBranches() throws IOException, InterruptedException {
         String urlTemplate = V2_API_BASE_URL + this.owner + "/" + this.repositoryName + "/refs/branches?page=%d&pagelen=50";
         int pageNumber = 1;
         String url;
         String response = getRequest(url = String.format(urlTemplate, pageNumber));
-        List<BitbucketCloudBranchAPI2> branches = new ArrayList<>();
+        List<BitbucketBranch> branches = new ArrayList<>();
         BitbucketCloudBranchs page;
         try {
             page = parse(response, BitbucketCloudBranchs.class);

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/BitbucketCloudApiClient.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/BitbucketCloudApiClient.java
@@ -317,12 +317,12 @@ public class BitbucketCloudApiClient implements BitbucketApi {
      */
     @NonNull
     @Override
-    public List<BitbucketBranch> getBranches() throws IOException, InterruptedException {
+    public List<? extends BitbucketBranch> getBranches() throws IOException, InterruptedException {
         String urlTemplate = V2_API_BASE_URL + this.owner + "/" + this.repositoryName + "/refs/branches?page=%d&pagelen=50";
         int pageNumber = 1;
         String url;
         String response = getRequest(url = String.format(urlTemplate, pageNumber));
-        List<BitbucketBranch> branches = new ArrayList<>();
+        List<BitbucketCloudBranchAPI2> branches = new ArrayList<>();
         BitbucketCloudBranchs page;
         try {
             page = parse(response, BitbucketCloudBranchs.class);

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/BitbucketCloudApiClient.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/BitbucketCloudApiClient.java
@@ -24,6 +24,7 @@
 package com.cloudbees.jenkins.plugins.bitbucket.client;
 
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketApi;
+import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketBranch;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketBuildStatus;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketCommit;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketException;
@@ -34,7 +35,8 @@ import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketRepositoryType;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketRequestException;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketTeam;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketWebHook;
-import com.cloudbees.jenkins.plugins.bitbucket.client.branch.BitbucketCloudBranch;
+import com.cloudbees.jenkins.plugins.bitbucket.client.branch.BitbucketCloudBranchAPI2;
+import com.cloudbees.jenkins.plugins.bitbucket.client.branch.BitbucketCloudBranchs;
 import com.cloudbees.jenkins.plugins.bitbucket.client.branch.BitbucketCloudCommit;
 import com.cloudbees.jenkins.plugins.bitbucket.client.pullrequest.BitbucketPullRequestCommit;
 import com.cloudbees.jenkins.plugins.bitbucket.client.pullrequest.BitbucketPullRequestCommits;
@@ -52,17 +54,6 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.ProxyConfiguration;
 import hudson.Util;
 import hudson.util.Secret;
-import java.io.ByteArrayOutputStream;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.UnsupportedEncodingException;
-import java.net.InetSocketAddress;
-import java.net.Proxy;
-import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.logging.Logger;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
 import org.apache.commons.httpclient.HostConfiguration;
@@ -83,6 +74,18 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
 import org.codehaus.jackson.JsonNode;
 import org.codehaus.jackson.map.ObjectMapper;
+
+import java.io.ByteArrayOutputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UnsupportedEncodingException;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Logger;
 
 public class BitbucketCloudApiClient implements BitbucketApi {
     private static final Logger LOGGER = Logger.getLogger(BitbucketCloudApiClient.class.getName());
@@ -314,14 +317,33 @@ public class BitbucketCloudApiClient implements BitbucketApi {
      */
     @NonNull
     @Override
-    public List<BitbucketCloudBranch> getBranches() throws IOException, InterruptedException {
-        String url = V1_API_BASE_URL + this.owner + "/" + this.repositoryName + "/branches";
-        String response = getRequest(url);
+    public List<? extends BitbucketBranch> getBranches() throws IOException, InterruptedException {
+        String urlTemplate = V2_API_BASE_URL + this.owner + "/" + this.repositoryName + "/refs/branches?page=%d&pagelen=50";
+        int pageNumber = 1;
+        String url;
+        String response = getRequest(url = String.format(urlTemplate, pageNumber));
+        List<BitbucketCloudBranchAPI2> branches = new ArrayList<>();
+        BitbucketCloudBranchs page;
         try {
-            return parseBranchesJson(response);
+            page = parse(response, BitbucketCloudBranchs.class);
         } catch (IOException e) {
             throw new IOException("I/O error when parsing response from URL: " + url, e);
         }
+        branches.addAll(page.getValues());
+        while (page.getNext() != null) {
+            if (Thread.interrupted()) {
+                throw new InterruptedException();
+            }
+            pageNumber++;
+            response = getRequest(url = String.format(urlTemplate, pageNumber));
+            try {
+                page = parse(response, BitbucketCloudBranchs.class);
+            } catch (IOException e) {
+                throw new IOException("I/O error when parsing response from URL: " + url, e);
+            }
+            branches.addAll(page.getValues());
+        }
+        return branches;
     }
 
     /**
@@ -727,17 +749,13 @@ public class BitbucketCloudApiClient implements BitbucketApi {
         return postRequest(httppost);
     }
 
-    private List<BitbucketCloudBranch> parseBranchesJson(String response) throws IOException {
-        List<BitbucketCloudBranch> branches = new ArrayList<BitbucketCloudBranch>();
+    private List<BitbucketCloudBranchAPI2> parseBranchesJson(String response) throws IOException {
+        List<BitbucketCloudBranchAPI2> branches = new ArrayList<>();
         ObjectMapper mapper = new ObjectMapper();
         JSONObject obj = JSONObject.fromObject(response);
-        for (Object name : obj.keySet()) {
-            BitbucketCloudBranch b = mapper.readValue(obj.getJSONObject((String) name).toString(), BitbucketCloudBranch.class);
-            if (b.getName() == null) {
-                // The branch name is null sometimes in API JSON response (unknown reason)
-                b.setName((String) name);
-            }
-            branches.add(b);
+        for (Object branch : obj.getJSONArray("values")) {
+                BitbucketCloudBranchAPI2 b = mapper.readValue(branch.toString(), BitbucketCloudBranchAPI2.class);
+                branches.add(b);
         }
         return branches;
     }

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/branch/BitbucketCloudBranchAPI2.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/branch/BitbucketCloudBranchAPI2.java
@@ -1,0 +1,70 @@
+package com.cloudbees.jenkins.plugins.bitbucket.client.branch;
+
+import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketBranch;
+import org.codehaus.jackson.annotate.JsonIgnoreProperties;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class BitbucketCloudBranchAPI2 implements BitbucketBranch {
+
+	private String name;
+
+	private Target target;
+
+	@Override
+	public String getRawNode() {
+		return this.target.getHash();
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	@Override
+	public long getDateMillis() {
+		final SimpleDateFormat dateParser = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX");
+		try {
+			return dateParser.parse(this.getTarget().getDate()).getTime();
+		} catch (ParseException e) {
+			return 0;
+		}
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public Target getTarget() {
+		return target;
+	}
+
+	public void setTarget(Target target) {
+		this.target = target;
+	}
+
+	@JsonIgnoreProperties(ignoreUnknown = true)
+	public static class Target {
+
+		private String hash;
+		private String date;
+
+		public String getHash() {
+			return hash;
+		}
+
+		public void setHash(String hash) {
+			this.hash = hash;
+		}
+
+		public String getDate() {
+			return date;
+		}
+
+		public void setDate(String date) {
+			this.date = date;
+		}
+	}
+
+}

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/branch/BitbucketCloudBranchs.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/branch/BitbucketCloudBranchs.java
@@ -1,0 +1,29 @@
+package com.cloudbees.jenkins.plugins.bitbucket.client.branch;
+
+import org.codehaus.jackson.annotate.JsonIgnoreProperties;
+
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class BitbucketCloudBranchs {
+
+	private List<BitbucketCloudBranchAPI2> values;
+
+	private String next;
+
+	public String getNext() {
+		return next;
+	}
+
+	public void setNext(String next) {
+		this.next = next;
+	}
+
+	public List<BitbucketCloudBranchAPI2> getValues() {
+		return values;
+	}
+
+	public void setValues(List<BitbucketCloudBranchAPI2> values) {
+		this.values = values;
+	}
+}

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketClientMockUtils.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketClientMockUtils.java
@@ -65,7 +65,7 @@ public class BitbucketClientMockUtils {
         branches.add(getBranch("branch1", "52fc8e220d77ec400f7fc96a91d2fd0bb1bc553a"));
         branches.add(getBranch("branch2", "707c59ce8292c927dddb6807fcf9c3c5e7c9b00f"));
         // add branches
-        when((List<BitbucketBranch>) ((Object) bitbucket.getBranches())).thenReturn(branches);
+        when(bitbucket.getBranches()).thenReturn(branches);
         if (BitbucketRepositoryType.MERCURIAL == type) {
             withMockMercurialRepos(bitbucket);
         } else {
@@ -172,10 +172,11 @@ public class BitbucketClientMockUtils {
         when(bitbucket.getRepository()).thenReturn(repo);
     }
 
-    private static BitbucketCloudBranch getBranch(String name, String hash) {
-        BitbucketCloudBranch b = new BitbucketCloudBranch();
+    private static BitbucketCloudBranchAPI2 getBranch(String name, String hash) {
+        BitbucketCloudBranchAPI2 b = new BitbucketCloudBranchAPI2();
         b.setName(name);
-        b.setRawNode(hash);
+        b.setTarget(new BitbucketCloudBranchAPI2.Target());
+        b.getTarget().setHash(hash);
         return b;
     }
 

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketClientMockUtils.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketClientMockUtils.java
@@ -65,7 +65,7 @@ public class BitbucketClientMockUtils {
         branches.add(getBranch("branch1", "52fc8e220d77ec400f7fc96a91d2fd0bb1bc553a"));
         branches.add(getBranch("branch2", "707c59ce8292c927dddb6807fcf9c3c5e7c9b00f"));
         // add branches
-        when(bitbucket.getBranches()).thenReturn(branches);
+        when((List<BitbucketBranch>) ((Object) bitbucket.getBranches())).thenReturn(branches);
         if (BitbucketRepositoryType.MERCURIAL == type) {
             withMockMercurialRepos(bitbucket);
         } else {
@@ -172,11 +172,10 @@ public class BitbucketClientMockUtils {
         when(bitbucket.getRepository()).thenReturn(repo);
     }
 
-    private static BitbucketCloudBranchAPI2 getBranch(String name, String hash) {
-        BitbucketCloudBranchAPI2 b = new BitbucketCloudBranchAPI2();
+    private static BitbucketCloudBranch getBranch(String name, String hash) {
+        BitbucketCloudBranch b = new BitbucketCloudBranch();
         b.setName(name);
-        b.setTarget(new BitbucketCloudBranchAPI2.Target());
-        b.getTarget().setHash(hash);
+        b.setRawNode(hash);
         return b;
     }
 

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketClientMockUtils.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketClientMockUtils.java
@@ -65,7 +65,7 @@ public class BitbucketClientMockUtils {
         branches.add(getBranch("branch1", "52fc8e220d77ec400f7fc96a91d2fd0bb1bc553a"));
         branches.add(getBranch("branch2", "707c59ce8292c927dddb6807fcf9c3c5e7c9b00f"));
         // add branches
-        when(bitbucket.getBranches()).thenReturn(branches);
+        when((List<BitbucketBranch>) ((Object) bitbucket.getBranches())).thenReturn(branches);
         if (BitbucketRepositoryType.MERCURIAL == type) {
             withMockMercurialRepos(bitbucket);
         } else {

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketClientMockUtils.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketClientMockUtils.java
@@ -24,11 +24,13 @@
 package com.cloudbees.jenkins.plugins.bitbucket;
 
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketApi;
+import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketBranch;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketHref;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketRepositoryProtocol;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketRepositoryType;
 import com.cloudbees.jenkins.plugins.bitbucket.client.BitbucketCloudApiClient;
 import com.cloudbees.jenkins.plugins.bitbucket.client.branch.BitbucketCloudBranch;
+import com.cloudbees.jenkins.plugins.bitbucket.client.branch.BitbucketCloudBranchAPI2;
 import com.cloudbees.jenkins.plugins.bitbucket.client.branch.BitbucketCloudCommit;
 import com.cloudbees.jenkins.plugins.bitbucket.client.pullrequest.BitbucketPullRequestValue;
 import com.cloudbees.jenkins.plugins.bitbucket.client.pullrequest.BitbucketPullRequestValueDestination;
@@ -38,13 +40,14 @@ import com.cloudbees.jenkins.plugins.bitbucket.client.repository.BitbucketCloudT
 import com.cloudbees.jenkins.plugins.bitbucket.client.repository.BitbucketRepositoryHook;
 import com.cloudbees.jenkins.plugins.bitbucket.hooks.BitbucketSCMSourcePushHookReceiver;
 import hudson.model.TaskListener;
+import jenkins.model.Jenkins;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
-import jenkins.model.Jenkins;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
@@ -58,7 +61,7 @@ public class BitbucketClientMockUtils {
         BitbucketCloudApiClient bitbucket = mock(BitbucketCloudApiClient.class);
         when(bitbucket.getRepositoryUri(any(BitbucketRepositoryType.class), any(BitbucketRepositoryProtocol.class), any(Integer.class), anyString(), anyString())).thenCallRealMethod();
         // mock branch list
-        List<BitbucketCloudBranch> branches = new ArrayList<BitbucketCloudBranch>();
+        List<BitbucketBranch> branches = new ArrayList<>();
         branches.add(getBranch("branch1", "52fc8e220d77ec400f7fc96a91d2fd0bb1bc553a"));
         branches.add(getBranch("branch2", "707c59ce8292c927dddb6807fcf9c3c5e7c9b00f"));
         // add branches


### PR DESCRIPTION
Fix bug which doesn't allow get more than ~100 branches from Bitbucket repository, because 1.0 Bitbucket API doesn't support pagination which added in 2.0 Bitbucket API