### PR TITLE
Fixed spelling error in job configuration branch source error message

### DIFF
--- a/src/main/resources/com/cloudbees/jenkins/plugins/bitbucket/Messages.properties
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/bitbucket/Messages.properties
@@ -5,7 +5,7 @@ BitbucketSCMSource.ChangeRequestSCMHeadCategory.DisplayName=Pull requests
 BitbucketSCMSource.NoMatchingOwner=Could not find: {0}
 BitbucketSCMSource.UnauthorizedAnonymous=Determination as to whether {0} may or may not exist is not permitted \
   without suitable credentials.
-BitbucketSCMSource.UnauthorizedOwner=The selected credentials do not have permission to determine whether {0} does or\
+BitbucketSCMSource.UnauthorizedOwner=The selected credentials do not have permission to determine whether {0} does or \
    does not exist.
 BitbucketSCMNavigator.DisplayName=Bitbucket Team/Project
 BitbucketSCMNavigator.Description=Scans a Bitbucket Cloud Team (or Bitbucket Server Project) for all repositories matching some defined markers.


### PR DESCRIPTION
In current HEAD, there is a spelling error in an error message when configuring branch sources for a job through the user interface:
![bb_err](https://user-images.githubusercontent.com/687092/33123087-6a69e3de-cf79-11e7-887f-abff615bd123.png)

This code change address that to spell out the words "or" and "does" with a space in between:
![bb_fixed](https://user-images.githubusercontent.com/687092/33123092-73b8b87a-cf79-11e7-98f5-1ef2d97a722b.png)
