### PR TITLE
[JENKINS-49295] Proper template pattern for readTrusted

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/BitbucketServerAPIClient.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/BitbucketServerAPIClient.java
@@ -117,7 +117,7 @@ public class BitbucketServerAPIClient implements BitbucketApi {
     private static final String API_BRANCHES_PATH = API_REPOSITORY_PATH + "/branches{?start,limit}";
     private static final String API_PULL_REQUESTS_PATH = API_REPOSITORY_PATH + "/pull-requests{?start,limit}";
     private static final String API_PULL_REQUEST_PATH = API_REPOSITORY_PATH + "/pull-requests/{id}";
-    private static final String API_BROWSE_PATH = API_REPOSITORY_PATH + "/browse{/path}{?at}";
+    private static final String API_BROWSE_PATH = API_REPOSITORY_PATH + "/browse/{+path}{?at}";
     private static final String API_COMMITS_PATH = API_REPOSITORY_PATH + "/commits{/hash}";
     private static final String API_PROJECT_PATH = API_BASE_PATH + "/projects/{owner}";
     private static final String API_COMMIT_COMMENT_PATH = API_REPOSITORY_PATH + "/commits{/hash}/comments";


### PR DESCRIPTION
The pattern {/path} will convert slashes in %2F.
In Bitbucket server cases we don't want this kind of conversion.

So {+path} will keep the slashes properly.