### PR TITLE
JENKINS-47978# Fix handling branch name with '/'

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/BitbucketCloudApiClient.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/BitbucketCloudApiClient.java
@@ -836,7 +836,7 @@ public class BitbucketCloudApiClient implements BitbucketApi {
         String url = UriTemplate.fromTemplate(REPO_URL_TEMPLATE + "/src{/branchOrHash,path}")
                 .set("owner", owner)
                 .set("repo", repositoryName)
-                .set("branchOrHash", parent.getRef())
+                .set("branchOrHash", parent.getHash())
                 .set("path", parent.getPath())
                 .expand();
         List<SCMFile> result = new ArrayList<>();
@@ -863,7 +863,7 @@ public class BitbucketCloudApiClient implements BitbucketApi {
         String url = UriTemplate.fromTemplate(REPO_URL_TEMPLATE + "/src{/branchOrHash,path}")
                 .set("owner", owner)
                 .set("repo", repositoryName)
-                .set("branchOrHash", file.getRef())
+                .set("branchOrHash", file.getHash())
                 .set("path", file.getPath())
                 .expand();
         return getRequestAsInputStream(url);

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/repository/BitbucketRepositorySource.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/repository/BitbucketRepositorySource.java
@@ -26,6 +26,7 @@ package com.cloudbees.jenkins.plugins.bitbucket.client.repository;
 
 import com.cloudbees.jenkins.plugins.bitbucket.filesystem.BitbucketSCMFile;
 import java.util.List;
+import java.util.Map;
 import jenkins.scm.api.SCMFile;
 import org.codehaus.jackson.annotate.JsonCreator;
 import org.codehaus.jackson.annotate.JsonIgnore;
@@ -34,13 +35,15 @@ import org.codehaus.jackson.annotate.JsonProperty;
 public class BitbucketRepositorySource {
     private final String path;
     private final String type;
+    private final String hash;
     private final List<String> attributes;
 
     @JsonCreator
-    public BitbucketRepositorySource(@JsonProperty("path") String path, @JsonProperty("type") String type, @JsonProperty("attributes") List<String> attributes) {
+    public BitbucketRepositorySource(@JsonProperty("path") String path, @JsonProperty("type") String type, @JsonProperty("attributes") List<String> attributes, @JsonProperty("commit") Map commit) {
         this.path = path;
         this.type = type;
         this.attributes = attributes;
+        this.hash = (String) commit.get("hash");
     }
 
     @JsonProperty("path")
@@ -56,6 +59,11 @@ public class BitbucketRepositorySource {
     @JsonProperty("attributes")
     public List<String> getAttributes() {
         return attributes;
+    }
+
+    @JsonIgnore
+    public String getHash() {
+        return hash;
     }
 
     @JsonIgnore
@@ -77,6 +85,6 @@ public class BitbucketRepositorySource {
                 }
             }
         }
-        return new BitbucketSCMFile(parent, path, fileType);
+        return new BitbucketSCMFile(parent, path, fileType, hash);
     }
 }

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/filesystem/BitbucketSCMFile.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/filesystem/BitbucketSCMFile.java
@@ -34,28 +34,44 @@ import jenkins.scm.api.SCMFile;
 public class BitbucketSCMFile  extends SCMFile {
 
 	private final BitbucketApi api;
-	private final String ref;
+	private  String ref;
 	private final String hash;
 	
 	public String getRef() {
 		return ref;
 	}
 
+	public void setRef(String ref) {
+		this.ref = ref;
+	}
+
+	@Deprecated
 	public BitbucketSCMFile(BitbucketSCMFileSystem bitBucketSCMFileSystem,
 							BitbucketApi api,
-							String ref, String rev) {
+							String ref) {
+		this(bitBucketSCMFileSystem, api, ref, null);
+	}
+
+	public BitbucketSCMFile(BitbucketSCMFileSystem bitBucketSCMFileSystem,
+							BitbucketApi api,
+							String ref, String hash) {
 		super();
 		type(Type.DIRECTORY);
 		this.api = api;
 		this.ref = ref;
-		this.hash = rev;
+		this.hash = hash;
 	}
-	
-    public BitbucketSCMFile(@NonNull BitbucketSCMFile parent, String name, Type type, String rev) {
+
+	@Deprecated
+	public BitbucketSCMFile(@NonNull BitbucketSCMFile parent, String name, Type type) {
+		this(parent, name, type, null);
+	}
+
+	public BitbucketSCMFile(@NonNull BitbucketSCMFile parent, String name, Type type, String hash) {
     	super(parent, name);
     	this.api = parent.api;
     	this.ref = parent.ref;
-    	this.hash = rev;
+    	this.hash = hash;
     	type(type);
     }
 

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/filesystem/BitbucketSCMFile.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/filesystem/BitbucketSCMFile.java
@@ -33,34 +33,36 @@ import jenkins.scm.api.SCMFile;
 
 public class BitbucketSCMFile  extends SCMFile {
 
-	private BitbucketApi api;
-	private String ref;
+	private final BitbucketApi api;
+	private final String ref;
+	private final String hash;
 	
 	public String getRef() {
 		return ref;
 	}
 
-	public void setRef(String ref) {
-		this.ref = ref;
-	}
-
 	public BitbucketSCMFile(BitbucketSCMFileSystem bitBucketSCMFileSystem,
 							BitbucketApi api,
-							String ref) {
+							String ref, String rev) {
 		super();
 		type(Type.DIRECTORY);
 		this.api = api;
 		this.ref = ref;
+		this.hash = rev;
 	}
 	
-    public BitbucketSCMFile(@NonNull BitbucketSCMFile parent, String name, Type type) {
+    public BitbucketSCMFile(@NonNull BitbucketSCMFile parent, String name, Type type, String rev) {
     	super(parent, name);
     	this.api = parent.api;
     	this.ref = parent.ref;
+    	this.hash = rev;
     	type(type);
-    	
     }
-    
+
+	public String getHash() {
+		return hash;
+	}
+
 	@Override
 	@NonNull
 	public Iterable<SCMFile> children() throws IOException,
@@ -91,7 +93,7 @@ public class BitbucketSCMFile  extends SCMFile {
 	@Override
 	@NonNull
 	protected SCMFile newChild(String name, boolean assumeIsDirectory) {
-		return new BitbucketSCMFile(this, name, assumeIsDirectory?Type.DIRECTORY:Type.REGULAR_FILE);
+		return new BitbucketSCMFile(this, name, assumeIsDirectory?Type.DIRECTORY:Type.REGULAR_FILE, hash);
 
 	}
 

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/filesystem/BitbucketSCMFileSystem.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/filesystem/BitbucketSCMFileSystem.java
@@ -75,7 +75,7 @@ public class BitbucketSCMFileSystem extends SCMFileSystem {
     @NonNull
     @Override
     public SCMFile getRoot() {
-        return new BitbucketSCMFile(this, api, ref);
+        return new BitbucketSCMFile(this, api, ref, getRevision().toString());
     }
 
     @Extension

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/filesystem/BitbucketSCMFileSystem.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/filesystem/BitbucketSCMFileSystem.java
@@ -75,7 +75,8 @@ public class BitbucketSCMFileSystem extends SCMFileSystem {
     @NonNull
     @Override
     public SCMFile getRoot() {
-        return new BitbucketSCMFile(this, api, ref, getRevision().toString());
+        SCMRevision revision = getRevision();
+        return new BitbucketSCMFile(this, api, ref, revision == null ? null : revision.toString());
     }
 
     @Extension

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/BitbucketServerAPIClient.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/BitbucketServerAPIClient.java
@@ -836,7 +836,9 @@ public class BitbucketServerAPIClient implements BitbucketApi {
                 fileType = SCMFile.Type.DIRECTORY;
             }
             if(components.size() > 0 && fileType != null){
-                files.add(new BitbucketSCMFile(parent, components.get(0), fileType));
+                // revision is set to null as fetched values from server API do not give us revision hash
+                // Later on hash is not needed anyways when file content is fetched from server API
+                files.add(new BitbucketSCMFile(parent, components.get(0), fileType, null));
             }
         }
     }

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/BitbucketServerAPIClient.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/BitbucketServerAPIClient.java
@@ -59,6 +59,7 @@ import java.io.InputStream;
 import java.net.InetSocketAddress;
 import java.net.MalformedURLException;
 import java.net.Proxy;
+import java.net.URI;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -641,6 +642,11 @@ public class BitbucketServerAPIClient implements BitbucketApi {
         }
     }
 
+    /**
+     * Create HttpClient from given host/port
+     * @param host must be of format: scheme://host:port. e.g. http://localhost:7990
+     * @return CloseableHttpClient
+     */
     private CloseableHttpClient getHttpClient(String host) {
         HttpClientBuilder httpClientBuilder = HttpClientBuilder.create();
 
@@ -703,7 +709,9 @@ public class BitbucketServerAPIClient implements BitbucketApi {
     }
 
     private static String getMethodHost(HttpRequestBase method) {
-        return method.getURI().getHost();
+        URI uri = method.getURI();
+        String scheme = uri.getScheme() == null ? "http" : uri.getScheme();
+        return scheme + "://" + uri.getAuthority();
     }
 
     private String postRequest(String path, List<? extends NameValuePair> params) throws IOException {


### PR DESCRIPTION
Bitbucket Cloud 2.0 API to get source (file/directory) content should be in context of revision hash and not branch name. 

`https://api.bitbucket.org/2.0/repositories/owner/repository/src/{node}/{path}`

I checked with BB cloud API team, the node parameter could be simple branch name but not all. Safe to use hash to have it work in all cases.

cc: @stephenc 