### PR TITLE
JENKINS-48098 - Lazily evaluate timestamp for branch

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -162,6 +162,14 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>1.8</source>
+          <target>1.8</target>
+       </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.jenkins-ci.tools</groupId>
         <artifactId>maven-hpi-plugin</artifactId>
         <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -175,6 +175,14 @@
           <compatibleSinceVersion>2.0.0</compatibleSinceVersion>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>1.8</source>
+          <target>1.8</target>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -175,14 +175,6 @@
           <compatibleSinceVersion>2.0.0</compatibleSinceVersion>
         </configuration>
       </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
-        </configuration>
-      </plugin>
     </plugins>
   </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
 
   <properties>
     <jenkins.version>1.642.3</jenkins.version>
-    <java.level>7</java.level>
+    <java.level>8</java.level>
     <scm-api.version>2.2.0</scm-api.version>
     <git.version>3.5.0</git.version>
   </properties>
@@ -177,14 +177,6 @@
 
   <build>
     <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
-       </configuration>
-      </plugin>
       <plugin>
         <groupId>org.jenkins-ci.tools</groupId>
         <artifactId>maven-hpi-plugin</artifactId>

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/BitbucketServerAPIClient.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/BitbucketServerAPIClient.java
@@ -46,7 +46,6 @@ import com.cloudbees.jenkins.plugins.bitbucket.server.client.repository.Bitbucke
 import com.cloudbees.jenkins.plugins.bitbucket.server.client.repository.BitbucketServerRepository;
 import com.cloudbees.jenkins.plugins.bitbucket.server.client.repository.BitbucketServerWebhooks;
 import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
-import com.google.common.base.Supplier;
 
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -66,6 +65,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Supplier;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import jenkins.model.Jenkins;
@@ -384,19 +384,16 @@ public class BitbucketServerAPIClient implements BitbucketApi {
                 branches.addAll(page.getValues());
             }
             for (final BitbucketServerBranch branch: branches) {
-                branch.setTimestamp(new Supplier<Long>() {
-                    @Override
-                    public Long get() {
-                        try {
-                            BitbucketCommit commit = BitbucketServerAPIClient.this.resolveCommit(branch.getRawNode());
-                            if (commit != null) {
-                                return commit.getDateMillis();
-                            }
-                        } catch (IOException e) {
-                            LOGGER.log(Level.FINE, "Error resolving commit: {0}", e);
+                branch.setTimestamp(() -> {
+                    try {
+                        BitbucketCommit commit = BitbucketServerAPIClient.this.resolveCommit(branch.getRawNode());
+                        if (commit != null) {
+                            return commit.getDateMillis();
                         }
-                        return null;
+                    } catch (IOException e) {
+                        LOGGER.log(Level.FINE, "Error resolving commit: {0}", e);
                     }
+                    return null;
                 });
 
             }

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/BitbucketServerAPIClient.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/BitbucketServerAPIClient.java
@@ -100,8 +100,8 @@ public class BitbucketServerAPIClient implements BitbucketApi {
     private static final String API_REPOSITORIES_PATH = API_BASE_PATH + "/projects/%s/repos?start=%s";
     private static final String API_REPOSITORY_PATH = API_BASE_PATH + "/projects/%s/repos/%s";
     private static final String API_DEFAULT_BRANCH_PATH = API_BASE_PATH + "/projects/%s/repos/%s/branches/default";
-    private static final String API_BRANCHES_PATH = API_BASE_PATH + "/projects/%s/repos/%s/branches?start=%s";
-    private static final String API_PULL_REQUESTS_PATH = API_BASE_PATH + "/projects/%s/repos/%s/pull-requests?start=%s";
+    private static final String API_BRANCHES_PATH = API_BASE_PATH + "/projects/%s/repos/%s/branches?start=%s&limit=%s";
+    private static final String API_PULL_REQUESTS_PATH = API_BASE_PATH + "/projects/%s/repos/%s/pull-requests?start=%s&limit=%s";
     private static final String API_PULL_REQUEST_PATH = API_BASE_PATH + "/projects/%s/repos/%s/pull-requests/%s";
     private static final String API_BROWSE_PATH = API_REPOSITORY_PATH + "/browse/%s?at=%s";
     private static final String API_COMMITS_PATH = API_REPOSITORY_PATH + "/commits/%s";
@@ -246,7 +246,7 @@ public class BitbucketServerAPIClient implements BitbucketApi {
     @NonNull
     @Override
     public List<BitbucketServerPullRequest> getPullRequests() throws IOException, InterruptedException {
-        String url = String.format(API_PULL_REQUESTS_PATH, getUserCentricOwner(), repositoryName, 0);
+        String url = String.format(API_PULL_REQUESTS_PATH, getUserCentricOwner(), repositoryName, 0, 200);
 
         try {
             List<BitbucketServerPullRequest> pullRequests = new ArrayList<>();
@@ -259,8 +259,9 @@ public class BitbucketServerAPIClient implements BitbucketApi {
                     throw new InterruptedException();
                 }
                 pageNumber++;
+                // Limit can be set by admin to lower value, so use limit provided by page
                 url = String.format(API_PULL_REQUESTS_PATH, getUserCentricOwner(), repositoryName,
-                        page.getNextPageStart());
+                        page.getNextPageStart(), page.getLimit());
                 response = getRequest(url);
                 page = JsonParser.toJava(response, BitbucketServerPullRequests.class);
                 pullRequests.addAll(page.getValues());
@@ -363,7 +364,7 @@ public class BitbucketServerAPIClient implements BitbucketApi {
     @Override
     @NonNull
     public List<BitbucketServerBranch> getBranches() throws IOException, InterruptedException {
-        String url = String.format(API_BRANCHES_PATH, getUserCentricOwner(), repositoryName, 0);
+        String url = String.format(API_BRANCHES_PATH, getUserCentricOwner(), repositoryName, 0, 200);
 
         try {
             List<BitbucketServerBranch> branches = new ArrayList<>();
@@ -376,7 +377,8 @@ public class BitbucketServerAPIClient implements BitbucketApi {
                     throw new InterruptedException();
                 }
                 pageNumber++;
-                url = String.format(API_BRANCHES_PATH, getUserCentricOwner(), repositoryName, page.getNextPageStart());
+                // Limit can be set by admin to lower value, so use limit provided by page
+                url = String.format(API_BRANCHES_PATH, getUserCentricOwner(), repositoryName, page.getNextPageStart(), page.getLimit());
                 response = getRequest(url);
                 page = JsonParser.toJava(response, BitbucketServerBranches.class);
                 branches.addAll(page.getValues());

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/BitbucketServerAPIClient.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/BitbucketServerAPIClient.java
@@ -380,10 +380,18 @@ public class BitbucketServerAPIClient implements BitbucketApi {
                 branches.addAll(page.getValues());
             }
             for (BitbucketServerBranch branch: branches) {
-                BitbucketCommit commit = resolveCommit(branch.getRawNode());
-                if (commit != null) {
-                    branch.setTimestamp(commit.getDateMillis());
-                }
+                branch.setTimestamp(() -> {
+                    try {
+                        BitbucketCommit commit = resolveCommit(branch.getRawNode());
+                        if (commit != null) {
+                            return commit.getDateMillis();
+                        }
+                    } catch (IOException e) {
+                        LOGGER.log(Level.FINE, "Error resolving commit: {0}",e);
+                    }
+                    return null;
+                });
+
             }
             return branches;
         } catch (IOException e) {

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/BitbucketServerAPIClient.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/BitbucketServerAPIClient.java
@@ -381,7 +381,7 @@ public class BitbucketServerAPIClient implements BitbucketApi {
                 page = JsonParser.toJava(response, BitbucketServerBranches.class);
                 branches.addAll(page.getValues());
             }
-            for (BitbucketServerBranch branch: branches) {
+            for (final BitbucketServerBranch branch: branches) {
                 branch.setTimestamp(new Supplier<Long>() {
                     @Override
                     public Long get() {

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/branch/BitbucketServerBranch.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/branch/BitbucketServerBranch.java
@@ -23,8 +23,10 @@
  */
 package com.cloudbees.jenkins.plugins.bitbucket.server.client.branch;
 
+import java.util.function.Supplier;
+
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketBranch;
-import com.google.common.base.Supplier;
+
 
 public class BitbucketServerBranch implements BitbucketBranch {
 

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/branch/BitbucketServerBranch.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/branch/BitbucketServerBranch.java
@@ -24,6 +24,7 @@
 package com.cloudbees.jenkins.plugins.bitbucket.server.client.branch;
 
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketBranch;
+import com.google.common.base.Supplier;
 
 public class BitbucketServerBranch implements BitbucketBranch {
 
@@ -31,7 +32,7 @@ public class BitbucketServerBranch implements BitbucketBranch {
 
     private String latestCommit;
 
-    private long timestamp;
+    private Supplier<Long> timestamp;
 
     public BitbucketServerBranch() {
     }
@@ -52,12 +53,12 @@ public class BitbucketServerBranch implements BitbucketBranch {
     }
 
     public long getTimestamp() {
-        return timestamp;
+        return timestamp.get();
     }
 
     @Override
     public long getDateMillis() {
-        return timestamp;
+        return timestamp.get();
     }
 
     public void setDisplayId(String displayId) {
@@ -76,7 +77,7 @@ public class BitbucketServerBranch implements BitbucketBranch {
         this.latestCommit = latestCommit;
     }
 
-    public void setTimestamp(long timestamp) {
+    public void setTimestamp(Supplier<Long> timestamp) {
         this.timestamp = timestamp;
     }
 

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/branch/BitbucketServerBranches.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/branch/BitbucketServerBranches.java
@@ -33,6 +33,8 @@ public class BitbucketServerBranches {
 
     private Integer size;
 
+    private Integer limit;
+
     @JsonProperty("isLastPage")
     private Boolean lastPage;
 
@@ -52,6 +54,14 @@ public class BitbucketServerBranches {
 
     public void setSize(Integer size) {
         this.size = size;
+    }
+
+    public Integer getLimit() {
+        return limit;
+    }
+
+    public void setLimit(Integer limit) {
+        this.limit = limit;
     }
 
     public Boolean isLastPage() {

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/pullrequest/BitbucketServerPullRequests.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/pullrequest/BitbucketServerPullRequests.java
@@ -33,6 +33,8 @@ public class BitbucketServerPullRequests {
 
     private Integer size;
 
+    private Integer limit;
+
     @JsonProperty("isLastPage")
     private Boolean lastPage;
 
@@ -52,6 +54,14 @@ public class BitbucketServerPullRequests {
 
     public void setSize(Integer size) {
         this.size = size;
+    }
+
+    public Integer getLimit() {
+        return limit;
+    }
+
+    public void setLimit(Integer limit) {
+        this.limit = limit;
     }
 
     public boolean isLastPage() {


### PR DESCRIPTION
When you have 1000s of branches, it does not make sense to evalute last commit date each time a build is done.
Changed to use [Supplier ](https://google.github.io/guava/releases/19.0/api/docs/com/google/common/base/Suppliers.html)and lazy initialize the timestamp when getTimestamp is called.