### PR TITLE
[FIX JENKINS-47958] Filter closed Hg branches out

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/BitbucketCloudApiClient.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/BitbucketCloudApiClient.java
@@ -833,7 +833,7 @@ public class BitbucketCloudApiClient implements BitbucketApi {
         // Filter the inactive branches out
         List<BitbucketCloudBranch> activeBranches = new ArrayList<>();
         for (BitbucketCloudBranch branch: branches) {
-            if (branch.getIsActive()) {
+            if (branch.isActive()) {
                 activeBranches.add(branch);
             }
         }

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/BitbucketCloudApiClient.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/BitbucketCloudApiClient.java
@@ -829,7 +829,16 @@ public class BitbucketCloudApiClient implements BitbucketApi {
                     new TypeReference<BitbucketCloudPage<BitbucketCloudBranch>>(){});
             branches.addAll(page.getValues());
         }
-        return branches;
+
+        // Filter the inactive branches out
+        List<BitbucketCloudBranch> activeBranches = new ArrayList<>();
+        for (BitbucketCloudBranch branch: branches) {
+            if (branch.getIsActive()) {
+                activeBranches.add(branch);
+            }
+        }
+
+        return activeBranches;
     }
 
     public Iterable<SCMFile> getDirectoryContent(final BitbucketSCMFile parent) throws IOException, InterruptedException {

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/branch/BitbucketCloudBranch.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/branch/BitbucketCloudBranch.java
@@ -85,7 +85,7 @@ public class BitbucketCloudBranch implements BitbucketBranch {
         return dateInMillis;
     }
 
-    public boolean getIsActive() {
+    public boolean isActive() {
         return isActive;
     }
 


### PR DESCRIPTION
For Hg repositories, Bitbucket returns all branches, including the closed/inactive ones.
To filter the closed branches out, we have a look at the 'heads' property in the json response:
- Branches with non-empty heads are active.
- Branches with empty heads are inactive.
- On branches from git repositories heads is null. They all are active.