### PR TITLE
JENKINS-48279# Update start of page in directory listing

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/BitbucketServerAPIClient.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/BitbucketServerAPIClient.java
@@ -682,6 +682,7 @@ public class BitbucketServerAPIClient implements BitbucketApi {
         List<Map> values = (List<Map>) page.get("values");
         collectFileAndDirectories(parent, path, values, files);
         while (!(boolean)page.get("isLastPage")){
+            start += (int) content.get("size");
             response = getRequest(url + String.format("&start=%s&limit=%s", start, 500));
             content = JsonParser.mapper.readValue(response, new TypeReference<Map<String,Object>>(){});
             page = (Map) content.get("children");


### PR DESCRIPTION
Increment page start parameter during recursive call to fetch directory listing page. This can cause the loop to never break for repo directory with number of files > 500.

See [https://issues.jenkins-ci.org/browse/JENKINS-48279](JENKINS-48279).

cc: @casz @stephenc 