### PR TITLE
Use AuthenticationTokens

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -191,6 +191,11 @@
       <version>2.11</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>authentication-tokens</artifactId>
+      <version>1.3</version>
+    </dependency>
   </dependencies>
 
   <repositories>

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMNavigator.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMNavigator.java
@@ -654,7 +654,7 @@ public class BitbucketSCMNavigator extends SCMNavigator {
 
 
         public ListBoxModel doFillCredentialsIdItems(@AncestorInPath SCMSourceOwner context,
-                                                     @QueryParameter String bitbucketServerUrl) {
+                                                     @QueryParameter String serverUrl) {
             StandardListBoxModel result = new StandardListBoxModel();
             result.withEmptySelection();
             result.includeMatchingAs(
@@ -663,8 +663,8 @@ public class BitbucketSCMNavigator extends SCMNavigator {
                             : ACL.SYSTEM,
                     context,
                     StandardCredentials.class,
-                    URIRequirementBuilder.fromUri(bitbucketServerUrl).build(),
-                    AuthenticationTokens.matcher(BitbucketAuthenticator.authenticationContext(bitbucketServerUrl))
+                    URIRequirementBuilder.fromUri(serverUrl).build(),
+                    AuthenticationTokens.matcher(BitbucketAuthenticator.authenticationContext(serverUrl))
             );
             return result;
         }

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMNavigator.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMNavigator.java
@@ -470,7 +470,7 @@ public class BitbucketSCMNavigator extends SCMNavigator {
             SourceFactory sourceFactory = new SourceFactory(request);
             WitnessImpl witness = new WitnessImpl(request, listener);
 
-            BitbucketAuthenticator authenticator = AuthenticationTokens.convert(BitbucketAuthenticator.class, credentials);
+            BitbucketAuthenticator authenticator = AuthenticationTokens.convert(BitbucketAuthenticator.authenticationContext(serverUrl), credentials);
 
             BitbucketApi bitbucket = BitbucketApiFactory.newInstance(serverUrl, authenticator, repoOwner, null);
             BitbucketTeam team = bitbucket.getTeam();
@@ -519,7 +519,7 @@ public class BitbucketSCMNavigator extends SCMNavigator {
                     CredentialsNameProvider.name(credentials));
         }
 
-        BitbucketAuthenticator authenticator = AuthenticationTokens.convert(BitbucketAuthenticator.class, credentials);
+        BitbucketAuthenticator authenticator = AuthenticationTokens.convert(BitbucketAuthenticator.authenticationContext(serverUrl), credentials);
 
         BitbucketApi bitbucket = BitbucketApiFactory.newInstance(serverUrl, authenticator, repoOwner, null);
         BitbucketTeam team = bitbucket.getTeam();
@@ -628,7 +628,7 @@ public class BitbucketSCMNavigator extends SCMNavigator {
                                 URIRequirementBuilder.fromUri(serverUrl).build()),
                         CredentialsMatchers.allOf(
                                 CredentialsMatchers.withId(value),
-                                AuthenticationTokens.matcher(BitbucketAuthenticator.class)
+                                AuthenticationTokens.matcher(BitbucketAuthenticator.authenticationContext(serverUrl))
                         )
                 ) != null) {
                        return FormValidation.warning("A certificate was selected. You will likely need to configure Checkout over SSH.");
@@ -664,7 +664,7 @@ public class BitbucketSCMNavigator extends SCMNavigator {
                     context,
                     StandardCredentials.class,
                     URIRequirementBuilder.fromUri(bitbucketServerUrl).build(),
-                    AuthenticationTokens.matcher(BitbucketAuthenticator.class)
+                    AuthenticationTokens.matcher(BitbucketAuthenticator.authenticationContext(bitbucketServerUrl))
             );
             return result;
         }
@@ -742,7 +742,7 @@ public class BitbucketSCMNavigator extends SCMNavigator {
                     context,
                     StandardCredentials.class,
                     URIRequirementBuilder.fromUri(bitbucketServerUrl).build(),
-                    AuthenticationTokens.matcher(BitbucketAuthenticator.class)
+                    AuthenticationTokens.matcher(BitbucketAuthenticator.authenticationContext(bitbucketServerUrl))
             );
             return result;
         }

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMNavigator.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMNavigator.java
@@ -40,7 +40,6 @@ import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.common.StandardCertificateCredentials;
 import com.cloudbees.plugins.credentials.common.StandardCredentials;
 import com.cloudbees.plugins.credentials.common.StandardListBoxModel;
-import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
 import com.cloudbees.plugins.credentials.domains.URIRequirementBuilder;
 import com.damnhandy.uri.template.UriTemplate;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
@@ -622,10 +621,16 @@ public class BitbucketSCMNavigator extends SCMNavigator {
         public FormValidation doCheckCredentialsId(@AncestorInPath SCMSourceOwner context, @QueryParameter String serverUrl, @QueryParameter String value) {
             if (!value.isEmpty()) {
                 if (CredentialsMatchers.firstOrNull(
-                        CredentialsProvider.lookupCredentials(StandardCertificateCredentials.class,
+                        CredentialsProvider.lookupCredentials(
+                                StandardCertificateCredentials.class,
                                 context,
                                 context instanceof Queue.Task ? Tasks.getDefaultAuthenticationOf((Queue.Task) context) : ACL.SYSTEM,
-                                URIRequirementBuilder.fromUri(serverUrl).build()), CredentialsMatchers.withId(value)) != null) {
+                                URIRequirementBuilder.fromUri(serverUrl).build()),
+                        CredentialsMatchers.allOf(
+                                CredentialsMatchers.withId(value),
+                                AuthenticationTokens.matcher(BitbucketAuthenticator.class)
+                        )
+                ) != null) {
                        return FormValidation.warning("A certificate was selected. You will likely need to configure Checkout over SSH.");
                 }
                 return FormValidation.ok();
@@ -659,9 +664,7 @@ public class BitbucketSCMNavigator extends SCMNavigator {
                     context,
                     StandardCredentials.class,
                     URIRequirementBuilder.fromUri(bitbucketServerUrl).build(),
-                    CredentialsMatchers.anyOf(
-                            CredentialsMatchers.instanceOf(StandardUsernamePasswordCredentials.class),
-                            CredentialsMatchers.instanceOf(StandardCertificateCredentials.class))
+                    AuthenticationTokens.matcher(BitbucketAuthenticator.class)
             );
             return result;
         }
@@ -739,9 +742,7 @@ public class BitbucketSCMNavigator extends SCMNavigator {
                     context,
                     StandardCredentials.class,
                     URIRequirementBuilder.fromUri(bitbucketServerUrl).build(),
-                    CredentialsMatchers.anyOf(
-                            CredentialsMatchers.instanceOf(StandardUsernamePasswordCredentials.class),
-                            CredentialsMatchers.instanceOf(StandardCertificateCredentials.class))
+                    AuthenticationTokens.matcher(BitbucketAuthenticator.class)
             );
             return result;
         }

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource.java
@@ -1173,17 +1173,17 @@ public class BitbucketSCMSource extends SCMSource {
 
         public FormValidation doCheckCredentialsId(@CheckForNull @AncestorInPath SCMSourceOwner context,
                                                    @QueryParameter String value,
-                                                   @QueryParameter String bitbucketServerUrl) {
+                                                   @QueryParameter String serverUrl) {
             if (!value.isEmpty()) {
                 if (CredentialsMatchers.firstOrNull(
                         CredentialsProvider.lookupCredentials(
                                 StandardCertificateCredentials.class,
                                 context,
                                 context instanceof Queue.Task ? Tasks.getDefaultAuthenticationOf((Queue.Task) context) : ACL.SYSTEM,
-                                URIRequirementBuilder.fromUri(bitbucketServerUrl).build()),
+                                URIRequirementBuilder.fromUri(serverUrl).build()),
                         CredentialsMatchers.allOf(
                                 CredentialsMatchers.withId(value),
-                                AuthenticationTokens.matcher(BitbucketAuthenticator.authenticationContext(bitbucketServerUrl))
+                                AuthenticationTokens.matcher(BitbucketAuthenticator.authenticationContext(serverUrl))
                         )
                 ) != null) {
                     return FormValidation.warning("A certificate was selected. You will likely need to configure Checkout over SSH.");

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource.java
@@ -46,7 +46,6 @@ import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.common.StandardCertificateCredentials;
 import com.cloudbees.plugins.credentials.common.StandardCredentials;
 import com.cloudbees.plugins.credentials.common.StandardListBoxModel;
-import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
 import com.cloudbees.plugins.credentials.domains.URIRequirementBuilder;
 import com.damnhandy.uri.template.UriTemplate;
 import com.fasterxml.jackson.databind.util.StdDateFormat;
@@ -1177,10 +1176,16 @@ public class BitbucketSCMSource extends SCMSource {
                                                    @QueryParameter String bitbucketServerUrl) {
             if (!value.isEmpty()) {
                 if (CredentialsMatchers.firstOrNull(
-                        CredentialsProvider.lookupCredentials(StandardCertificateCredentials.class,
+                        CredentialsProvider.lookupCredentials(
+                                StandardCertificateCredentials.class,
                                 context,
                                 context instanceof Queue.Task ? Tasks.getDefaultAuthenticationOf((Queue.Task) context) : ACL.SYSTEM,
-                                URIRequirementBuilder.fromUri(bitbucketServerUrl).build()), CredentialsMatchers.withId(value)) != null) {
+                                URIRequirementBuilder.fromUri(bitbucketServerUrl).build()),
+                        CredentialsMatchers.allOf(
+                                CredentialsMatchers.withId(value),
+                                AuthenticationTokens.matcher(BitbucketAuthenticator.class)
+                        )
+                ) != null) {
                     return FormValidation.warning("A certificate was selected. You will likely need to configure Checkout over SSH.");
                 }
                 return FormValidation.ok();
@@ -1229,9 +1234,7 @@ public class BitbucketSCMSource extends SCMSource {
                     context,
                     StandardCredentials.class,
                     URIRequirementBuilder.fromUri(serverUrl).build(),
-                    CredentialsMatchers.anyOf(
-                            CredentialsMatchers.instanceOf(StandardUsernamePasswordCredentials.class),
-                            CredentialsMatchers.instanceOf(StandardCertificateCredentials.class))
+                    AuthenticationTokens.matcher(BitbucketAuthenticator.class)
             );
             return result;
         }
@@ -1306,9 +1309,7 @@ public class BitbucketSCMSource extends SCMSource {
                     context,
                     StandardCredentials.class,
                     URIRequirementBuilder.fromUri(bitbucketServerUrl).build(),
-                    CredentialsMatchers.anyOf(
-                            CredentialsMatchers.instanceOf(StandardUsernamePasswordCredentials.class),
-                            CredentialsMatchers.instanceOf(StandardCertificateCredentials.class))
+                    AuthenticationTokens.matcher(BitbucketAuthenticator.class)
             );
             return result;
         }

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource.java
@@ -1037,7 +1037,7 @@ public class BitbucketSCMSource extends SCMSource {
 
     @CheckForNull
     BitbucketAuthenticator authenticator() {
-        return AuthenticationTokens.convert(BitbucketAuthenticator.class, credentials());
+        return AuthenticationTokens.convert(BitbucketAuthenticator.authenticationContext(getServerUrl()), credentials());
     }
 
     @NonNull
@@ -1183,7 +1183,7 @@ public class BitbucketSCMSource extends SCMSource {
                                 URIRequirementBuilder.fromUri(bitbucketServerUrl).build()),
                         CredentialsMatchers.allOf(
                                 CredentialsMatchers.withId(value),
-                                AuthenticationTokens.matcher(BitbucketAuthenticator.class)
+                                AuthenticationTokens.matcher(BitbucketAuthenticator.authenticationContext(bitbucketServerUrl))
                         )
                 ) != null) {
                     return FormValidation.warning("A certificate was selected. You will likely need to configure Checkout over SSH.");
@@ -1234,7 +1234,7 @@ public class BitbucketSCMSource extends SCMSource {
                     context,
                     StandardCredentials.class,
                     URIRequirementBuilder.fromUri(serverUrl).build(),
-                    AuthenticationTokens.matcher(BitbucketAuthenticator.class)
+                    AuthenticationTokens.matcher(BitbucketAuthenticator.authenticationContext(serverUrl))
             );
             return result;
         }
@@ -1257,7 +1257,7 @@ public class BitbucketSCMSource extends SCMSource {
                     StandardCredentials.class
             );
 
-            BitbucketAuthenticator authenticator = AuthenticationTokens.convert(BitbucketAuthenticator.class, credentials);
+            BitbucketAuthenticator authenticator = AuthenticationTokens.convert(BitbucketAuthenticator.authenticationContext(serverUrl), credentials);
 
             try {
                 BitbucketApi bitbucket = BitbucketApiFactory.newInstance(serverUrl, authenticator, repoOwner, null);
@@ -1309,7 +1309,7 @@ public class BitbucketSCMSource extends SCMSource {
                     context,
                     StandardCredentials.class,
                     URIRequirementBuilder.fromUri(bitbucketServerUrl).build(),
-                    AuthenticationTokens.matcher(BitbucketAuthenticator.class)
+                    AuthenticationTokens.matcher(BitbucketAuthenticator.authenticationContext(bitbucketServerUrl))
             );
             return result;
         }

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource.java
@@ -25,6 +25,7 @@ package com.cloudbees.jenkins.plugins.bitbucket;
 
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketApi;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketApiFactory;
+import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketAuthenticator;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketBranch;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketCommit;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketHref;
@@ -41,9 +42,10 @@ import com.cloudbees.jenkins.plugins.bitbucket.endpoints.BitbucketCloudEndpoint;
 import com.cloudbees.jenkins.plugins.bitbucket.endpoints.BitbucketEndpointConfiguration;
 import com.cloudbees.plugins.credentials.CredentialsMatchers;
 import com.cloudbees.plugins.credentials.CredentialsNameProvider;
+import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.common.StandardCertificateCredentials;
 import com.cloudbees.plugins.credentials.common.StandardCredentials;
 import com.cloudbees.plugins.credentials.common.StandardListBoxModel;
-import com.cloudbees.plugins.credentials.common.StandardUsernameCredentials;
 import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
 import com.cloudbees.plugins.credentials.domains.URIRequirementBuilder;
 import com.damnhandy.uri.template.UriTemplate;
@@ -87,6 +89,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import jenkins.authentication.tokens.api.AuthenticationTokens;
 import jenkins.plugins.git.AbstractGitSCMSource.SCMRevisionImpl;
 import jenkins.plugins.git.traits.GitBrowserSCMSourceTrait;
 import jenkins.scm.api.SCMHead;
@@ -510,11 +513,11 @@ public class BitbucketSCMSource extends SCMSource {
     }
 
     public BitbucketApi buildBitbucketClient() {
-        return BitbucketApiFactory.newInstance(getServerUrl(), credentials(), repoOwner, repository);
+        return BitbucketApiFactory.newInstance(getServerUrl(), authenticator(), repoOwner, repository);
     }
 
     public BitbucketApi buildBitbucketClient(PullRequestSCMHead head) {
-        return BitbucketApiFactory.newInstance(getServerUrl(), credentials(), head.getRepoOwner(), head.getRepository());
+        return BitbucketApiFactory.newInstance(getServerUrl(), authenticator(), head.getRepoOwner(), head.getRepository());
     }
 
     @Override
@@ -535,7 +538,7 @@ public class BitbucketSCMSource extends SCMSource {
         try (BitbucketSCMSourceRequest request = new BitbucketSCMSourceContext(criteria, observer)
                 .withTraits(traits)
                 .newRequest(this, listener)) {
-            StandardUsernamePasswordCredentials scanCredentials = credentials();
+            StandardCredentials scanCredentials = credentials();
             if (scanCredentials == null) {
                 listener.getLogger().format("Connecting to %s with no credentials, anonymous access%n", getServerUrl());
             } else {
@@ -630,7 +633,7 @@ public class BitbucketSCMSource extends SCMSource {
             final BitbucketApi pullBitbucket = fork && originBitbucket instanceof BitbucketCloudApiClient
                     ? BitbucketApiFactory.newInstance(
                     getServerUrl(),
-                    credentials(),
+                    authenticator(),
                     pullRepoOwner,
                     pullRepository
             )
@@ -1024,13 +1027,18 @@ public class BitbucketSCMSource extends SCMSource {
     }
 
     @CheckForNull
-    /* package */ StandardUsernamePasswordCredentials credentials() {
+    /* package */ StandardCredentials credentials() {
         return BitbucketCredentials.lookupCredentials(
                 getServerUrl(),
                 getOwner(),
                 getCredentialsId(),
-                StandardUsernamePasswordCredentials.class
+                StandardCredentials.class
         );
+    }
+
+    @CheckForNull
+    BitbucketAuthenticator authenticator() {
+        return AuthenticationTokens.convert(BitbucketAuthenticator.class, credentials());
     }
 
     @NonNull
@@ -1164,9 +1172,17 @@ public class BitbucketSCMSource extends SCMSource {
             return "Bitbucket";
         }
 
-        public FormValidation doCheckCredentialsId(@QueryParameter String value,
+        public FormValidation doCheckCredentialsId(@CheckForNull @AncestorInPath SCMSourceOwner context,
+                                                   @QueryParameter String value,
                                                    @QueryParameter String bitbucketServerUrl) {
             if (!value.isEmpty()) {
+                if (CredentialsMatchers.firstOrNull(
+                        CredentialsProvider.lookupCredentials(StandardCertificateCredentials.class,
+                                context,
+                                context instanceof Queue.Task ? Tasks.getDefaultAuthenticationOf((Queue.Task) context) : ACL.SYSTEM,
+                                URIRequirementBuilder.fromUri(bitbucketServerUrl).build()), CredentialsMatchers.withId(value)) != null) {
+                    return FormValidation.warning("A certificate was selected. You will likely need to configure Checkout over SSH.");
+                }
                 return FormValidation.ok();
             } else {
                 return FormValidation.warning("Credentials are required for notifications");
@@ -1211,9 +1227,11 @@ public class BitbucketSCMSource extends SCMSource {
                             ? Tasks.getDefaultAuthenticationOf((Queue.Task) context)
                             : ACL.SYSTEM,
                     context,
-                    StandardUsernameCredentials.class,
+                    StandardCredentials.class,
                     URIRequirementBuilder.fromUri(serverUrl).build(),
-                    CredentialsMatchers.anyOf(CredentialsMatchers.instanceOf(StandardUsernamePasswordCredentials.class))
+                    CredentialsMatchers.anyOf(
+                            CredentialsMatchers.instanceOf(StandardUsernamePasswordCredentials.class),
+                            CredentialsMatchers.instanceOf(StandardCertificateCredentials.class))
             );
             return result;
         }
@@ -1229,14 +1247,17 @@ public class BitbucketSCMSource extends SCMSource {
             context.getACL().checkPermission(Item.CONFIGURE);
             serverUrl = StringUtils.defaultIfBlank(serverUrl, BitbucketCloudEndpoint.SERVER_URL);
             ListBoxModel result = new ListBoxModel();
-            StandardUsernamePasswordCredentials credentials = BitbucketCredentials.lookupCredentials(
+            StandardCredentials credentials = BitbucketCredentials.lookupCredentials(
                     serverUrl,
                     context,
                     credentialsId,
-                    StandardUsernamePasswordCredentials.class
+                    StandardCredentials.class
             );
+
+            BitbucketAuthenticator authenticator = AuthenticationTokens.convert(BitbucketAuthenticator.class, credentials);
+
             try {
-                BitbucketApi bitbucket = BitbucketApiFactory.newInstance(serverUrl, credentials, repoOwner, null);
+                BitbucketApi bitbucket = BitbucketApiFactory.newInstance(serverUrl, authenticator, repoOwner, null);
                 BitbucketTeam team = bitbucket.getTeam();
                 List<? extends BitbucketRepository> repositories =
                         bitbucket.getRepositories(team != null ? null : UserRoleInRepository.CONTRIBUTOR);
@@ -1285,7 +1306,9 @@ public class BitbucketSCMSource extends SCMSource {
                     context,
                     StandardCredentials.class,
                     URIRequirementBuilder.fromUri(bitbucketServerUrl).build(),
-                    CredentialsMatchers.anyOf(CredentialsMatchers.instanceOf(StandardCredentials.class))
+                    CredentialsMatchers.anyOf(
+                            CredentialsMatchers.instanceOf(StandardUsernamePasswordCredentials.class),
+                            CredentialsMatchers.instanceOf(StandardCertificateCredentials.class))
             );
             return result;
         }

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/SCMHeadWithOwnerAndRepo.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/SCMHeadWithOwnerAndRepo.java
@@ -109,7 +109,7 @@ public class SCMHeadWithOwnerAndRepo extends SCMHead {
         try {
             final BitbucketApi bitbucket = BitbucketApiFactory.newInstance(
                     source.getServerUrl(),
-                    source.credentials(),
+                    source.authenticator(),
                     source.getRepoOwner(),
                     source.getRepository()
             );

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/BitbucketApiFactory.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/BitbucketApiFactory.java
@@ -1,6 +1,5 @@
 package com.cloudbees.jenkins.plugins.bitbucket.api;
 
-import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
@@ -28,14 +27,14 @@ public abstract class BitbucketApiFactory implements ExtensionPoint {
      * repository.
      *
      * @param serverUrl   the server URL.
-     * @param credentials the (optional) credentials.
+     * @param authenticator the (optional) authenticator.
      * @param owner       the owner name.
      * @param repository  the (optional) repository name.
      * @return the {@link BitbucketApi}.
      */
     @NonNull
     protected abstract BitbucketApi create(@Nullable String serverUrl,
-                                           @Nullable StandardUsernamePasswordCredentials credentials,
+                                           @Nullable BitbucketAuthenticator authenticator,
                                            @NonNull String owner,
                                            @CheckForNull String repository);
 
@@ -44,7 +43,7 @@ public abstract class BitbucketApiFactory implements ExtensionPoint {
      * repository.
      *
      * @param serverUrl   the server URL.
-     * @param credentials the (optional) credentials.
+     * @param authenticator the (optional) authenticator.
      * @param owner       the owner name.
      * @param repository  the (optional) repository name.
      * @return the {@link BitbucketApi}.
@@ -52,12 +51,12 @@ public abstract class BitbucketApiFactory implements ExtensionPoint {
      */
     @NonNull
     public static BitbucketApi newInstance(@Nullable String serverUrl,
-                                           @Nullable StandardUsernamePasswordCredentials credentials,
+                                           @Nullable BitbucketAuthenticator authenticator,
                                            @NonNull String owner,
                                            @CheckForNull String repository) {
         for (BitbucketApiFactory factory : ExtensionList.lookup(BitbucketApiFactory.class)) {
             if (factory.isMatch(serverUrl)) {
-                return factory.create(serverUrl, credentials, owner, repository);
+                return factory.create(serverUrl, authenticator, owner, repository);
             }
         }
         throw new IllegalArgumentException("Unsupported Bitbucket server URL: " + serverUrl);

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/BitbucketApiFactory.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/BitbucketApiFactory.java
@@ -46,7 +46,8 @@ public abstract class BitbucketApiFactory implements ExtensionPoint {
                                            @Nullable StandardUsernamePasswordCredentials credentials,
                                            @NonNull String owner,
                                            @CheckForNull String repository) {
-        return create(serverUrl, new BitbucketUsernamePasswordAuthenticator(credentials), owner, repository);
+        BitbucketAuthenticator auth = credentials != null ? new BitbucketUsernamePasswordAuthenticator(credentials) : null;
+        return create(serverUrl, auth, owner, repository);
     }
 
     /**
@@ -79,6 +80,7 @@ public abstract class BitbucketApiFactory implements ExtensionPoint {
                                            @Nullable StandardUsernamePasswordCredentials credentials,
                                            @NonNull String owner,
                                            @CheckForNull String repository) {
-        return newInstance(serverUrl, new BitbucketUsernamePasswordAuthenticator(credentials), owner, repository);
+        BitbucketAuthenticator auth = credentials != null ? new BitbucketUsernamePasswordAuthenticator(credentials) : null;
+        return newInstance(serverUrl, auth, owner, repository);
     }
 }

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/BitbucketApiFactory.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/BitbucketApiFactory.java
@@ -1,5 +1,7 @@
 package com.cloudbees.jenkins.plugins.bitbucket.api;
 
+import com.cloudbees.jenkins.plugins.bitbucket.api.credentials.BitbucketUsernamePasswordAuthenticator;
+import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
@@ -38,6 +40,15 @@ public abstract class BitbucketApiFactory implements ExtensionPoint {
                                            @NonNull String owner,
                                            @CheckForNull String repository);
 
+    @NonNull
+    @Deprecated
+    protected BitbucketApi create(@Nullable String serverUrl,
+                                           @Nullable StandardUsernamePasswordCredentials credentials,
+                                           @NonNull String owner,
+                                           @CheckForNull String repository) {
+        return create(serverUrl, new BitbucketUsernamePasswordAuthenticator(credentials), owner, repository);
+    }
+
     /**
      * Creates a {@link BitbucketApi} for the specified URL with the supplied credentials, owner and (optional)
      * repository.
@@ -60,5 +71,14 @@ public abstract class BitbucketApiFactory implements ExtensionPoint {
             }
         }
         throw new IllegalArgumentException("Unsupported Bitbucket server URL: " + serverUrl);
+    }
+
+    @NonNull
+    @Deprecated
+    public static BitbucketApi newInstance(@Nullable String serverUrl,
+                                           @Nullable StandardUsernamePasswordCredentials credentials,
+                                           @NonNull String owner,
+                                           @CheckForNull String repository) {
+        return newInstance(serverUrl, new BitbucketUsernamePasswordAuthenticator(credentials), owner, repository);
     }
 }

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/BitbucketAuthenticator.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/BitbucketAuthenticator.java
@@ -8,37 +8,91 @@ import org.apache.http.HttpRequest;
 import org.apache.http.client.protocol.HttpClientContext;
 import org.apache.http.impl.client.HttpClientBuilder;
 
+/**
+ * Support for various different methods of authenticating with Bitbucket
+ */
 public abstract class BitbucketAuthenticator {
 
     private String id;
 
+    /**
+     * The URL protocol as reported in an {@link AuthenticationTokenContext}
+     */
     public static String PROTOCOL_PURPOSE = "PROTOCOL";
 
+    /**
+     * The purpose value for HTTP instances
+     */
     public static String PROTOCOL_HTTP = "HTTP";
 
+    /**
+     * The purpose value for HTTPS instances
+     */
     public static String PROTOCOL_HTTPS = "HTTPS";
 
 
+    /**
+     * The Bitbucket instance type as reported in an {@link AuthenticationTokenContext}
+     */
     public static String INSTANCE_TYPE_PURPOSE = "INSTANCE_TYPE";
 
+    /**
+     * Purpose value for bitbucket cloud (i.e. bitbucket.org)
+     */
     public static String INSTANCE_TYPE_CLOUD = "CLOUD";
 
+    /**
+     * Purpose value for bitbucket server
+     */
     public static String INSTANCE_TYPE_SERVER = "SERVER";
 
+    /**
+     * Constructor
+     *
+     * @param credentials credentials instance this authenticator will use
+     */
     public BitbucketAuthenticator(StandardCredentials credentials) {
         id = credentials.getId();
     }
 
+    /**
+     * @return id of the credentials used.
+     */
     public String getId() {
         return id;
     }
 
+    /**
+     * Configures an {@link HttpClientBuilder}. Override if you need to adjust connection setup.
+     * @param builder The client builder.
+     */
     public void configureBuilder(HttpClientBuilder builder) { }
 
+
+    /**
+     * Configures an {@link HttpClientContext}. Override
+     * @param context The connection context
+     * @param host host being connected to
+     */
     public void configureContext(HttpClientContext context, HttpHost host) { }
 
+
+    /**
+     * Configures an {@link HttpRequest}. Override this if your authentication method needs to set headers on a
+     * per-request basis.
+     *
+     * @param request the request.
+     */
     public void configureRequest(HttpRequest request) { }
 
+
+    /**
+     * Generates context that sub-classes can use to determine if they would be able to authenticate against the
+     * provided server.
+     *
+     * @param serverUrl The URL being authenticated against
+     * @return an {@link AuthenticationTokenContext} for use with the AuthenticationTokens APIs
+     */
     public static AuthenticationTokenContext<BitbucketAuthenticator> authenticationContext(String serverUrl) {
         boolean isHttps = serverUrl == null || serverUrl.startsWith("https");
         boolean isCloud = serverUrl == null || serverUrl.equals(BitbucketCloudEndpoint.SERVER_URL);

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/BitbucketAuthenticator.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/BitbucketAuthenticator.java
@@ -1,0 +1,26 @@
+package com.cloudbees.jenkins.plugins.bitbucket.api;
+
+import com.cloudbees.plugins.credentials.common.StandardCredentials;
+import org.apache.http.HttpHost;
+import org.apache.http.HttpRequest;
+import org.apache.http.client.protocol.HttpClientContext;
+import org.apache.http.impl.client.HttpClientBuilder;
+
+public abstract class BitbucketAuthenticator<T extends StandardCredentials> {
+
+    public final T credentials;
+
+    public String getId() {
+        return credentials.getId();
+    }
+
+    public BitbucketAuthenticator(T credentials) {
+        this.credentials = credentials;
+    }
+
+    public void configureBuilder(HttpClientBuilder builder) { }
+
+    public void configureContext(HttpClientContext context, HttpHost host) { }
+
+    public void configureRequest(HttpRequest request) { }
+}

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/BitbucketAuthenticator.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/BitbucketAuthenticator.java
@@ -18,33 +18,33 @@ public abstract class BitbucketAuthenticator {
     /**
      * The URL protocol as reported in an {@link AuthenticationTokenContext}
      */
-    public static String PROTOCOL_PURPOSE = "PROTOCOL";
+    public static final String PROTOCOL_PURPOSE = "PROTOCOL";
 
     /**
      * The purpose value for HTTP instances
      */
-    public static String PROTOCOL_HTTP = "HTTP";
+    public static final String PROTOCOL_HTTP = "HTTP";
 
     /**
      * The purpose value for HTTPS instances
      */
-    public static String PROTOCOL_HTTPS = "HTTPS";
+    public static final String PROTOCOL_HTTPS = "HTTPS";
 
 
     /**
      * The Bitbucket instance type as reported in an {@link AuthenticationTokenContext}
      */
-    public static String INSTANCE_TYPE_PURPOSE = "INSTANCE_TYPE";
+    public static final String INSTANCE_TYPE_PURPOSE = "INSTANCE_TYPE";
 
     /**
      * Purpose value for bitbucket cloud (i.e. bitbucket.org)
      */
-    public static String INSTANCE_TYPE_CLOUD = "CLOUD";
+    public static final String INSTANCE_TYPE_CLOUD = "CLOUD";
 
     /**
      * Purpose value for bitbucket server
      */
-    public static String INSTANCE_TYPE_SERVER = "SERVER";
+    public static final String INSTANCE_TYPE_SERVER = "SERVER";
 
     /**
      * Constructor

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/BitbucketAuthenticator.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/BitbucketAuthenticator.java
@@ -10,12 +10,12 @@ public abstract class BitbucketAuthenticator {
 
     private String id;
 
-    public String getId() {
-        return id;
+    public BitbucketAuthenticator(StandardCredentials credentials) {
+        id = credentials.getId();
     }
 
-    public BitbucketAuthenticator(StandardCredentials credentials) {
-        this.id = credentials.getId();
+    public String getId() {
+        return id;
     }
 
     public void configureBuilder(HttpClientBuilder builder) { }

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/BitbucketAuthenticator.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/BitbucketAuthenticator.java
@@ -16,34 +16,29 @@ public abstract class BitbucketAuthenticator {
     private String id;
 
     /**
-     * The URL protocol as reported in an {@link AuthenticationTokenContext}
+     * The key for bitbucket URL as rerported in an {@link AuthenticationTokenContext}
      */
-    public static final String PROTOCOL_PURPOSE = "PROTOCOL";
+    public static final String SERVER_URL = "bitbucket.server.uri";
 
     /**
-     * The purpose value for HTTP instances
+     * The key for URL scheme as reported in an {@link AuthenticationTokenContext}
      */
-    public static final String PROTOCOL_HTTP = "HTTP";
+    public static final String SCHEME = "bitbucket.server.uri.scheme";
 
     /**
-     * The purpose value for HTTPS instances
+     * The key for Bitbucket instance type as reported in an {@link AuthenticationTokenContext}
      */
-    public static final String PROTOCOL_HTTPS = "HTTPS";
-
-    /**
-     * The Bitbucket instance type as reported in an {@link AuthenticationTokenContext}
-     */
-    public static final String INSTANCE_TYPE_PURPOSE = "INSTANCE_TYPE";
+    public static final String BITBUCKET_INSTANCE_TYPE = "bitbucket.server.type";
 
     /**
      * Purpose value for bitbucket cloud (i.e. bitbucket.org)
      */
-    public static final String INSTANCE_TYPE_CLOUD = "CLOUD";
+    public static final String BITBUCKET_INSTANCE_TYPE_CLOUD = "BITBUCKET_CLOUD";
 
     /**
      * Purpose value for bitbucket server
      */
-    public static final String INSTANCE_TYPE_SERVER = "SERVER";
+    public static final String BITBUCKET_INSTANCE_TYPE_SERVER = "BITBUCKET_SERVER";
 
     /**
      * Constructor
@@ -90,12 +85,17 @@ public abstract class BitbucketAuthenticator {
      * @return an {@link AuthenticationTokenContext} for use with the AuthenticationTokens APIs
      */
     public static AuthenticationTokenContext<BitbucketAuthenticator> authenticationContext(String serverUrl) {
-        boolean isHttps = serverUrl == null || serverUrl.startsWith("https");
-        boolean isCloud = serverUrl == null || serverUrl.equals(BitbucketCloudEndpoint.SERVER_URL);
+        if (serverUrl == null) {
+            serverUrl = BitbucketCloudEndpoint.SERVER_URL;
+        }
+
+        String scheme = serverUrl.split(":")[0].toLowerCase();
+        boolean isCloud = serverUrl.equals(BitbucketCloudEndpoint.SERVER_URL);
 
         return AuthenticationTokenContext.builder(BitbucketAuthenticator.class)
-                .with(PROTOCOL_PURPOSE, isHttps ? PROTOCOL_HTTPS : PROTOCOL_HTTP)
-                .with(INSTANCE_TYPE_PURPOSE, isCloud ? INSTANCE_TYPE_CLOUD : INSTANCE_TYPE_SERVER)
+                .with(SERVER_URL, serverUrl)
+                .with(SCHEME, scheme)
+                .with(BITBUCKET_INSTANCE_TYPE, isCloud ? BITBUCKET_INSTANCE_TYPE_CLOUD : BITBUCKET_INSTANCE_TYPE_SERVER)
                 .build();
     }
 }

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/BitbucketAuthenticator.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/BitbucketAuthenticator.java
@@ -1,6 +1,8 @@
 package com.cloudbees.jenkins.plugins.bitbucket.api;
 
+import com.cloudbees.jenkins.plugins.bitbucket.endpoints.BitbucketCloudEndpoint;
 import com.cloudbees.plugins.credentials.common.StandardCredentials;
+import jenkins.authentication.tokens.api.AuthenticationTokenContext;
 import org.apache.http.HttpHost;
 import org.apache.http.HttpRequest;
 import org.apache.http.client.protocol.HttpClientContext;
@@ -9,6 +11,19 @@ import org.apache.http.impl.client.HttpClientBuilder;
 public abstract class BitbucketAuthenticator {
 
     private String id;
+
+    public static String PROTOCOL_PURPOSE = "PROTOCOL";
+
+    public static String PROTOCOL_HTTP = "HTTP";
+
+    public static String PROTOCOL_HTTPS = "HTTPS";
+
+
+    public static String INSTANCE_TYPE_PURPOSE = "INSTANCE_TYPE";
+
+    public static String INSTANCE_TYPE_CLOUD = "CLOUD";
+
+    public static String INSTANCE_TYPE_SERVER = "SERVER";
 
     public BitbucketAuthenticator(StandardCredentials credentials) {
         id = credentials.getId();
@@ -23,4 +38,14 @@ public abstract class BitbucketAuthenticator {
     public void configureContext(HttpClientContext context, HttpHost host) { }
 
     public void configureRequest(HttpRequest request) { }
+
+    public static AuthenticationTokenContext<BitbucketAuthenticator> authenticationContext(String serverUrl) {
+        boolean isHttps = serverUrl == null || serverUrl.startsWith("https");
+        boolean isCloud = serverUrl == null || serverUrl.equals(BitbucketCloudEndpoint.SERVER_URL);
+
+        return AuthenticationTokenContext.builder(BitbucketAuthenticator.class)
+                .with(PROTOCOL_PURPOSE, isHttps ? PROTOCOL_HTTPS : PROTOCOL_HTTP)
+                .with(INSTANCE_TYPE_PURPOSE, isCloud ? INSTANCE_TYPE_CLOUD : INSTANCE_TYPE_SERVER)
+                .build();
+    }
 }

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/BitbucketAuthenticator.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/BitbucketAuthenticator.java
@@ -30,7 +30,6 @@ public abstract class BitbucketAuthenticator {
      */
     public static final String PROTOCOL_HTTPS = "HTTPS";
 
-
     /**
      * The Bitbucket instance type as reported in an {@link AuthenticationTokenContext}
      */
@@ -68,14 +67,12 @@ public abstract class BitbucketAuthenticator {
      */
     public void configureBuilder(HttpClientBuilder builder) { }
 
-
     /**
      * Configures an {@link HttpClientContext}. Override
      * @param context The connection context
      * @param host host being connected to
      */
     public void configureContext(HttpClientContext context, HttpHost host) { }
-
 
     /**
      * Configures an {@link HttpRequest}. Override this if your authentication method needs to set headers on a
@@ -84,7 +81,6 @@ public abstract class BitbucketAuthenticator {
      * @param request the request.
      */
     public void configureRequest(HttpRequest request) { }
-
 
     /**
      * Generates context that sub-classes can use to determine if they would be able to authenticate against the

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/BitbucketAuthenticator.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/BitbucketAuthenticator.java
@@ -1,3 +1,27 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2018, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
 package com.cloudbees.jenkins.plugins.bitbucket.api;
 
 import com.cloudbees.jenkins.plugins.bitbucket.endpoints.BitbucketCloudEndpoint;

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/BitbucketAuthenticator.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/BitbucketAuthenticator.java
@@ -6,16 +6,16 @@ import org.apache.http.HttpRequest;
 import org.apache.http.client.protocol.HttpClientContext;
 import org.apache.http.impl.client.HttpClientBuilder;
 
-public abstract class BitbucketAuthenticator<T extends StandardCredentials> {
+public abstract class BitbucketAuthenticator {
 
-    public final T credentials;
+    private String id;
 
     public String getId() {
-        return credentials.getId();
+        return id;
     }
 
-    public BitbucketAuthenticator(T credentials) {
-        this.credentials = credentials;
+    public BitbucketAuthenticator(StandardCredentials credentials) {
+        this.id = credentials.getId();
     }
 
     public void configureBuilder(HttpClientBuilder builder) { }

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/credentials/BitbucketClientCertificateAuthenticator.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/credentials/BitbucketClientCertificateAuthenticator.java
@@ -15,6 +15,9 @@ import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.ssl.SSLContextBuilder;
 import org.apache.http.ssl.SSLContexts;
 
+/**
+ * Authenticates against Bitbucket using a TLS client certificate
+ */
 public class BitbucketClientCertificateAuthenticator extends BitbucketAuthenticator {
 
     private KeyStore keyStore;
@@ -22,12 +25,19 @@ public class BitbucketClientCertificateAuthenticator extends BitbucketAuthentica
 
     private static final Logger LOGGER = Logger.getLogger(BitbucketClientCertificateAuthenticator.class.getName());
 
+    /**
+     * {@inheritDoc}
+     */
     public BitbucketClientCertificateAuthenticator(StandardCertificateCredentials credentials) {
         super(credentials);
         keyStore = credentials.getKeyStore();
         password = credentials.getPassword();
     }
 
+    /**
+     * Sets the SSLContext for the builder to one that will connect with the selected certificate.
+     * @param builder The client builder.
+     */
     @Override
     public void configureBuilder(HttpClientBuilder builder) {
         try {

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/credentials/BitbucketClientCertificateAuthenticator.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/credentials/BitbucketClientCertificateAuthenticator.java
@@ -1,3 +1,27 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2018, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
 package com.cloudbees.jenkins.plugins.bitbucket.api.credentials;
 
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketAuthenticator;

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/credentials/BitbucketClientCertificateAuthenticator.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/credentials/BitbucketClientCertificateAuthenticator.java
@@ -2,33 +2,45 @@ package com.cloudbees.jenkins.plugins.bitbucket.api.credentials;
 
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketAuthenticator;
 import com.cloudbees.plugins.credentials.common.StandardCertificateCredentials;
+import hudson.util.Secret;
 import java.security.KeyManagementException;
+import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.UnrecoverableKeyException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import javax.net.ssl.SSLContext;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.ssl.SSLContextBuilder;
 import org.apache.http.ssl.SSLContexts;
 
-public class BitbucketClientCertificateAuthenticator extends BitbucketAuthenticator<StandardCertificateCredentials> {
+public class BitbucketClientCertificateAuthenticator extends BitbucketAuthenticator {
+
+    private KeyStore keyStore;
+    private Secret password;
+
+    private static final Logger LOGGER = Logger.getLogger(BitbucketClientCertificateAuthenticator.class.getName());
 
     public BitbucketClientCertificateAuthenticator(StandardCertificateCredentials credentials) {
         super(credentials);
+        keyStore = credentials.getKeyStore();
+        password = credentials.getPassword();
     }
 
     @Override
     public void configureBuilder(HttpClientBuilder builder) {
         try {
             builder.setSSLContext(buildSSLContext());
-        } catch (NoSuchAlgorithmException | UnrecoverableKeyException | KeyStoreException | KeyManagementException ignored) {
-
+        } catch (NoSuchAlgorithmException | UnrecoverableKeyException | KeyStoreException | KeyManagementException e) {
+            LOGGER.log(Level.WARNING, "Failed to set up SSL context from provided client certificate: " + e.getMessage());
+            // TODO: handle this error in a way that provides feedback to the user
         }
     }
 
     private SSLContext buildSSLContext() throws NoSuchAlgorithmException, KeyStoreException, UnrecoverableKeyException, KeyManagementException {
         SSLContextBuilder contextBuilder = SSLContexts.custom();
-        contextBuilder.loadKeyMaterial(credentials.getKeyStore(), credentials.getPassword().getPlainText().toCharArray());
+        contextBuilder.loadKeyMaterial(keyStore, password.getPlainText().toCharArray());
         return contextBuilder.build();
     }
 }

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/credentials/BitbucketClientCertificateAuthenticator.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/credentials/BitbucketClientCertificateAuthenticator.java
@@ -1,0 +1,34 @@
+package com.cloudbees.jenkins.plugins.bitbucket.api.credentials;
+
+import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketAuthenticator;
+import com.cloudbees.plugins.credentials.common.StandardCertificateCredentials;
+import java.security.KeyManagementException;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.UnrecoverableKeyException;
+import javax.net.ssl.SSLContext;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.ssl.SSLContextBuilder;
+import org.apache.http.ssl.SSLContexts;
+
+public class BitbucketClientCertificateAuthenticator extends BitbucketAuthenticator<StandardCertificateCredentials> {
+
+    public BitbucketClientCertificateAuthenticator(StandardCertificateCredentials credentials) {
+        super(credentials);
+    }
+
+    @Override
+    public void configureBuilder(HttpClientBuilder builder) {
+        try {
+            builder.setSSLContext(buildSSLContext());
+        } catch (NoSuchAlgorithmException | UnrecoverableKeyException | KeyStoreException | KeyManagementException ignored) {
+
+        }
+    }
+
+    private SSLContext buildSSLContext() throws NoSuchAlgorithmException, KeyStoreException, UnrecoverableKeyException, KeyManagementException {
+        SSLContextBuilder contextBuilder = SSLContexts.custom();
+        contextBuilder.loadKeyMaterial(credentials.getKeyStore(), credentials.getPassword().getPlainText().toCharArray());
+        return contextBuilder.build();
+    }
+}

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/credentials/BitbucketClientCertificateAuthenticatorSource.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/credentials/BitbucketClientCertificateAuthenticatorSource.java
@@ -40,7 +40,7 @@ public class BitbucketClientCertificateAuthenticatorSource
      */
     @Override
     public boolean isFit(AuthenticationTokenContext ctx) {
-        return ctx.mustHave(BitbucketAuthenticator.PROTOCOL_PURPOSE, BitbucketAuthenticator.PROTOCOL_HTTPS)
-                && ctx.mustHave(BitbucketAuthenticator.INSTANCE_TYPE_PURPOSE, BitbucketAuthenticator.INSTANCE_TYPE_SERVER);
+        return ctx.mustHave(BitbucketAuthenticator.SCHEME, "https")
+                && ctx.mustHave(BitbucketAuthenticator.BITBUCKET_INSTANCE_TYPE, BitbucketAuthenticator.BITBUCKET_INSTANCE_TYPE_SERVER);
     }
 }

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/credentials/BitbucketClientCertificateAuthenticatorSource.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/credentials/BitbucketClientCertificateAuthenticatorSource.java
@@ -1,8 +1,10 @@
 package com.cloudbees.jenkins.plugins.bitbucket.api.credentials;
 
+import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketAuthenticator;
 import com.cloudbees.plugins.credentials.common.StandardCertificateCredentials;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
+import jenkins.authentication.tokens.api.AuthenticationTokenContext;
 import jenkins.authentication.tokens.api.AuthenticationTokenSource;
 
 @Extension
@@ -17,5 +19,11 @@ public class BitbucketClientCertificateAuthenticatorSource
     @Override
     public BitbucketClientCertificateAuthenticator convert(@NonNull StandardCertificateCredentials certificateCredentials) {
         return new BitbucketClientCertificateAuthenticator(certificateCredentials);
+    }
+
+    @Override
+    public boolean isFit(AuthenticationTokenContext ctx) {
+        return ctx.mustHave(BitbucketAuthenticator.PROTOCOL_PURPOSE, BitbucketAuthenticator.PROTOCOL_HTTPS)
+                && ctx.mustHave(BitbucketAuthenticator.INSTANCE_TYPE_PURPOSE, BitbucketAuthenticator.INSTANCE_TYPE_SERVER);
     }
 }

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/credentials/BitbucketClientCertificateAuthenticatorSource.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/credentials/BitbucketClientCertificateAuthenticatorSource.java
@@ -1,3 +1,27 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2018, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
 package com.cloudbees.jenkins.plugins.bitbucket.api.credentials;
 
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketAuthenticator;

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/credentials/BitbucketClientCertificateAuthenticatorSource.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/credentials/BitbucketClientCertificateAuthenticatorSource.java
@@ -1,0 +1,21 @@
+package com.cloudbees.jenkins.plugins.bitbucket.api.credentials;
+
+import com.cloudbees.plugins.credentials.common.StandardCertificateCredentials;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Extension;
+import jenkins.authentication.tokens.api.AuthenticationTokenSource;
+
+@Extension
+public class BitbucketClientCertificateAuthenticatorSource
+        extends AuthenticationTokenSource<BitbucketClientCertificateAuthenticator, StandardCertificateCredentials> {
+
+    public BitbucketClientCertificateAuthenticatorSource() {
+        super(BitbucketClientCertificateAuthenticator.class, StandardCertificateCredentials.class);
+    }
+
+    @NonNull
+    @Override
+    public BitbucketClientCertificateAuthenticator convert(@NonNull StandardCertificateCredentials certificateCredentials) {
+        return new BitbucketClientCertificateAuthenticator(certificateCredentials);
+    }
+}

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/credentials/BitbucketClientCertificateAuthenticatorSource.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/credentials/BitbucketClientCertificateAuthenticatorSource.java
@@ -7,20 +7,37 @@ import hudson.Extension;
 import jenkins.authentication.tokens.api.AuthenticationTokenContext;
 import jenkins.authentication.tokens.api.AuthenticationTokenSource;
 
+/**
+ * Provider for client-cert authenticators
+ */
 @Extension
 public class BitbucketClientCertificateAuthenticatorSource
         extends AuthenticationTokenSource<BitbucketClientCertificateAuthenticator, StandardCertificateCredentials> {
 
+    /**
+     * Constructor.
+     */
     public BitbucketClientCertificateAuthenticatorSource() {
         super(BitbucketClientCertificateAuthenticator.class, StandardCertificateCredentials.class);
     }
 
+    /**
+     * Convert a {@link StandardCertificateCredentials} into a {@link BitbucketAuthenticator}
+     * @param certificateCredentials the cert
+     * @return an authenticator that will use the cert
+     */
     @NonNull
     @Override
     public BitbucketClientCertificateAuthenticator convert(@NonNull StandardCertificateCredentials certificateCredentials) {
         return new BitbucketClientCertificateAuthenticator(certificateCredentials);
     }
 
+    /**
+     * Whether this source works in the given context. For client certs, only HTTPS BitbucketServer instances make sense
+     *
+     * @param ctx
+     * @return whether or not this can authenticate given the context
+     */
     @Override
     public boolean isFit(AuthenticationTokenContext ctx) {
         return ctx.mustHave(BitbucketAuthenticator.PROTOCOL_PURPOSE, BitbucketAuthenticator.PROTOCOL_HTTPS)

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/credentials/BitbucketUsernamePasswordAuthenticator.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/credentials/BitbucketUsernamePasswordAuthenticator.java
@@ -13,16 +13,29 @@ import org.apache.http.impl.auth.BasicScheme;
 import org.apache.http.impl.client.BasicAuthCache;
 import org.apache.http.impl.client.BasicCredentialsProvider;
 
+/**
+ * Authenticator that uses a username and password (probably the default)
+ */
 public class BitbucketUsernamePasswordAuthenticator extends BitbucketAuthenticator {
 
     private UsernamePasswordCredentials httpCredentials;
 
+    /**
+     * Constructor.
+     * @param credentials the username/password that will be used
+     */
     public BitbucketUsernamePasswordAuthenticator(StandardUsernamePasswordCredentials credentials) {
         super(credentials);
         httpCredentials = new UsernamePasswordCredentials(credentials.getUsername(),
                 Secret.toString(credentials.getPassword()));
     }
 
+    /**
+     * Sets up HTTP Basic Auth with the provided username/password
+     *
+     * @param context The connection context
+     * @param host host being connected to
+     */
     @Override
     public void configureContext(HttpClientContext context, HttpHost host) {
         CredentialsProvider credentialsProvider = new BasicCredentialsProvider();

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/credentials/BitbucketUsernamePasswordAuthenticator.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/credentials/BitbucketUsernamePasswordAuthenticator.java
@@ -1,3 +1,28 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2018, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+
 package com.cloudbees.jenkins.plugins.bitbucket.api.credentials;
 
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketAuthenticator;

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/credentials/BitbucketUsernamePasswordAuthenticator.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/credentials/BitbucketUsernamePasswordAuthenticator.java
@@ -1,0 +1,35 @@
+package com.cloudbees.jenkins.plugins.bitbucket.api.credentials;
+
+import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketAuthenticator;
+import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
+import hudson.util.Secret;
+import org.apache.http.HttpHost;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.AuthCache;
+import org.apache.http.client.CredentialsProvider;
+import org.apache.http.client.protocol.HttpClientContext;
+import org.apache.http.impl.auth.BasicScheme;
+import org.apache.http.impl.client.BasicAuthCache;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+
+public class BitbucketUsernamePasswordAuthenticator extends BitbucketAuthenticator<StandardUsernamePasswordCredentials> {
+
+    private UsernamePasswordCredentials httpCredentials;
+
+    public BitbucketUsernamePasswordAuthenticator(StandardUsernamePasswordCredentials credentials) {
+        super(credentials);
+        httpCredentials = new UsernamePasswordCredentials(credentials.getUsername(),
+                Secret.toString(credentials.getPassword()));
+    }
+
+    @Override
+    public void configureContext(HttpClientContext context, HttpHost host) {
+        CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
+        credentialsProvider.setCredentials(AuthScope.ANY, httpCredentials);
+        AuthCache authCache = new BasicAuthCache();
+        authCache.put(host, new BasicScheme());
+        context.setCredentialsProvider(credentialsProvider);
+        context.setAuthCache(authCache);
+    }
+}

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/credentials/BitbucketUsernamePasswordAuthenticator.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/credentials/BitbucketUsernamePasswordAuthenticator.java
@@ -13,7 +13,7 @@ import org.apache.http.impl.auth.BasicScheme;
 import org.apache.http.impl.client.BasicAuthCache;
 import org.apache.http.impl.client.BasicCredentialsProvider;
 
-public class BitbucketUsernamePasswordAuthenticator extends BitbucketAuthenticator<StandardUsernamePasswordCredentials> {
+public class BitbucketUsernamePasswordAuthenticator extends BitbucketAuthenticator {
 
     private UsernamePasswordCredentials httpCredentials;
 

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/credentials/BitbucketUsernamePasswordAuthenticatorSource.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/credentials/BitbucketUsernamePasswordAuthenticatorSource.java
@@ -5,13 +5,24 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import jenkins.authentication.tokens.api.AuthenticationTokenSource;
 
+/**
+ * Source for username/password authenticators.
+ */
 @Extension
 public class BitbucketUsernamePasswordAuthenticatorSource extends AuthenticationTokenSource<BitbucketUsernamePasswordAuthenticator, StandardUsernamePasswordCredentials> {
 
+    /**
+     * Constructor.
+     */
     public BitbucketUsernamePasswordAuthenticatorSource() {
         super(BitbucketUsernamePasswordAuthenticator.class, StandardUsernamePasswordCredentials.class);
     }
 
+    /**
+     * Converts username/password credentials to an authenticator.
+     * @param standardUsernamePasswordCredentials the username/password combo
+     * @return an authenticator that will use them.
+     */
     @NonNull
     @Override
     public BitbucketUsernamePasswordAuthenticator convert(@NonNull StandardUsernamePasswordCredentials standardUsernamePasswordCredentials) {

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/credentials/BitbucketUsernamePasswordAuthenticatorSource.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/credentials/BitbucketUsernamePasswordAuthenticatorSource.java
@@ -1,3 +1,28 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2018, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+
 package com.cloudbees.jenkins.plugins.bitbucket.api.credentials;
 
 import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/credentials/BitbucketUsernamePasswordAuthenticatorSource.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/credentials/BitbucketUsernamePasswordAuthenticatorSource.java
@@ -1,0 +1,20 @@
+package com.cloudbees.jenkins.plugins.bitbucket.api.credentials;
+
+import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Extension;
+import jenkins.authentication.tokens.api.AuthenticationTokenSource;
+
+@Extension
+public class BitbucketUsernamePasswordAuthenticatorSource extends AuthenticationTokenSource<BitbucketUsernamePasswordAuthenticator, StandardUsernamePasswordCredentials> {
+
+    public BitbucketUsernamePasswordAuthenticatorSource() {
+        super(BitbucketUsernamePasswordAuthenticator.class, StandardUsernamePasswordCredentials.class);
+    }
+
+    @NonNull
+    @Override
+    public BitbucketUsernamePasswordAuthenticator convert(@NonNull StandardUsernamePasswordCredentials standardUsernamePasswordCredentials) {
+        return new BitbucketUsernamePasswordAuthenticator(standardUsernamePasswordCredentials);
+    }
+}

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/BitbucketCloudApiClient.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/BitbucketCloudApiClient.java
@@ -26,6 +26,7 @@ package com.cloudbees.jenkins.plugins.bitbucket.client;
 
 import com.cloudbees.jenkins.plugins.bitbucket.JsonParser;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketApi;
+import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketAuthenticator;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketBuildStatus;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketCommit;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketException;
@@ -50,14 +51,12 @@ import com.cloudbees.jenkins.plugins.bitbucket.client.repository.BitbucketReposi
 import com.cloudbees.jenkins.plugins.bitbucket.client.repository.PaginatedBitbucketRepository;
 import com.cloudbees.jenkins.plugins.bitbucket.client.repository.UserRoleInRepository;
 import com.cloudbees.jenkins.plugins.bitbucket.filesystem.BitbucketSCMFile;
-import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
 import com.damnhandy.uri.template.UriTemplate;
 import com.fasterxml.jackson.core.type.TypeReference;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.ProxyConfiguration;
 import hudson.Util;
-import hudson.util.Secret;
 import java.io.ByteArrayOutputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -123,9 +122,8 @@ public class BitbucketCloudApiClient implements BitbucketApi {
     private HttpClientContext context;
     private final String owner;
     private final String repositoryName;
-    @CheckForNull
-    private final UsernamePasswordCredentials credentials;
     private final boolean enableCache;
+    private final BitbucketAuthenticator authenticator;
     static {
         connectionManager.setDefaultMaxPerRoute(20);
         connectionManager.setMaxTotal(22);
@@ -149,12 +147,8 @@ public class BitbucketCloudApiClient implements BitbucketApi {
     }
 
     public BitbucketCloudApiClient(boolean enableCache, int teamCacheDuration, int repositoriesCacheDuraction,
-            String owner, String repositoryName, StandardUsernamePasswordCredentials creds) {
-        if (creds != null) {
-            this.credentials = new UsernamePasswordCredentials(creds.getUsername(), Secret.toString(creds.getPassword()));
-        } else {
-            this.credentials = null;
-        }
+            String owner, String repositoryName, BitbucketAuthenticator authenticator) {
+        this.authenticator = authenticator;
         this.owner = owner;
         this.repositoryName = repositoryName;
         this.enableCache = enableCache;
@@ -168,14 +162,11 @@ public class BitbucketCloudApiClient implements BitbucketApi {
         httpClientBuilder.setConnectionManager(connectionManager);
         httpClientBuilder.setConnectionManagerShared(true);
 
-        if (credentials != null) {
-            CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
-            credentialsProvider.setCredentials(AuthScope.ANY, credentials);
-            AuthCache authCache = new BasicAuthCache();
-            authCache.put(API_HOST, new BasicScheme());
+        if (authenticator != null) {
+            authenticator.configureBuilder(httpClientBuilder);
+
             context = HttpClientContext.create();
-            context.setCredentialsProvider(credentialsProvider);
-            context.setAuthCache(authCache);
+            authenticator.configureContext(context, API_HOST);
         }
 
         setClientProxyParams("bitbucket.org", httpClientBuilder);
@@ -245,13 +236,6 @@ public class BitbucketCloudApiClient implements BitbucketApi {
         }
     }
 
-    @CheckForNull
-    public String getLogin() {
-        if (credentials != null) {
-            return credentials.getUserName();
-        }
-        return null;
-    }
 
     /**
      * {@inheritDoc}
@@ -624,21 +608,18 @@ public class BitbucketCloudApiClient implements BitbucketApi {
 
     /**
      * The role parameter only makes sense when the request is authenticated, so
-     * if there is no auth information ({@link #credentials}) the role will be omitted.
+     * if there is no auth information ({@link #authenticator}) the role will be omitted.
      */
     @NonNull
     @Override
     public List<BitbucketCloudRepository> getRepositories(@CheckForNull UserRoleInRepository role)
             throws InterruptedException, IOException {
         StringBuilder cacheKey = new StringBuilder();
-        cacheKey.append(owner);
-        if (credentials != null) {
-            cacheKey.append("::").append(credentials.getUserName());
-        }
+        cacheKey.append(owner).append("::").append(authenticator.getId());
         final UriTemplate template = UriTemplate.fromTemplate(V2_API_BASE_URL + "{/owner}{?role,page,pagelen}")
                 .set("owner", owner)
                 .set("pagelen", 50);
-        if (role != null && getLogin() != null) {
+        if (role != null &&  authenticator != null) {
             template.set("role", role.getId());
             cacheKey.append("::").append(role.getId());
         }
@@ -718,6 +699,11 @@ public class BitbucketCloudApiClient implements BitbucketApi {
     }
 
     private CloseableHttpResponse executeMethod(HttpRequestBase httpMethod) throws InterruptedException, IOException {
+
+        if (authenticator != null) {
+            authenticator.configureRequest(httpMethod);
+        }
+
         RequestConfig.Builder requestConfig = RequestConfig.custom();
         requestConfig.setConnectTimeout(10 * 1000);
         requestConfig.setConnectionRequestTimeout(60 * 1000);

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/BitbucketCloudApiClient.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/BitbucketCloudApiClient.java
@@ -37,6 +37,7 @@ import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketRepositoryType;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketRequestException;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketTeam;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketWebHook;
+import com.cloudbees.jenkins.plugins.bitbucket.api.credentials.BitbucketUsernamePasswordAuthenticator;
 import com.cloudbees.jenkins.plugins.bitbucket.client.branch.BitbucketCloudBranch;
 import com.cloudbees.jenkins.plugins.bitbucket.client.branch.BitbucketCloudCommit;
 import com.cloudbees.jenkins.plugins.bitbucket.client.pullrequest.BitbucketPullRequestCommit;
@@ -51,6 +52,7 @@ import com.cloudbees.jenkins.plugins.bitbucket.client.repository.BitbucketReposi
 import com.cloudbees.jenkins.plugins.bitbucket.client.repository.PaginatedBitbucketRepository;
 import com.cloudbees.jenkins.plugins.bitbucket.client.repository.UserRoleInRepository;
 import com.cloudbees.jenkins.plugins.bitbucket.filesystem.BitbucketSCMFile;
+import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
 import com.damnhandy.uri.template.UriTemplate;
 import com.fasterxml.jackson.core.type.TypeReference;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
@@ -144,6 +146,13 @@ public class BitbucketCloudApiClient implements BitbucketApi {
     public static void clearCaches() {
         cachedTeam.evictAll();
         cachedRepositories.evictAll();
+    }
+
+    @Deprecated
+    public BitbucketCloudApiClient(boolean enableCache, int teamCacheDuration, int repositoriesCacheDuraction,
+                                   String owner, String repositoryName, StandardUsernamePasswordCredentials credentials) {
+        this(enableCache, teamCacheDuration, repositoriesCacheDuraction, owner, repositoryName,
+                new BitbucketUsernamePasswordAuthenticator(credentials));
     }
 
     public BitbucketCloudApiClient(boolean enableCache, int teamCacheDuration, int repositoriesCacheDuraction,
@@ -274,6 +283,15 @@ public class BitbucketCloudApiClient implements BitbucketApi {
             pullRequests.addAll(page.getValues());
         }
         return pullRequests;
+    }
+
+    @Deprecated
+    @CheckForNull
+    public String getLogin() {
+        if (authenticator != null) {
+            return authenticator.getId();
+        }
+        return null;
     }
 
     /**

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/BitbucketCloudApiClient.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/BitbucketCloudApiClient.java
@@ -615,7 +615,14 @@ public class BitbucketCloudApiClient implements BitbucketApi {
     public List<BitbucketCloudRepository> getRepositories(@CheckForNull UserRoleInRepository role)
             throws InterruptedException, IOException {
         StringBuilder cacheKey = new StringBuilder();
-        cacheKey.append(owner).append("::").append(authenticator.getId());
+        cacheKey.append(owner);
+
+        if (authenticator != null) {
+            cacheKey.append("::").append(authenticator.getId());
+        } else {
+            cacheKey.append("::<anonymous>");
+        }
+
         final UriTemplate template = UriTemplate.fromTemplate(V2_API_BASE_URL + "{/owner}{?role,page,pagelen}")
                 .set("owner", owner)
                 .set("pagelen", 50);

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/BitbucketCloudApiFactory.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/BitbucketCloudApiFactory.java
@@ -5,7 +5,8 @@ import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketApiFactory;
 import com.cloudbees.jenkins.plugins.bitbucket.endpoints.AbstractBitbucketEndpoint;
 import com.cloudbees.jenkins.plugins.bitbucket.endpoints.BitbucketCloudEndpoint;
 import com.cloudbees.jenkins.plugins.bitbucket.endpoints.BitbucketEndpointConfiguration;
-import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
+import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketAuthenticator;
+import com.cloudbees.jenkins.plugins.bitbucket.endpoints.BitbucketCloudEndpoint;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
@@ -20,7 +21,7 @@ public class BitbucketCloudApiFactory extends BitbucketApiFactory {
 
     @NonNull
     @Override
-    protected BitbucketApi create(@Nullable String serverUrl, @Nullable StandardUsernamePasswordCredentials credentials,
+    protected BitbucketApi create(@Nullable String serverUrl, @Nullable BitbucketAuthenticator authenticator,
                                   @NonNull String owner, @CheckForNull String repository) {
         AbstractBitbucketEndpoint endpoint = BitbucketEndpointConfiguration.get().findEndpoint(BitbucketCloudEndpoint.SERVER_URL);
         boolean enableCache = false;
@@ -33,6 +34,6 @@ public class BitbucketCloudApiFactory extends BitbucketApiFactory {
         }
         return new BitbucketCloudApiClient(
                 enableCache, teamCacheDuration, repositoriesCacheDuration,
-                owner, repository, credentials);
+                owner, repository, authenticator);
     }
 }

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/endpoints/AbstractBitbucketEndpoint.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/endpoints/AbstractBitbucketEndpoint.java
@@ -130,7 +130,7 @@ public abstract class AbstractBitbucketEndpoint extends AbstractDescribableImpl<
                 ),
                 CredentialsMatchers.allOf(
                         CredentialsMatchers.withId(credentialsId),
-                        AuthenticationTokens.matcher(BitbucketAuthenticator.class)
+                        AuthenticationTokens.matcher(BitbucketAuthenticator.authenticationContext(getServerUrl()))
                 )
         );
     }
@@ -142,7 +142,7 @@ public abstract class AbstractBitbucketEndpoint extends AbstractDescribableImpl<
      */
     @CheckForNull
     public BitbucketAuthenticator authenticator() {
-        return AuthenticationTokens.convert(BitbucketAuthenticator.class, credentials());
+        return AuthenticationTokens.convert(BitbucketAuthenticator.authenticationContext(getServerUrl()), credentials());
     }
 
     /**

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/endpoints/AbstractBitbucketEndpoint.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/endpoints/AbstractBitbucketEndpoint.java
@@ -128,7 +128,10 @@ public abstract class AbstractBitbucketEndpoint extends AbstractDescribableImpl<
                         ACL.SYSTEM,
                         URIRequirementBuilder.fromUri(getServerUrl()).build()
                 ),
-                CredentialsMatchers.withId(credentialsId)
+                CredentialsMatchers.allOf(
+                        CredentialsMatchers.withId(credentialsId),
+                        AuthenticationTokens.matcher(BitbucketAuthenticator.class)
+                )
         );
     }
 

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/endpoints/AbstractBitbucketEndpoint.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/endpoints/AbstractBitbucketEndpoint.java
@@ -23,14 +23,17 @@
  */
 package com.cloudbees.jenkins.plugins.bitbucket.endpoints;
 
+import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketAuthenticator;
 import com.cloudbees.plugins.credentials.CredentialsMatchers;
 import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.common.StandardCredentials;
 import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
 import com.cloudbees.plugins.credentials.domains.URIRequirementBuilder;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.model.AbstractDescribableImpl;
 import hudson.security.ACL;
+import jenkins.authentication.tokens.api.AuthenticationTokens;
 import jenkins.model.Jenkins;
 import org.apache.commons.lang.StringUtils;
 
@@ -47,7 +50,7 @@ public abstract class AbstractBitbucketEndpoint extends AbstractDescribableImpl<
     private final boolean manageHooks;
 
     /**
-     * The {@link StandardUsernamePasswordCredentials#getId()} of the credentials to use for auto-management of hooks.
+     * The {@link StandardCredentials#getId()} of the credentials to use for auto-management of hooks.
      */
     @CheckForNull
     private final String credentialsId;
@@ -56,7 +59,7 @@ public abstract class AbstractBitbucketEndpoint extends AbstractDescribableImpl<
      * Constructor.
      *
      * @param manageHooks   {@code true} if and only if Jenkins is supposed to auto-manage hooks for this end-point.
-     * @param credentialsId The {@link StandardUsernamePasswordCredentials#getId()} of the credentials to use for
+     * @param credentialsId The {@link StandardCredentials#getId()} of the credentials to use for
      *                      auto-management of hooks.
      */
     AbstractBitbucketEndpoint(boolean manageHooks, @CheckForNull String credentialsId) {
@@ -112,21 +115,31 @@ public abstract class AbstractBitbucketEndpoint extends AbstractDescribableImpl<
     }
 
     /**
-     * Looks up the {@link StandardUsernamePasswordCredentials} to use for auto-management of hooks.
+     * Looks up the {@link StandardCredentials} to use for auto-management of hooks.
      *
      * @return the credentials or {@code null}.
      */
     @CheckForNull
-    public StandardUsernamePasswordCredentials credentials() {
+    public StandardCredentials credentials() {
         return StringUtils.isBlank(credentialsId) ? null : CredentialsMatchers.firstOrNull(
                 CredentialsProvider.lookupCredentials(
-                        StandardUsernamePasswordCredentials.class,
+                        StandardCredentials.class,
                         Jenkins.getActiveInstance(),
                         ACL.SYSTEM,
                         URIRequirementBuilder.fromUri(getServerUrl()).build()
                 ),
                 CredentialsMatchers.withId(credentialsId)
         );
+    }
+
+    /**
+     * Retrieves the {@link BitbucketAuthenticator} to use for auto-management of hooks.
+     *
+     * @return the authenticator or {@code null}.
+     */
+    @CheckForNull
+    public BitbucketAuthenticator authenticator() {
+        return AuthenticationTokens.convert(BitbucketAuthenticator.class, credentials());
     }
 
     /**

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/endpoints/AbstractBitbucketEndpointDescriptor.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/endpoints/AbstractBitbucketEndpointDescriptor.java
@@ -23,15 +23,14 @@
  */
 package com.cloudbees.jenkins.plugins.bitbucket.endpoints;
 
-import com.cloudbees.plugins.credentials.CredentialsMatchers;
-import com.cloudbees.plugins.credentials.common.StandardCertificateCredentials;
+import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketAuthenticator;
 import com.cloudbees.plugins.credentials.common.StandardCredentials;
 import com.cloudbees.plugins.credentials.common.StandardListBoxModel;
-import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
 import com.cloudbees.plugins.credentials.domains.URIRequirementBuilder;
 import hudson.model.Descriptor;
 import hudson.security.ACL;
 import hudson.util.ListBoxModel;
+import jenkins.authentication.tokens.api.AuthenticationTokens;
 import jenkins.model.Jenkins;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
@@ -60,10 +59,7 @@ public abstract class AbstractBitbucketEndpointDescriptor extends Descriptor<Abs
                 jenkins,
                 StandardCredentials.class,
                 URIRequirementBuilder.fromUri(serverUrl).build(),
-                CredentialsMatchers.anyOf(
-                        CredentialsMatchers.instanceOf(StandardUsernamePasswordCredentials.class),
-                        CredentialsMatchers.instanceOf(StandardCertificateCredentials.class)
-                )
+                AuthenticationTokens.matcher(BitbucketAuthenticator.class)
         );
         return result;
     }

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/endpoints/AbstractBitbucketEndpointDescriptor.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/endpoints/AbstractBitbucketEndpointDescriptor.java
@@ -59,7 +59,7 @@ public abstract class AbstractBitbucketEndpointDescriptor extends Descriptor<Abs
                 jenkins,
                 StandardCredentials.class,
                 URIRequirementBuilder.fromUri(serverUrl).build(),
-                AuthenticationTokens.matcher(BitbucketAuthenticator.class)
+                AuthenticationTokens.matcher(BitbucketAuthenticator.authenticationContext(serverUrl))
         );
         return result;
     }

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/endpoints/AbstractBitbucketEndpointDescriptor.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/endpoints/AbstractBitbucketEndpointDescriptor.java
@@ -24,8 +24,9 @@
 package com.cloudbees.jenkins.plugins.bitbucket.endpoints;
 
 import com.cloudbees.plugins.credentials.CredentialsMatchers;
+import com.cloudbees.plugins.credentials.common.StandardCertificateCredentials;
+import com.cloudbees.plugins.credentials.common.StandardCredentials;
 import com.cloudbees.plugins.credentials.common.StandardListBoxModel;
-import com.cloudbees.plugins.credentials.common.StandardUsernameCredentials;
 import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
 import com.cloudbees.plugins.credentials.domains.URIRequirementBuilder;
 import hudson.model.Descriptor;
@@ -57,9 +58,12 @@ public abstract class AbstractBitbucketEndpointDescriptor extends Descriptor<Abs
         result.includeMatchingAs(
                 ACL.SYSTEM,
                 jenkins,
-                StandardUsernameCredentials.class,
+                StandardCredentials.class,
                 URIRequirementBuilder.fromUri(serverUrl).build(),
-                CredentialsMatchers.instanceOf(StandardUsernamePasswordCredentials.class)
+                CredentialsMatchers.anyOf(
+                        CredentialsMatchers.instanceOf(StandardUsernamePasswordCredentials.class),
+                        CredentialsMatchers.instanceOf(StandardCertificateCredentials.class)
+                )
         );
         return result;
     }

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/endpoints/BitbucketCloudEndpoint.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/endpoints/BitbucketCloudEndpoint.java
@@ -24,9 +24,8 @@
 package com.cloudbees.jenkins.plugins.bitbucket.endpoints;
 
 import com.cloudbees.jenkins.plugins.bitbucket.client.BitbucketCloudApiClient;
-import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
+import com.cloudbees.plugins.credentials.common.StandardCredentials;
 import com.damnhandy.uri.template.UriTemplate;
-
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
@@ -78,7 +77,7 @@ public class BitbucketCloudEndpoint extends AbstractBitbucketEndpoint {
      * @param teamCacheDuration How long, in minutes, to cache the team response.
      * @param repositoriesCacheDuration How long, in minutes, to cache the repositories response.
      * @param manageHooks   {@code true} if and only if Jenkins is supposed to auto-manage hooks for this end-point.
-     * @param credentialsId The {@link StandardUsernamePasswordCredentials#getId()} of the credentials to use for
+     * @param credentialsId The {@link StandardCredentials#getId()} of the credentials to use for
      *                      auto-management of hooks.
      */
     @DataBoundConstructor
@@ -139,7 +138,7 @@ public class BitbucketCloudEndpoint extends AbstractBitbucketEndpoint {
         /**
          * {@inheritDoc}
          */
-        @Nonnull
+        @NonNull
         @Override
         public String getDisplayName() {
             return Messages.BitbucketCloudEndpoint_displayName();

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/endpoints/BitbucketServerEndpoint.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/endpoints/BitbucketServerEndpoint.java
@@ -23,8 +23,8 @@
  */
 package com.cloudbees.jenkins.plugins.bitbucket.endpoints;
 
-import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
 import com.damnhandy.uri.template.UriTemplate;
+import com.cloudbees.plugins.credentials.common.StandardCredentials;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
@@ -79,7 +79,7 @@ public class BitbucketServerEndpoint extends AbstractBitbucketEndpoint {
      * @param displayName   Optional name to use to describe the end-point.
      * @param serverUrl     The URL of this Bitbucket Server
      * @param manageHooks   {@code true} if and only if Jenkins is supposed to auto-manage hooks for this end-point.
-     * @param credentialsId The {@link StandardUsernamePasswordCredentials#getId()} of the credentials to use for
+     * @param credentialsId The {@link StandardCredentials#getId()} of the credentials to use for
      *                      auto-management of hooks.
      */
     @DataBoundConstructor

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/filesystem/BitbucketSCMFileSystem.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/filesystem/BitbucketSCMFileSystem.java
@@ -114,7 +114,10 @@ public class BitbucketSCMFileSystem extends SCMFileSystem {
                                         ? Tasks.getDefaultAuthenticationOf((Queue.Task) context)
                                         : ACL.SYSTEM
                         ),
-                        CredentialsMatchers.withId(scanCredentialsId)
+                        CredentialsMatchers.allOf(
+                                CredentialsMatchers.withId(scanCredentialsId),
+                                AuthenticationTokens.matcher(BitbucketAuthenticator.class)
+                        )
                 );
             }
         }

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/filesystem/BitbucketSCMFileSystem.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/filesystem/BitbucketSCMFileSystem.java
@@ -31,9 +31,10 @@ import com.cloudbees.jenkins.plugins.bitbucket.BranchSCMHead;
 import com.cloudbees.jenkins.plugins.bitbucket.PullRequestSCMHead;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketApi;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketApiFactory;
+import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketAuthenticator;
 import com.cloudbees.plugins.credentials.CredentialsMatchers;
 import com.cloudbees.plugins.credentials.CredentialsProvider;
-import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
+import com.cloudbees.plugins.credentials.common.StandardCredentials;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
@@ -44,6 +45,7 @@ import hudson.model.queue.Tasks;
 import hudson.scm.SCM;
 import hudson.security.ACL;
 import java.io.IOException;
+import jenkins.authentication.tokens.api.AuthenticationTokens;
 import jenkins.scm.api.SCMFile;
 import jenkins.scm.api.SCMFileSystem;
 import jenkins.scm.api.SCMHead;
@@ -99,14 +101,14 @@ public class BitbucketSCMFileSystem extends SCMFileSystem {
             return null;
         }
         
-        private static StandardUsernamePasswordCredentials lookupScanCredentials(@CheckForNull Item context,
+        private static StandardCredentials lookupScanCredentials(@CheckForNull Item context,
                 @CheckForNull String scanCredentialsId) {
             if (Util.fixEmpty(scanCredentialsId) == null) {
                 return null;
             } else {
                 return CredentialsMatchers.firstOrNull(
                         CredentialsProvider.lookupCredentials(
-                                StandardUsernamePasswordCredentials.class,
+                                StandardCredentials.class,
                                 context,
                                 context instanceof Queue.Task
                                         ? Tasks.getDefaultAuthenticationOf((Queue.Task) context)
@@ -126,10 +128,12 @@ public class BitbucketSCMFileSystem extends SCMFileSystem {
             String owner = src.getRepoOwner();
             String repository = src.getRepository();
             String serverUrl = src.getServerUrl();
-            StandardUsernamePasswordCredentials credentials;
+            StandardCredentials credentials;
             credentials = lookupScanCredentials(src.getOwner(), credentialsId);
+
+            BitbucketAuthenticator authenticator = AuthenticationTokens.convert(BitbucketAuthenticator.class, credentials);
             
-            BitbucketApi apiClient = BitbucketApiFactory.newInstance(serverUrl, credentials, owner, repository);
+            BitbucketApi apiClient = BitbucketApiFactory.newInstance(serverUrl, authenticator, owner, repository);
             String ref;
             if (head instanceof BranchSCMHead) {
                 ref = head.getName();

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/filesystem/BitbucketSCMFileSystem.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/filesystem/BitbucketSCMFileSystem.java
@@ -102,7 +102,7 @@ public class BitbucketSCMFileSystem extends SCMFileSystem {
         }
         
         private static StandardCredentials lookupScanCredentials(@CheckForNull Item context,
-                @CheckForNull String scanCredentialsId) {
+                @CheckForNull String scanCredentialsId, String serverUrl) {
             if (Util.fixEmpty(scanCredentialsId) == null) {
                 return null;
             } else {
@@ -116,7 +116,7 @@ public class BitbucketSCMFileSystem extends SCMFileSystem {
                         ),
                         CredentialsMatchers.allOf(
                                 CredentialsMatchers.withId(scanCredentialsId),
-                                AuthenticationTokens.matcher(BitbucketAuthenticator.class)
+                                AuthenticationTokens.matcher(BitbucketAuthenticator.authenticationContext(serverUrl))
                         )
                 );
             }
@@ -132,9 +132,9 @@ public class BitbucketSCMFileSystem extends SCMFileSystem {
             String repository = src.getRepository();
             String serverUrl = src.getServerUrl();
             StandardCredentials credentials;
-            credentials = lookupScanCredentials(src.getOwner(), credentialsId);
+            credentials = lookupScanCredentials(src.getOwner(), credentialsId, serverUrl);
 
-            BitbucketAuthenticator authenticator = AuthenticationTokens.convert(BitbucketAuthenticator.class, credentials);
+            BitbucketAuthenticator authenticator = AuthenticationTokens.convert(BitbucketAuthenticator.authenticationContext(serverUrl), credentials);
             
             BitbucketApi apiClient = BitbucketApiFactory.newInstance(serverUrl, authenticator, owner, repository);
             String ref;

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/WebhookAutoRegisterListener.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/WebhookAutoRegisterListener.java
@@ -222,7 +222,7 @@ public class WebhookAutoRegisterListener extends ItemListener {
                         ? null
                         : BitbucketApiFactory.newInstance(
                                 endpoint.getServerUrl(),
-                                endpoint.credentials(),
+                                endpoint.authenticator(),
                                 source.getRepoOwner(),
                                 source.getRepository()
                         );

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/BitbucketServerAPIClient.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/BitbucketServerAPIClient.java
@@ -35,6 +35,7 @@ import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketRepositoryType;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketRequestException;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketTeam;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketWebHook;
+import com.cloudbees.jenkins.plugins.bitbucket.api.credentials.BitbucketUsernamePasswordAuthenticator;
 import com.cloudbees.jenkins.plugins.bitbucket.client.repository.UserRoleInRepository;
 import com.cloudbees.jenkins.plugins.bitbucket.endpoints.AbstractBitbucketEndpoint;
 import com.cloudbees.jenkins.plugins.bitbucket.endpoints.BitbucketEndpointConfiguration;
@@ -160,6 +161,12 @@ public class BitbucketServerAPIClient implements BitbucketApi {
     private HttpClientContext context;
 
     private final String baseURL;
+
+    @Deprecated
+    public BitbucketServerAPIClient(@NonNull String baseURL, @NonNull String owner, @CheckForNull String repositoryName,
+                                    @CheckForNull StandardUsernamePasswordCredentials credentials, boolean userCentric) {
+        this(baseURL, owner, repositoryName, new BitbucketUsernamePasswordAuthenticator(credentials), userCentric);
+    }
 
     public BitbucketServerAPIClient(@NonNull String baseURL, @NonNull String owner, @CheckForNull String repositoryName,
                                     @CheckForNull BitbucketAuthenticator authenticator, boolean userCentric) {

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/BitbucketServerAPIClient.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/BitbucketServerAPIClient.java
@@ -165,7 +165,7 @@ public class BitbucketServerAPIClient implements BitbucketApi {
     @Deprecated
     public BitbucketServerAPIClient(@NonNull String baseURL, @NonNull String owner, @CheckForNull String repositoryName,
                                     @CheckForNull StandardUsernamePasswordCredentials credentials, boolean userCentric) {
-        this(baseURL, owner, repositoryName, new BitbucketUsernamePasswordAuthenticator(credentials), userCentric);
+        this(baseURL, owner, repositoryName, credentials != null ? new BitbucketUsernamePasswordAuthenticator(credentials) : null, userCentric);
     }
 
     public BitbucketServerAPIClient(@NonNull String baseURL, @NonNull String owner, @CheckForNull String repositoryName,

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/BitbucketServerApiFactory.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/BitbucketServerApiFactory.java
@@ -2,8 +2,8 @@ package com.cloudbees.jenkins.plugins.bitbucket.server.client;
 
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketApi;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketApiFactory;
+import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketAuthenticator;
 import com.cloudbees.jenkins.plugins.bitbucket.endpoints.BitbucketCloudEndpoint;
-import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
@@ -19,11 +19,11 @@ public class BitbucketServerApiFactory extends BitbucketApiFactory {
 
     @NonNull
     @Override
-    protected BitbucketApi create(@Nullable String serverUrl, @Nullable StandardUsernamePasswordCredentials credentials,
+    protected BitbucketApi create(@Nullable String serverUrl, @Nullable BitbucketAuthenticator authenticator,
                                   @NonNull String owner, @CheckForNull String repository) {
         if(StringUtils.isBlank(serverUrl)){
             throw new IllegalArgumentException("serverUrl is required");
         }
-        return new BitbucketServerAPIClient(serverUrl, owner, repository, credentials, false);
+        return new BitbucketServerAPIClient(serverUrl, owner, repository, authenticator, false);
     }
 }

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketAuthenticatorTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketAuthenticatorTest.java
@@ -38,25 +38,21 @@ public class BitbucketAuthenticatorTest {
         AuthenticationTokenContext httpContext = BitbucketAuthenticator.authenticationContext("http://git.example.com");
         AuthenticationTokenContext httpsContext = BitbucketAuthenticator.authenticationContext("https://git.example.com");
 
-        assertThat(nullCloudContext.mustHave(BitbucketAuthenticator.PROTOCOL_PURPOSE,
-                BitbucketAuthenticator.PROTOCOL_HTTPS), is(true));
-        assertThat(nullCloudContext.mustHave(BitbucketAuthenticator.INSTANCE_TYPE_PURPOSE,
-                BitbucketAuthenticator.INSTANCE_TYPE_CLOUD), is(true));
+        assertThat(nullCloudContext.mustHave(BitbucketAuthenticator.SCHEME, "https"), is(true));
+        assertThat(nullCloudContext.mustHave(BitbucketAuthenticator.BITBUCKET_INSTANCE_TYPE,
+                BitbucketAuthenticator.BITBUCKET_INSTANCE_TYPE_CLOUD), is(true));
 
-        assertThat(cloudContext.mustHave(BitbucketAuthenticator.PROTOCOL_PURPOSE,
-                BitbucketAuthenticator.PROTOCOL_HTTPS), is(true));
-        assertThat(cloudContext.mustHave(BitbucketAuthenticator.INSTANCE_TYPE_PURPOSE,
-                BitbucketAuthenticator.INSTANCE_TYPE_CLOUD), is(true));
+        assertThat(cloudContext.mustHave(BitbucketAuthenticator.SCHEME, "https"), is(true));
+        assertThat(cloudContext.mustHave(BitbucketAuthenticator.BITBUCKET_INSTANCE_TYPE,
+                BitbucketAuthenticator.BITBUCKET_INSTANCE_TYPE_CLOUD), is(true));
 
-        assertThat(httpContext.mustHave(BitbucketAuthenticator.PROTOCOL_PURPOSE,
-                BitbucketAuthenticator.PROTOCOL_HTTP), is(true));
-        assertThat(httpContext.mustHave(BitbucketAuthenticator.INSTANCE_TYPE_PURPOSE,
-                BitbucketAuthenticator.INSTANCE_TYPE_SERVER), is(true));
+        assertThat(httpContext.mustHave(BitbucketAuthenticator.SCHEME, "http"), is(true));
+        assertThat(httpContext.mustHave(BitbucketAuthenticator.BITBUCKET_INSTANCE_TYPE,
+                BitbucketAuthenticator.BITBUCKET_INSTANCE_TYPE_SERVER), is(true));
 
-        assertThat(httpsContext.mustHave(BitbucketAuthenticator.PROTOCOL_PURPOSE,
-                BitbucketAuthenticator.PROTOCOL_HTTPS), is(true));
-        assertThat(httpsContext.mustHave(BitbucketAuthenticator.INSTANCE_TYPE_PURPOSE,
-                BitbucketAuthenticator.INSTANCE_TYPE_SERVER), is(true));
+        assertThat(httpsContext.mustHave(BitbucketAuthenticator.SCHEME, "https"), is(true));
+        assertThat(httpsContext.mustHave(BitbucketAuthenticator.BITBUCKET_INSTANCE_TYPE,
+                BitbucketAuthenticator.BITBUCKET_INSTANCE_TYPE_SERVER), is(true));
     }
 
     @Test

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketAuthenticatorTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketAuthenticatorTest.java
@@ -1,0 +1,102 @@
+package com.cloudbees.jenkins.plugins.bitbucket;
+
+import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketAuthenticator;
+import com.cloudbees.jenkins.plugins.bitbucket.endpoints.BitbucketCloudEndpoint;
+import com.cloudbees.plugins.credentials.Credentials;
+import com.cloudbees.plugins.credentials.CredentialsMatchers;
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.cloudbees.plugins.credentials.impl.CertificateCredentialsImpl;
+import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Collections;
+import java.util.List;
+import jenkins.authentication.tokens.api.AuthenticationTokenContext;
+import jenkins.authentication.tokens.api.AuthenticationTokens;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+
+public class BitbucketAuthenticatorTest {
+
+    @ClassRule
+    public static JenkinsRule j = new JenkinsRule();
+    @Rule
+    public TestName currentTestName = new TestName();
+
+    @Test
+    public void authenticationContextTest() {
+        AuthenticationTokenContext nullCloudContext = BitbucketAuthenticator.authenticationContext(null);
+        AuthenticationTokenContext cloudContext = BitbucketAuthenticator.authenticationContext(BitbucketCloudEndpoint.SERVER_URL);
+        AuthenticationTokenContext httpContext = BitbucketAuthenticator.authenticationContext("http://git.example.com");
+        AuthenticationTokenContext httpsContext = BitbucketAuthenticator.authenticationContext("https://git.example.com");
+
+        assertThat(nullCloudContext.mustHave(BitbucketAuthenticator.PROTOCOL_PURPOSE,
+                BitbucketAuthenticator.PROTOCOL_HTTPS), is(true));
+        assertThat(nullCloudContext.mustHave(BitbucketAuthenticator.INSTANCE_TYPE_PURPOSE,
+                BitbucketAuthenticator.INSTANCE_TYPE_CLOUD), is(true));
+
+        assertThat(cloudContext.mustHave(BitbucketAuthenticator.PROTOCOL_PURPOSE,
+                BitbucketAuthenticator.PROTOCOL_HTTPS), is(true));
+        assertThat(cloudContext.mustHave(BitbucketAuthenticator.INSTANCE_TYPE_PURPOSE,
+                BitbucketAuthenticator.INSTANCE_TYPE_CLOUD), is(true));
+
+        assertThat(httpContext.mustHave(BitbucketAuthenticator.PROTOCOL_PURPOSE,
+                BitbucketAuthenticator.PROTOCOL_HTTP), is(true));
+        assertThat(httpContext.mustHave(BitbucketAuthenticator.INSTANCE_TYPE_PURPOSE,
+                BitbucketAuthenticator.INSTANCE_TYPE_SERVER), is(true));
+
+        assertThat(httpsContext.mustHave(BitbucketAuthenticator.PROTOCOL_PURPOSE,
+                BitbucketAuthenticator.PROTOCOL_HTTPS), is(true));
+        assertThat(httpsContext.mustHave(BitbucketAuthenticator.INSTANCE_TYPE_PURPOSE,
+                BitbucketAuthenticator.INSTANCE_TYPE_SERVER), is(true));
+    }
+
+    @Test
+    public void passwordCredentialsTest() {
+        List<Credentials> list = Collections.<Credentials>singletonList(new UsernamePasswordCredentialsImpl(
+                        CredentialsScope.SYSTEM, "dummy", "dummy", "user", "pass"));
+        AuthenticationTokenContext ctx = BitbucketAuthenticator.authenticationContext((null));
+        Credentials c = CredentialsMatchers.firstOrNull(list, AuthenticationTokens.matcher(ctx));
+        assertThat(c, notNullValue());
+        assertThat(AuthenticationTokens.convert(ctx, c), notNullValue());
+    }
+
+    @Test
+    public void certCredentialsTest() {
+        List<Credentials> list = Collections.<Credentials>singletonList(new CertificateCredentialsImpl(
+                CredentialsScope.SYSTEM, "dummy", "dummy", "password", new DummyKeyStoreSource()));
+
+        AuthenticationTokenContext ctx = BitbucketAuthenticator.authenticationContext(null);
+        Credentials c = CredentialsMatchers.firstOrNull(list, AuthenticationTokens.matcher(ctx));
+        assertThat(c, nullValue());
+
+        ctx = BitbucketAuthenticator.authenticationContext("http://git.example.com");
+        c = CredentialsMatchers.firstOrNull(list, AuthenticationTokens.matcher(ctx));
+        assertThat(c, nullValue());
+
+        ctx = BitbucketAuthenticator.authenticationContext("https://git.example.com");
+        c = CredentialsMatchers.firstOrNull(list, AuthenticationTokens.matcher(ctx));
+        assertThat(c, notNullValue());
+        assertThat(AuthenticationTokens.convert(ctx, c), notNullValue());
+    }
+
+    private static class DummyKeyStoreSource extends CertificateCredentialsImpl.KeyStoreSource {
+        @NonNull
+        @Override
+        public byte[] getKeyStoreBytes() { return new byte[0]; }
+
+        @Override
+        public long getKeyStoreLastModified() { return 0; }
+
+        @Override
+        public boolean isSnapshotSource() { return true; }
+    }
+}

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketMockApiFactory.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketMockApiFactory.java
@@ -2,7 +2,7 @@ package com.cloudbees.jenkins.plugins.bitbucket;
 
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketApi;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketApiFactory;
-import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
+import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketAuthenticator;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
@@ -41,7 +41,7 @@ public class BitbucketMockApiFactory extends BitbucketApiFactory {
 
     @NonNull
     @Override
-    protected BitbucketApi create(@Nullable String serverUrl, @Nullable StandardUsernamePasswordCredentials credentials,
+    protected BitbucketApi create(@Nullable String serverUrl, @Nullable BitbucketAuthenticator authenticator,
                                   @NonNull String owner, @CheckForNull String repository) {
         return mocks.get(StringUtils.defaultString(serverUrl, NULL));
     }

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/UriResolverTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/UriResolverTest.java
@@ -67,7 +67,7 @@ public class UriResolverTest {
                 "user2",
                 "repo2"
         ));
-        api = new BitbucketServerAPIClient("http://devtools.test:1234/git/web/", "test", null, null, false);
+        api = new BitbucketServerAPIClient("http://devtools.test:1234/git/web/", "test", null, (BitbucketAuthenticator) null, false);
         assertEquals("http://devtools.test:1234/git/web/scm/user2/repo2.git", api.getRepositoryUri(
                 BitbucketRepositoryType.GIT,
                 BitbucketRepositoryProtocol.HTTP,

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/UriResolverTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/UriResolverTest.java
@@ -24,6 +24,7 @@
 package com.cloudbees.jenkins.plugins.bitbucket;
 
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketApi;
+import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketAuthenticator;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketRepositoryProtocol;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketRepositoryType;
 import com.cloudbees.jenkins.plugins.bitbucket.client.BitbucketCloudApiClient;
@@ -35,7 +36,7 @@ public class UriResolverTest {
 
     @Test
     public void httpUriResolver() throws Exception {
-        BitbucketApi api = new BitbucketCloudApiClient(false, 0, 0, "test", null, null);
+        BitbucketApi api = new BitbucketCloudApiClient(false, 0, 0, "test", null, (BitbucketAuthenticator) null);
         assertEquals("https://bitbucket.org/user1/repo1.git", api.getRepositoryUri(
                 BitbucketRepositoryType.GIT,
                 BitbucketRepositoryProtocol.HTTP,
@@ -50,7 +51,7 @@ public class UriResolverTest {
                 "user1",
                 "repo1"
         ));
-        api = new BitbucketServerAPIClient("http://localhost:1234", "test", null, null, false);
+        api = new BitbucketServerAPIClient("http://localhost:1234", "test", null, (BitbucketAuthenticator) null, false);
         assertEquals("http://localhost:1234/scm/user2/repo2.git", api.getRepositoryUri(
                 BitbucketRepositoryType.GIT,
                 BitbucketRepositoryProtocol.HTTP,
@@ -58,7 +59,7 @@ public class UriResolverTest {
                 "user2",
                 "repo2"
         ));
-        api = new BitbucketServerAPIClient("http://192.168.1.100:1234", "test", null, null, false);
+        api = new BitbucketServerAPIClient("http://192.168.1.100:1234", "test", null, (BitbucketAuthenticator) null, false);
         assertEquals("http://192.168.1.100:1234/scm/user2/repo2.git", api.getRepositoryUri(
                 BitbucketRepositoryType.GIT,
                 BitbucketRepositoryProtocol.HTTP,
@@ -78,7 +79,7 @@ public class UriResolverTest {
 
     @Test
     public void sshUriResolver() throws Exception {
-        BitbucketApi api = new BitbucketCloudApiClient(false, 0, 0, "test", null, null);
+        BitbucketApi api = new BitbucketCloudApiClient(false, 0, 0, "test", null, (BitbucketAuthenticator) null);
         assertEquals("git@bitbucket.org:user1/repo1.git", api.getRepositoryUri(
                 BitbucketRepositoryType.GIT,
                 BitbucketRepositoryProtocol.SSH,
@@ -93,7 +94,7 @@ public class UriResolverTest {
                 "user1",
                 "repo1"
         ));
-        api = new BitbucketServerAPIClient("http://localhost:1234", "test", null, null, false);
+        api = new BitbucketServerAPIClient("http://localhost:1234", "test", null, (BitbucketAuthenticator) null, false);
         assertEquals("ssh://git@localhost:7999/user2/repo2.git", api.getRepositoryUri(
                 BitbucketRepositoryType.GIT,
                 BitbucketRepositoryProtocol.SSH,
@@ -101,7 +102,7 @@ public class UriResolverTest {
                 "user2",
                 "repo2"
         ));
-        api = new BitbucketServerAPIClient("http://myserver", "test", null, null, false);
+        api = new BitbucketServerAPIClient("http://myserver", "test", null, (BitbucketAuthenticator) null, false);
         assertEquals("ssh://git@myserver:7999/user2/repo2.git", api.getRepositoryUri(
                 BitbucketRepositoryType.GIT,
                 BitbucketRepositoryProtocol.SSH,
@@ -113,13 +114,13 @@ public class UriResolverTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void httpUriResolverIllegalStates() throws Exception {
-        new BitbucketServerAPIClient("http://localhost:1234", "test", null, null, false)
+        new BitbucketServerAPIClient("http://localhost:1234", "test", null, (BitbucketAuthenticator) null, false)
                 .getRepositoryUri(BitbucketRepositoryType.MERCURIAL, BitbucketRepositoryProtocol.HTTP, null, "user1", "repo1");
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void sshUriResolverIllegalStates() throws Exception {
-        new BitbucketServerAPIClient("http://localhost:1234", "test", null, null, false)
+        new BitbucketServerAPIClient("http://localhost:1234", "test", null, (BitbucketAuthenticator) null, false)
                 .getRepositoryUri(BitbucketRepositoryType.MERCURIAL, BitbucketRepositoryProtocol.SSH, null, "user1",
                         "repo1");
     }

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/client/BitbucketIntegrationClientFactory.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/client/BitbucketIntegrationClientFactory.java
@@ -24,6 +24,7 @@
 package com.cloudbees.jenkins.plugins.bitbucket.client;
 
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketApi;
+import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketAuthenticator;
 import com.cloudbees.jenkins.plugins.bitbucket.endpoints.BitbucketCloudEndpoint;
 import com.cloudbees.jenkins.plugins.bitbucket.server.client.BitbucketServerAPIClient;
 import java.io.IOException;
@@ -51,7 +52,7 @@ public class BitbucketIntegrationClientFactory {
         private final String payloadRootPath;
 
         public BitbucketServerIntegrationClient(String payloadRootPath, String baseURL, String owner, String repositoryName) {
-            super(baseURL, owner, repositoryName, null, false);
+            super(baseURL, owner, repositoryName, (BitbucketAuthenticator) null, false);
 
             if (payloadRootPath == null) {
                 this.payloadRootPath = PAYLOAD_RESOURCE_ROOTPATH;
@@ -83,7 +84,7 @@ public class BitbucketIntegrationClientFactory {
         private final String payloadRootPath;
 
         public BitbucketCouldIntegrationClient(String payloadRootPath, String owner, String repositoryName) {
-            super(false, 0, 0, owner, repositoryName, null);
+            super(false, 0, 0, owner, repositoryName, (BitbucketAuthenticator) null);
 
             if (payloadRootPath == null) {
                 this.payloadRootPath = PAYLOAD_RESOURCE_ROOTPATH;


### PR DESCRIPTION
Opening for initial feedback.

This is based on #92 and moves to using the AuthenticationTokens plugin as was suggested in a couple of other pull-requests (#69, #68, and #94). This also includes support for client certificates like #94.
