### PR TITLE
fix JENKINS-47617 CHANGE_BRANCH should return source branch name

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource.java
@@ -666,7 +666,7 @@ public class BitbucketSCMSource extends SCMSource {
                                 repoOwner,
                                 repository,
                                 repositoryType,
-                                branchName,
+                                pull.getSource().getBranch().getName(),
                                 pull,
                                 originOf(pullRepoOwner, pullRepository),
                                 strategy

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/PullRequestHookProcessor.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/PullRequestHookProcessor.java
@@ -205,7 +205,7 @@ public class PullRequestHookProcessor extends HookProcessor {
                                         src.getRepoOwner(),
                                         src.getRepository(),
                                         type,
-                                        branchName,
+                                        pull.getSource().getBranch().getName(),
                                         pull,
                                         headOrigin,
                                         strategy


### PR DESCRIPTION
CHANGE_BRANCH is correct on bitbucket cloud but not bitbucket server, maybe a typo in origin PR #63  ? cc @zigarn for review

CHANGE_BRANCH is set in branch-api-plugin from getOriginName() 

   ```
   if (head instanceof ChangeRequestSCMHead2) {
      envs.putIfNotNull("CHANGE_BRANCH", ((ChangeRequestSCMHead2) head).getOriginName());
   }
   ```