### PR TITLE
[JENKINS-49640] Do not mark builds in NOT_BUILT state as failed

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketBuildStatusNotifications.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketBuildStatusNotifications.java
@@ -25,6 +25,7 @@ package com.cloudbees.jenkins.plugins.bitbucket;
 
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketApi;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketBuildStatus;
+import com.cloudbees.jenkins.plugins.bitbucket.client.BitbucketCloudApiClient;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.FilePath;
@@ -104,6 +105,10 @@ public class BitbucketBuildStatusNotifications {
         } else if (Result.FAILURE.equals(result)) {
             statusDescription = StringUtils.defaultIfBlank(buildDescription, "There was a failure building this commit.");
             state = "FAILED";
+        } else if (Result.NOT_BUILT.equals(result)) {
+            // Bitbucket Cloud and Server support different build states.
+            state = (bitbucket instanceof BitbucketCloudApiClient) ? "STOPPED" : "SUCCESSFUL";
+            statusDescription = StringUtils.defaultIfBlank(buildDescription, "This commit was not built (probably the build was skipped)");
         } else if (result != null) { // ABORTED etc.
             statusDescription = StringUtils.defaultIfBlank(buildDescription, "Something is wrong with the build of this commit.");
             state = "FAILED";


### PR DESCRIPTION
This PR is about marking not built Jenkins builds as not failed but instead succeeded in Bitbucket. Unfortunately Bitbucket has only 3 states (SUCCESS, FAILURE and INPROGRESS) so therefore I decided to map NOT_BUILT to SUCCESS.

Similar solution was as well taken in the Stash Notifier Plugin: https://github.com/jenkinsci/stashnotifier-plugin/pull/116