### PR TITLE
JENKINS-48517 Use client certificates

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSourceBuilder.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSourceBuilder.java
@@ -50,6 +50,11 @@ public class BitbucketSCMSourceBuilder extends SCMSourceBuilder<BitbucketSCMSour
     @CheckForNull
     private final String credentialsId;
     /**
+     * The certificate credentials id or {@code null}
+     */
+    @CheckForNull
+    private final String certificateCredentialsId;
+    /**
      * The repository owner.
      */
     @NonNull
@@ -65,12 +70,13 @@ public class BitbucketSCMSourceBuilder extends SCMSourceBuilder<BitbucketSCMSour
      * @param repoName      the project name.
      */
     public BitbucketSCMSourceBuilder(@CheckForNull String id, @NonNull String serverUrl,
-                                     @CheckForNull String credentialsId, @NonNull String repoOwner,
-                                     @NonNull String repoName) {
+                                     @CheckForNull String credentialsId, @CheckForNull String certificateCredentialsId,
+                                     @NonNull String repoOwner, @NonNull String repoName) {
         super(BitbucketSCMSource.class, repoName);
         this.id = id;
         this.serverUrl = BitbucketEndpointConfiguration.normalizeServerUrl(serverUrl);
         this.credentialsId = credentialsId;
+        this.certificateCredentialsId = certificateCredentialsId;
         this.repoOwner = repoOwner;
     }
 
@@ -105,6 +111,14 @@ public class BitbucketSCMSourceBuilder extends SCMSourceBuilder<BitbucketSCMSour
     }
 
     /**
+     * The certificate credentials that the {@link BitbucketSCMSource} will use.
+     *
+     * @return the certificate credentials that the {@link BitbucketSCMSource} will use.
+     */
+    @CheckForNull
+    public final String certificateCredentialsId() { return certificateCredentialsId; }
+
+    /**
      * The repository owner that the {@link BitbucketSCMSource} will be configured to use.
      *
      * @return the repository owner that the {@link BitbucketSCMSource} will be configured to use.
@@ -124,6 +138,7 @@ public class BitbucketSCMSourceBuilder extends SCMSourceBuilder<BitbucketSCMSour
         result.setId(id());
         result.setServerUrl(serverUrl());
         result.setCredentialsId(credentialsId());
+        result.setCertificateCredentialsId(certificateCredentialsId());
         result.setTraits(traits());
         return result;
     }

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/SCMHeadWithOwnerAndRepo.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/SCMHeadWithOwnerAndRepo.java
@@ -110,6 +110,7 @@ public class SCMHeadWithOwnerAndRepo extends SCMHead {
             final BitbucketApi bitbucket = BitbucketApiFactory.newInstance(
                     source.getServerUrl(),
                     source.credentials(),
+                    source.certificateCredentials(),
                     source.getRepoOwner(),
                     source.getRepository()
             );

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/BitbucketApiFactory.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/BitbucketApiFactory.java
@@ -1,5 +1,6 @@
 package com.cloudbees.jenkins.plugins.bitbucket.api;
 
+import com.cloudbees.plugins.credentials.common.StandardCertificateCredentials;
 import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -29,6 +30,7 @@ public abstract class BitbucketApiFactory implements ExtensionPoint {
      *
      * @param serverUrl   the server URL.
      * @param credentials the (optional) credentials.
+     * @param certificateCredentials the (optional) certificate.
      * @param owner       the owner name.
      * @param repository  the (optional) repository name.
      * @return the {@link BitbucketApi}.
@@ -36,6 +38,7 @@ public abstract class BitbucketApiFactory implements ExtensionPoint {
     @NonNull
     protected abstract BitbucketApi create(@Nullable String serverUrl,
                                            @Nullable StandardUsernamePasswordCredentials credentials,
+                                           @Nullable StandardCertificateCredentials certificateCredentials,
                                            @NonNull String owner,
                                            @CheckForNull String repository);
 
@@ -45,6 +48,7 @@ public abstract class BitbucketApiFactory implements ExtensionPoint {
      *
      * @param serverUrl   the server URL.
      * @param credentials the (optional) credentials.
+     * @param certificateCredentials the (optional) certificate.
      * @param owner       the owner name.
      * @param repository  the (optional) repository name.
      * @return the {@link BitbucketApi}.
@@ -53,13 +57,16 @@ public abstract class BitbucketApiFactory implements ExtensionPoint {
     @NonNull
     public static BitbucketApi newInstance(@Nullable String serverUrl,
                                            @Nullable StandardUsernamePasswordCredentials credentials,
+                                           @Nullable StandardCertificateCredentials certificateCredentials,
                                            @NonNull String owner,
                                            @CheckForNull String repository) {
         for (BitbucketApiFactory factory : ExtensionList.lookup(BitbucketApiFactory.class)) {
             if (factory.isMatch(serverUrl)) {
-                return factory.create(serverUrl, credentials, owner, repository);
+                return factory.create(serverUrl, credentials, certificateCredentials, owner, repository);
             }
         }
         throw new IllegalArgumentException("Unsupported Bitbucket server URL: " + serverUrl);
     }
+
+
 }

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/BitbucketCloudApiFactory.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/BitbucketCloudApiFactory.java
@@ -3,6 +3,7 @@ package com.cloudbees.jenkins.plugins.bitbucket.client;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketApi;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketApiFactory;
 import com.cloudbees.jenkins.plugins.bitbucket.endpoints.BitbucketCloudEndpoint;
+import com.cloudbees.plugins.credentials.common.StandardCertificateCredentials;
 import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -19,6 +20,7 @@ public class BitbucketCloudApiFactory extends BitbucketApiFactory {
     @NonNull
     @Override
     protected BitbucketApi create(@Nullable String serverUrl, @Nullable StandardUsernamePasswordCredentials credentials,
+                                  @Nullable StandardCertificateCredentials certCreds,
                                   @NonNull String owner, @CheckForNull String repository) {
         return new BitbucketCloudApiClient(owner, repository, credentials);
     }

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/endpoints/AbstractBitbucketEndpoint.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/endpoints/AbstractBitbucketEndpoint.java
@@ -25,6 +25,7 @@ package com.cloudbees.jenkins.plugins.bitbucket.endpoints;
 
 import com.cloudbees.plugins.credentials.CredentialsMatchers;
 import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.common.StandardCertificateCredentials;
 import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
 import com.cloudbees.plugins.credentials.domains.URIRequirementBuilder;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
@@ -53,6 +54,12 @@ public abstract class AbstractBitbucketEndpoint extends AbstractDescribableImpl<
     private final String credentialsId;
 
     /**
+     * The {@link StandardCertificateCredentials#getId()} of the certificate to use for auto-management of hooks.
+     */
+    @CheckForNull
+    private final String certificateCredentialsId;
+
+    /**
      * Constructor.
      *
      * @param manageHooks   {@code true} if and only if Jenkins is supposed to auto-manage hooks for this end-point.
@@ -62,6 +69,7 @@ public abstract class AbstractBitbucketEndpoint extends AbstractDescribableImpl<
     AbstractBitbucketEndpoint(boolean manageHooks, @CheckForNull String credentialsId) {
         this.manageHooks = manageHooks && StringUtils.isNotBlank(credentialsId);
         this.credentialsId = manageHooks ? credentialsId : null;
+        this.certificateCredentialsId = null;
     }
 
     /**
@@ -126,6 +134,23 @@ public abstract class AbstractBitbucketEndpoint extends AbstractDescribableImpl<
                         URIRequirementBuilder.fromUri(getServerUrl()).build()
                 ),
                 CredentialsMatchers.withId(credentialsId)
+        );
+    }
+
+    /**
+     * Looks up the {@link StandardCertificateCredentials} to use for auto-management of hooks.
+     *
+     * @return the credentials or {@code null}.
+     */
+    public StandardCertificateCredentials certificateCredentials() {
+        return StringUtils.isBlank(certificateCredentialsId) ? null : CredentialsMatchers.firstOrNull(
+                CredentialsProvider.lookupCredentials(
+                        StandardCertificateCredentials.class,
+                        Jenkins.getActiveInstance(),
+                        ACL.SYSTEM,
+                        URIRequirementBuilder.fromUri(getServerUrl()).build()
+                ),
+                CredentialsMatchers.withId(certificateCredentialsId)
         );
     }
 

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/endpoints/AbstractBitbucketEndpointDescriptor.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/endpoints/AbstractBitbucketEndpointDescriptor.java
@@ -23,7 +23,10 @@
  */
 package com.cloudbees.jenkins.plugins.bitbucket.endpoints;
 
+import com.cloudbees.plugins.credentials.Credentials;
+import com.cloudbees.plugins.credentials.CredentialsMatcher;
 import com.cloudbees.plugins.credentials.CredentialsMatchers;
+import com.cloudbees.plugins.credentials.common.StandardCertificateCredentials;
 import com.cloudbees.plugins.credentials.common.StandardListBoxModel;
 import com.cloudbees.plugins.credentials.common.StandardUsernameCredentials;
 import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
@@ -60,6 +63,22 @@ public abstract class AbstractBitbucketEndpointDescriptor extends Descriptor<Abs
                 StandardUsernameCredentials.class,
                 URIRequirementBuilder.fromUri(serverUrl).build(),
                 CredentialsMatchers.instanceOf(StandardUsernamePasswordCredentials.class)
+        );
+        return result;
+    }
+
+    @Restricted(NoExternalUse.class) //stapler
+    @SuppressWarnings("unused")
+    public ListBoxModel doFillCertificateCredentialsIdItems(@QueryParameter String serverUrl) {
+        Jenkins jenkins = Jenkins.getActiveInstance();
+        jenkins.checkPermission(Jenkins.ADMINISTER);
+        StandardListBoxModel result = new StandardListBoxModel();
+        result.includeMatchingAs(
+                ACL.SYSTEM,
+                jenkins,
+                StandardCertificateCredentials.class,
+                URIRequirementBuilder.fromUri(serverUrl).build(),
+                CredentialsMatchers.instanceOf(StandardCertificateCredentials.class)
         );
         return result;
     }

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/WebhookAutoRegisterListener.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/WebhookAutoRegisterListener.java
@@ -240,6 +240,7 @@ public class WebhookAutoRegisterListener extends ItemListener {
                         : BitbucketApiFactory.newInstance(
                                 endpoint.getServerUrl(),
                                 endpoint.credentials(),
+                                endpoint.certificateCredentials(),
                                 source.getRepoOwner(),
                                 source.getRepository()
                         );

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/BitbucketServerApiFactory.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/BitbucketServerApiFactory.java
@@ -3,6 +3,7 @@ package com.cloudbees.jenkins.plugins.bitbucket.server.client;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketApi;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketApiFactory;
 import com.cloudbees.jenkins.plugins.bitbucket.endpoints.BitbucketCloudEndpoint;
+import com.cloudbees.plugins.credentials.common.StandardCertificateCredentials;
 import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -20,10 +21,11 @@ public class BitbucketServerApiFactory extends BitbucketApiFactory {
     @NonNull
     @Override
     protected BitbucketApi create(@Nullable String serverUrl, @Nullable StandardUsernamePasswordCredentials credentials,
-                                  @NonNull String owner, @CheckForNull String repository) {
+                                  @CheckForNull StandardCertificateCredentials certCreds, @NonNull String owner,
+                                  @CheckForNull String repository) {
         if(StringUtils.isBlank(serverUrl)){
             throw new IllegalArgumentException("serverUrl is required");
         }
-        return new BitbucketServerAPIClient(serverUrl, owner, repository, credentials, false);
+        return new BitbucketServerAPIClient(serverUrl, owner, repository, credentials, certCreds, false);
     }
 }

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/ClientCertSSLInitializationError.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/ClientCertSSLInitializationError.java
@@ -1,0 +1,12 @@
+package com.cloudbees.jenkins.plugins.bitbucket.server.client;
+
+public class ClientCertSSLInitializationError extends Error {
+
+    public ClientCertSSLInitializationError() {
+        super();
+    }
+
+    public ClientCertSSLInitializationError(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/ClientCertSSLProtocolSocketFactory.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/ClientCertSSLProtocolSocketFactory.java
@@ -1,0 +1,99 @@
+package com.cloudbees.jenkins.plugins.bitbucket.server.client;
+
+import org.apache.commons.httpclient.protocol.ProtocolSocketFactory;
+import org.apache.commons.httpclient.params.HttpConnectionParams;
+
+import javax.net.SocketFactory;
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.net.SocketAddress;
+import java.security.*;
+
+/*
+ * Largely based on http://svn.apache.org/viewvc/httpcomponents/oac.hc3x/trunk/src/contrib/org/apache/commons/httpclient/contrib/ssl/AuthSSLProtocolSocketFactory.java?view=markup
+ */
+public class ClientCertSSLProtocolSocketFactory implements ProtocolSocketFactory {
+
+    private SSLContext sslContext;
+    private KeyStore keyStore;
+    private String keyStorePassword;
+
+    public ClientCertSSLProtocolSocketFactory(KeyStore keyStore, String keyStorePassword) {
+        super();
+        this.keyStore = keyStore;
+        this.keyStorePassword = keyStorePassword;
+    }
+
+    private SSLContext createSSLContext() {
+        try {
+            keyStore.load(null, null); // "initialize" the keystore
+            KeyManagerFactory keyManagerFactory = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+            keyManagerFactory.init(this.keyStore, this.keyStorePassword != null ? this.keyStorePassword.toCharArray() : null);
+            KeyManager[] keyManagers = keyManagerFactory.getKeyManagers();
+            SSLContext context = SSLContext.getInstance("TLS");
+            context.init(keyManagers, null, null);
+            return context;
+        } catch (NoSuchAlgorithmException e) {
+            throw new ClientCertSSLInitializationError("Unsupported algorithm exception: " + e.getMessage());
+        } catch (KeyStoreException e) {
+            throw new ClientCertSSLInitializationError("KeystoreException: " + e.getMessage());
+        } catch (GeneralSecurityException e) {
+            throw new ClientCertSSLInitializationError(("General security error: " + e.getMessage()));
+        } catch (IOException e) {
+            throw new ClientCertSSLInitializationError("IOException: " + e.getMessage());
+        }
+    }
+
+    private SSLContext getSSLContext() {
+        if (this.sslContext == null) {
+            this.sslContext = createSSLContext();
+        }
+        return this.sslContext;
+    }
+
+    public Socket createSocket(
+            final String host,
+            final int port,
+            final InetAddress localAddress,
+            final int localPort,
+            final HttpConnectionParams params
+    )
+        throws IOException
+    {
+        if (params == null) {
+            throw new IllegalArgumentException("Parameters may not be null");
+        }
+        int timeout = params.getConnectionTimeout();
+        SocketFactory socketFactory = getSSLContext().getSocketFactory();
+        if (timeout == 0) {
+            return socketFactory.createSocket(host, port, localAddress, localPort);
+        } else {
+            Socket socket = socketFactory.createSocket();
+            SocketAddress localaddr = new InetSocketAddress(localAddress, localPort);
+            SocketAddress remoteaddr = new InetSocketAddress(host, port);
+            socket.bind(localaddr);
+            socket.connect(remoteaddr, timeout);
+            return socket;
+        }
+    }
+
+    public Socket createSocket(String host, int port, InetAddress clientHost, int clientPort)
+        throws IOException
+    {
+        return getSSLContext().getSocketFactory().createSocket(
+                host, port, clientHost, clientPort
+        );
+    }
+
+
+    public Socket createSocket(String host, int port) throws IOException
+    {
+        return getSSLContext().getSocketFactory().createSocket(host, port);
+    }
+
+}

--- a/src/main/resources/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMNavigator/config.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMNavigator/config.jelly
@@ -19,6 +19,11 @@
   <f:entry title="${%Owner}" field="repoOwner">
     <f:textbox/>
   </f:entry>
+  <f:advanced>
+    <f:entry title="${%Client Certificate}" field="certificateCredentialsId">
+      <c:select/>
+    </f:entry>
+  </f:advanced>
   <f:entry title="${%Behaviours}" field="traits">
     <scm:traits field="traits"/>
   </f:entry>

--- a/src/main/resources/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMNavigator/help-certificateCredentialsId.html
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMNavigator/help-certificateCredentialsId.html
@@ -1,0 +1,3 @@
+<div>
+    Client certificate used to scan branches (also the default certificate to use when checking out sources)
+</div>

--- a/src/main/resources/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource/config-detail.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource/config-detail.jelly
@@ -24,6 +24,11 @@
     <!-- TODO switch back to f:select once Jenkins core has JENKINS-42443 -->
     <f2:select/>
   </f:entry>
+  <f:advanced>
+    <f:entry title="${%Client Certificate}" field="certificateCredentialsId">
+      <c:select/>
+    </f:entry>
+  </f:advanced>
   <f:entry title="${%Behaviours}" field="traits">
     <scm:traits field="traits"/>
   </f:entry>

--- a/src/main/resources/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource/help-certificateCredentialsId.html
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource/help-certificateCredentialsId.html
@@ -1,0 +1,3 @@
+<div>
+    Client certificate used to scan branches (also the default certificate to use when checking out sources)
+</div>

--- a/src/main/resources/com/cloudbees/jenkins/plugins/bitbucket/endpoints/AbstractBitbucketEndpoint/config.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/bitbucket/endpoints/AbstractBitbucketEndpoint/config.jelly
@@ -6,5 +6,8 @@
     <f:entry field="credentialsId" title="${%Credentials}">
       <c:select context="${app}"/>
     </f:entry>
+    <f:entry title="${%Client Certificate}" field="certificateCredentialsId">
+      <c:select context="${app}"/>
+    </f:entry>
   </f:optionalBlock>
 </j:jelly>

--- a/src/main/resources/com/cloudbees/jenkins/plugins/bitbucket/endpoints/AbstractBitbucketEndpoint/help-certificateCredentialsId.html
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/bitbucket/endpoints/AbstractBitbucketEndpoint/help-certificateCredentialsId.html
@@ -1,0 +1,4 @@
+<div>
+    Select the client certificate to use for managing hooks. Both GLOBAL and SYSTEM scoped credentials are eligible as
+    the management of hooks is run in the context of Jenkins itself and not in the context of the individual items.
+</div>

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketMockApiFactory.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketMockApiFactory.java
@@ -2,6 +2,7 @@ package com.cloudbees.jenkins.plugins.bitbucket;
 
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketApi;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketApiFactory;
+import com.cloudbees.plugins.credentials.common.StandardCertificateCredentials;
 import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -42,7 +43,7 @@ public class BitbucketMockApiFactory extends BitbucketApiFactory {
     @NonNull
     @Override
     protected BitbucketApi create(@Nullable String serverUrl, @Nullable StandardUsernamePasswordCredentials credentials,
-                                  @NonNull String owner, @CheckForNull String repository) {
+                                  @Nullable StandardCertificateCredentials certificateCredentials, @NonNull String owner, @CheckForNull String repository) {
         return mocks.get(StringUtils.defaultString(serverUrl, NULL));
     }
 }

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/UriResolverTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/UriResolverTest.java
@@ -50,7 +50,7 @@ public class UriResolverTest {
                 "user1",
                 "repo1"
         ));
-        api = new BitbucketServerAPIClient("http://localhost:1234", "test", null, null, false);
+        api = new BitbucketServerAPIClient("http://localhost:1234", "test", null, null, null, false);
         assertEquals("http://localhost:1234/scm/user2/repo2.git", api.getRepositoryUri(
                 BitbucketRepositoryType.GIT,
                 BitbucketRepositoryProtocol.HTTP,
@@ -58,7 +58,7 @@ public class UriResolverTest {
                 "user2",
                 "repo2"
         ));
-        api = new BitbucketServerAPIClient("http://192.168.1.100:1234", "test", null, null, false);
+        api = new BitbucketServerAPIClient("http://192.168.1.100:1234", "test", null, null, null,false);
         assertEquals("http://192.168.1.100:1234/scm/user2/repo2.git", api.getRepositoryUri(
                 BitbucketRepositoryType.GIT,
                 BitbucketRepositoryProtocol.HTTP,
@@ -85,7 +85,7 @@ public class UriResolverTest {
                 "user1",
                 "repo1"
         ));
-        api = new BitbucketServerAPIClient("http://localhost:1234", "test", null, null, false);
+        api = new BitbucketServerAPIClient("http://localhost:1234", "test", null, null, null, false);
         assertEquals("ssh://git@localhost:7999/user2/repo2.git", api.getRepositoryUri(
                 BitbucketRepositoryType.GIT,
                 BitbucketRepositoryProtocol.SSH,
@@ -93,7 +93,7 @@ public class UriResolverTest {
                 "user2",
                 "repo2"
         ));
-        api = new BitbucketServerAPIClient("http://myserver", "test", null, null, false);
+        api = new BitbucketServerAPIClient("http://myserver", "test", null, null, null,false);
         assertEquals("ssh://git@myserver:7999/user2/repo2.git", api.getRepositoryUri(
                 BitbucketRepositoryType.GIT,
                 BitbucketRepositoryProtocol.SSH,
@@ -105,13 +105,13 @@ public class UriResolverTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void httpUriResolverIllegalStates() throws Exception {
-        new BitbucketServerAPIClient("http://localhost:1234", "test", null, null, false)
+        new BitbucketServerAPIClient("http://localhost:1234", "test", null, null, null,false)
                 .getRepositoryUri(BitbucketRepositoryType.MERCURIAL, BitbucketRepositoryProtocol.HTTP, null, "user1", "repo1");
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void sshUriResolverIllegalStates() throws Exception {
-        new BitbucketServerAPIClient("http://localhost:1234", "test", null, null, false)
+        new BitbucketServerAPIClient("http://localhost:1234", "test", null, null, null,false)
                 .getRepositoryUri(BitbucketRepositoryType.MERCURIAL, BitbucketRepositoryProtocol.SSH, null, "user1",
                         "repo1");
     }


### PR DESCRIPTION
This implements JENKINS-48517 to allow users to specify a client certificate to use when connecting to a Bitbucket Server instance.
 