### PR TITLE
don't notify bitbucket if BuildResult is NOT_BUILT

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketBuildStatusNotifications.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketBuildStatusNotifications.java
@@ -90,7 +90,7 @@ public class BitbucketBuildStatusNotifications {
         } else {
             status = new BitbucketBuildStatus(hash, "The tests have started...", "INPROGRESS", url, key, name);
         }
-        if (result != null && !Result.NOT_BUILT.equals(result)) {
+        if (!Result.NOT_BUILT.equals(result)) {
             new BitbucketChangesetCommentNotifier(bitbucket).buildStatus(status);
             listener.getLogger().println("[Bitbucket] Build result notified");
         }

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketBuildStatusNotifications.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketBuildStatusNotifications.java
@@ -90,8 +90,8 @@ public class BitbucketBuildStatusNotifications {
         } else {
             status = new BitbucketBuildStatus(hash, "The tests have started...", "INPROGRESS", url, key, name);
         }
-        new BitbucketChangesetCommentNotifier(bitbucket).buildStatus(status);
-        if (result != null) {
+        if (result != null && !Result.NOT_BUILT.equals(result)) {
+            new BitbucketChangesetCommentNotifier(bitbucket).buildStatus(status);
             listener.getLogger().println("[Bitbucket] Build result notified");
         }
     }


### PR DESCRIPTION
If my build result is NOT_BUILT then I don't want bitbucket to see it, especially since it gets reported as Failed.

I came across this because we need this because we only want to build pull requests and master branch but you can't configure branch source plugin to do this. In this case, we force all non-PR or master builds to not do anything except stop with a result of NOT_BUILT. Now that I;ve seen this code I think that NOT_BUILT really represents something that I don't want reported to bitbucket.

Also we shouldn't send a notification if result is null