### PR TITLE
JENKINS-47978 Fix lightweight checkout not preserving Jenkinsfile path

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/BitbucketServerAPIClient.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/BitbucketServerAPIClient.java
@@ -716,7 +716,11 @@ public class BitbucketServerAPIClient implements BitbucketApi {
     @Override
     public InputStream getFileContent(BitbucketSCMFile file) throws IOException, InterruptedException {
         List<String> lines = new ArrayList<>();
-        String path = encodePath(file.getPath());
+        StringBuilder path = new StringBuilder();
+        for (String segment : StringUtils.split(file.getPath(), "/")) {
+            path.append(encodePath(segment));
+            path.append('/');
+        }
         String ref = Util.rawEncode(file.getRef());
         int start=0;
         String url = String.format(API_REPOSITORY_PATH+"/browse/%s?at=%s", owner, repositoryName, path, ref);


### PR DESCRIPTION
This is a fix for [JENKINS-47978](https://issues.jenkins-ci.org/browse/JENKINS-47978), where the slashes would not be preserved when trying to do a lightweight checkout.