### PR TITLE
JENKINS-47283: Use more information from clone links when determining SCM URLs.

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketGitSCMBuilder.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketGitSCMBuilder.java
@@ -41,8 +41,6 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Util;
 import hudson.plugins.git.GitSCM;
 import hudson.plugins.git.browser.BitbucketWeb;
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -173,15 +171,6 @@ public class BitbucketGitSCMBuilder extends GitSCMBuilder<BitbucketGitSCMBuilder
         BitbucketRepositoryProtocol protocol = credentials instanceof SSHUserPrivateKey
                 ? BitbucketRepositoryProtocol.SSH
                 : BitbucketRepositoryProtocol.HTTP;
-        String cloneLink = null;
-        if (protocol == BitbucketRepositoryProtocol.SSH) {
-            for (BitbucketHref link : cloneLinks()) {
-                if ("ssh".equals(link.getName())) {
-                    cloneLink = link.getHref();
-                    break;
-                }
-            }
-        }
         SCMHead h = head();
         String repoOwner;
         String repository;
@@ -194,6 +183,14 @@ public class BitbucketGitSCMBuilder extends GitSCMBuilder<BitbucketGitSCMBuilder
             // head instanceof BranchSCMHead
             repoOwner = scmSource.getRepoOwner();
             repository = scmSource.getRepository();
+        }
+
+        String cloneLink = null;
+        for (BitbucketHref link : cloneLinks()) {
+            if (protocol.getType().equals(link.getName())) {
+                cloneLink = link.getHref();
+                break;
+            }
         }
         withRemote(bitbucket.getRepositoryUri(
                 BitbucketRepositoryType.GIT,

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketGitSCMBuilder.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketGitSCMBuilder.java
@@ -170,22 +170,14 @@ public class BitbucketGitSCMBuilder extends GitSCMBuilder<BitbucketGitSCMBuilder
                         credentialsId(),
                         StandardCredentials.class
                 );
-        Integer protocolPortOverride = null;
         BitbucketRepositoryProtocol protocol = credentials instanceof SSHUserPrivateKey
                 ? BitbucketRepositoryProtocol.SSH
                 : BitbucketRepositoryProtocol.HTTP;
+        String cloneLink = null;
         if (protocol == BitbucketRepositoryProtocol.SSH) {
             for (BitbucketHref link : cloneLinks()) {
                 if ("ssh".equals(link.getName())) {
-                    // extract the port from this link and use that
-                    try {
-                        URI uri = new URI(link.getHref());
-                        if (uri.getPort() != -1) {
-                            protocolPortOverride = uri.getPort();
-                        }
-                    } catch (URISyntaxException e) {
-                        // ignore
-                    }
+                    cloneLink = link.getHref();
                     break;
                 }
             }
@@ -206,7 +198,7 @@ public class BitbucketGitSCMBuilder extends GitSCMBuilder<BitbucketGitSCMBuilder
         withRemote(bitbucket.getRepositoryUri(
                 BitbucketRepositoryType.GIT,
                 protocol,
-                protocolPortOverride,
+                cloneLink,
                 repoOwner,
                 repository));
         AbstractBitbucketEndpoint endpoint =
@@ -233,7 +225,7 @@ public class BitbucketGitSCMBuilder extends GitSCMBuilder<BitbucketGitSCMBuilder
                         bitbucket.getRepositoryUri(
                                 BitbucketRepositoryType.GIT,
                                 protocol,
-                                protocolPortOverride,
+                                cloneLink,
                                 scmSource().getRepoOwner(),
                                 scmSource().getRepository()),
                         "+refs/heads/" + name + ":refs/remotes/@{remote}/" + localName);

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketHgSCMBuilder.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketHgSCMBuilder.java
@@ -161,22 +161,14 @@ public class BitbucketHgSCMBuilder extends MercurialSCMBuilder<BitbucketHgSCMBui
                         credentialsId(),
                         StandardCredentials.class
                 );
-        Integer protocolPortOverride = null;
         BitbucketRepositoryProtocol protocol = credentials instanceof SSHUserPrivateKey
                 ? BitbucketRepositoryProtocol.SSH
                 : BitbucketRepositoryProtocol.HTTP;
+        String cloneLink = null;
         if (protocol == BitbucketRepositoryProtocol.SSH) {
             for (BitbucketHref link : cloneLinks()) {
                 if ("ssh".equals(link.getName())) {
-                    // extract the port from this link and use that
-                    try {
-                        URI uri = new URI(link.getHref());
-                        if (uri.getPort() != -1) {
-                            protocolPortOverride = uri.getPort();
-                        }
-                    } catch (URISyntaxException e) {
-                        // ignore
-                    }
+                    cloneLink = link.getHref();
                     break;
                 }
             }
@@ -197,7 +189,7 @@ public class BitbucketHgSCMBuilder extends MercurialSCMBuilder<BitbucketHgSCMBui
         withSource(bitbucket.getRepositoryUri(
                 BitbucketRepositoryType.MERCURIAL,
                 protocol,
-                protocolPortOverride,
+                cloneLink,
                 repoOwner,
                 repository));
         AbstractBitbucketEndpoint endpoint =

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketHgSCMBuilder.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketHgSCMBuilder.java
@@ -44,8 +44,6 @@ import hudson.plugins.mercurial.MercurialSCMBuilder;
 import hudson.plugins.mercurial.MercurialSCMSource;
 import hudson.plugins.mercurial.browser.BitBucket;
 import java.net.MalformedURLException;
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -164,15 +162,6 @@ public class BitbucketHgSCMBuilder extends MercurialSCMBuilder<BitbucketHgSCMBui
         BitbucketRepositoryProtocol protocol = credentials instanceof SSHUserPrivateKey
                 ? BitbucketRepositoryProtocol.SSH
                 : BitbucketRepositoryProtocol.HTTP;
-        String cloneLink = null;
-        if (protocol == BitbucketRepositoryProtocol.SSH) {
-            for (BitbucketHref link : cloneLinks()) {
-                if ("ssh".equals(link.getName())) {
-                    cloneLink = link.getHref();
-                    break;
-                }
-            }
-        }
         SCMHead h = head();
         String repoOwner;
         String repository;
@@ -185,6 +174,14 @@ public class BitbucketHgSCMBuilder extends MercurialSCMBuilder<BitbucketHgSCMBui
             // head instanceof BranchSCMHead
             repoOwner = scmSource.getRepoOwner();
             repository = scmSource.getRepository();
+        }
+
+        String cloneLink = null;
+        for (BitbucketHref link : cloneLinks()) {
+            if (protocol.getType().equals(link.getName())) {
+                cloneLink = link.getHref();
+                break;
+            }
         }
         withSource(bitbucket.getRepositoryUri(
                 BitbucketRepositoryType.MERCURIAL,

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/BitbucketApi.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/BitbucketApi.java
@@ -57,7 +57,7 @@ public interface BitbucketApi {
      *
      * @param type the type of repository.
      * @param protocol the protocol to access the repository with.
-     * @param protocolPortOverride the port to override or {@code null} to use the default.
+     * @param cloneLink the actual clone link for the repository as sent by the server, or {@code null} if unknown.
      * @param owner the owner
      * @param repository the repository.
      * @return the URI.
@@ -65,7 +65,7 @@ public interface BitbucketApi {
     @NonNull
     String getRepositoryUri(@NonNull BitbucketRepositoryType type,
                             @NonNull BitbucketRepositoryProtocol protocol,
-                            @CheckForNull Integer protocolPortOverride,
+                            @CheckForNull String cloneLink,
                             @NonNull String owner,
                             @NonNull String repository);
 

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/BitbucketCloudApiClient.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/BitbucketCloudApiClient.java
@@ -195,7 +195,7 @@ public class BitbucketCloudApiClient implements BitbucketApi {
     @Override
     public String getRepositoryUri(@NonNull BitbucketRepositoryType type,
                                    @NonNull BitbucketRepositoryProtocol protocol,
-                                   @CheckForNull Integer protocolPortOverride,
+                                   @CheckForNull String cloneLink,
                                    @NonNull String owner,
                                    @NonNull String repository) {
         // ignore port override on Cloud

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/BitbucketServerAPIClient.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/BitbucketServerAPIClient.java
@@ -216,16 +216,18 @@ public class BitbucketServerAPIClient implements BitbucketApi {
                 }
 
                 UriTemplate template = UriTemplate.fromTemplate("{scheme}://{+authority}{+path}{/owner,repository}.git");
-                template.set("scheme", baseUri.getScheme());
-                template.set("authority", baseUri.getRawAuthority());
                 template.set("owner", owner);
                 template.set("repository", repository);
 
                 switch (protocol) {
                     case HTTP:
+                        template.set("scheme", baseUri.getScheme());
+                        template.set("authority", baseUri.getRawAuthority());
                         template.set("path", Objects.toString(baseUri.getRawPath(), "") + "/scm");
                         break;
                     case SSH:
+                        template.set("scheme", BitbucketRepositoryProtocol.SSH.getType());
+                        template.set("authority", "git@" + baseUri.getHost());
                         if (cloneLink != null) {
                             try {
                                 URI cloneLinkUri = new URI(cloneLink);

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/BitbucketServerAPIClient.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/BitbucketServerAPIClient.java
@@ -57,16 +57,16 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.InetSocketAddress;
-import java.net.MalformedURLException;
 import java.net.Proxy;
 import java.net.URI;
-import java.net.URL;
+import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.Callable;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -203,53 +203,47 @@ public class BitbucketServerAPIClient implements BitbucketApi {
     @Override
     public String getRepositoryUri(@NonNull BitbucketRepositoryType type,
                                    @NonNull BitbucketRepositoryProtocol protocol,
-                                   @CheckForNull Integer protocolPortOverride,
+                                   @CheckForNull String cloneLink,
                                    @NonNull String owner,
                                    @NonNull String repository) {
         switch (type) {
             case GIT:
-                URL url;
+                URI baseUri;
                 try {
-                    url = new URL(baseURL);
-                } catch (MalformedURLException e) {
-                    throw new IllegalStateException("Server URL is not a valid URL", e);
+                    baseUri = new URI(baseURL);
+                } catch (URISyntaxException e) {
+                    throw new IllegalStateException("Server URL is not a valid URI", e);
                 }
-                StringBuilder result = new StringBuilder();
+
+                UriTemplate template = UriTemplate.fromTemplate("{scheme}://{+authority}{+path}{/owner,repository}.git");
+                template.set("scheme", baseUri.getScheme());
+                template.set("authority", baseUri.getRawAuthority());
+                template.set("owner", owner);
+                template.set("repository", repository);
+
                 switch (protocol) {
                     case HTTP:
-                        result.append(url.getProtocol());
-                        result.append("://");
-                        if (protocolPortOverride != null && protocolPortOverride > 0) {
-                            result.append(url.getHost());
-                            result.append(':');
-                            result.append(protocolPortOverride);
-                        } else {
-                            result.append(url.getAuthority());
-                        }
-                        result.append(url.getPath());
-                        result.append("/scm/");
-                        result.append(owner);
-                        result.append('/');
-                        result.append(repository);
-                        result.append(".git");
+                        template.set("path", Objects.toString(baseUri.getRawPath(), "") + "/scm");
                         break;
                     case SSH:
-                        result.append("ssh://git@");
-                        result.append(url.getHost());
-                        if (protocolPortOverride  != null && protocolPortOverride > 0) {
-                            result.append(':');
-                            result.append(protocolPortOverride);
+                        if (cloneLink != null) {
+                            try {
+                                URI cloneLinkUri = new URI(cloneLink);
+                                if (cloneLinkUri.getScheme() != null) {
+                                    template.set("scheme", cloneLinkUri.getScheme());
+                                }
+                                if (cloneLinkUri.getRawAuthority() != null) {
+                                    template.set("authority", cloneLinkUri.getRawAuthority());
+                                }
+                            } catch (@SuppressWarnings("unused") URISyntaxException ignored) {
+                                // fall through
+                            }
                         }
-                        result.append('/');
-                        result.append(owner);
-                        result.append('/');
-                        result.append(repository);
-                        result.append(".git");
                         break;
                     default:
                         throw new IllegalArgumentException("Unsupported repository protocol: " + protocol);
                 }
-                return result.toString();
+                return template.expand();
                 default:
                     throw new IllegalArgumentException("Unsupported repository type: " + type);
         }

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketClientMockUtils.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketClientMockUtils.java
@@ -57,7 +57,7 @@ public class BitbucketClientMockUtils {
     public static BitbucketCloudApiClient getAPIClientMock(BitbucketRepositoryType type, boolean includePullRequests,
             boolean includeWebHooks) throws IOException, InterruptedException {
         BitbucketCloudApiClient bitbucket = mock(BitbucketCloudApiClient.class);
-        when(bitbucket.getRepositoryUri(any(BitbucketRepositoryType.class), any(BitbucketRepositoryProtocol.class), any(Integer.class), anyString(), anyString())).thenCallRealMethod();
+        when(bitbucket.getRepositoryUri(any(BitbucketRepositoryType.class), any(BitbucketRepositoryProtocol.class), anyString(), anyString(), anyString())).thenCallRealMethod();
         // mock branch list
         List<BitbucketCloudBranch> branches = new ArrayList<BitbucketCloudBranch>();
         branches.add(getBranch("branch1", "52fc8e220d77ec400f7fc96a91d2fd0bb1bc553a"));

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/UriResolverTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/UriResolverTest.java
@@ -66,6 +66,14 @@ public class UriResolverTest {
                 "user2",
                 "repo2"
         ));
+        api = new BitbucketServerAPIClient("http://devtools.test:1234/git/web/", "test", null, null, false);
+        assertEquals("http://devtools.test:1234/git/web/scm/user2/repo2.git", api.getRepositoryUri(
+                BitbucketRepositoryType.GIT,
+                BitbucketRepositoryProtocol.HTTP,
+                null,
+                "user2",
+                "repo2"
+        ));
     }
 
     @Test
@@ -89,7 +97,7 @@ public class UriResolverTest {
         assertEquals("ssh://git@localhost:7999/user2/repo2.git", api.getRepositoryUri(
                 BitbucketRepositoryType.GIT,
                 BitbucketRepositoryProtocol.SSH,
-                7999,
+                "ssh://git@localhost:7999/user1/repo1.git",
                 "user2",
                 "repo2"
         ));
@@ -97,7 +105,7 @@ public class UriResolverTest {
         assertEquals("ssh://git@myserver:7999/user2/repo2.git", api.getRepositoryUri(
                 BitbucketRepositoryType.GIT,
                 BitbucketRepositoryProtocol.SSH,
-                7999,
+                "ssh://git@myserver:7999/user1/repo1.git",
                 "user2",
                 "repo2"
         ));

--- a/src/test/java/integration/ScanningFailuresTest.java
+++ b/src/test/java/integration/ScanningFailuresTest.java
@@ -46,6 +46,7 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.when;
 
@@ -136,7 +137,7 @@ public class ScanningFailuresTest {
 
         when(api.getRepositoryUri(eq(BitbucketRepositoryType.GIT),
                 any(BitbucketRepositoryProtocol.class),
-                any(Integer.class),
+                anyString(),
                 eq("bob"),
                 eq("foo")))
                 .thenReturn(sampleRepo.fileUrl());
@@ -211,7 +212,7 @@ public class ScanningFailuresTest {
 
         when(api.getRepositoryUri(eq(BitbucketRepositoryType.GIT),
                 any(BitbucketRepositoryProtocol.class),
-                any(Integer.class),
+                anyString(),
                 eq("bob"),
                 eq("foo")))
                 .thenReturn(sampleRepo.fileUrl());
@@ -278,7 +279,7 @@ public class ScanningFailuresTest {
 
         when(api.getRepositoryUri(eq(BitbucketRepositoryType.GIT),
                 any(BitbucketRepositoryProtocol.class),
-                any(Integer.class),
+                anyString(),
                 eq("bob"),
                 eq("foo")))
                 .thenReturn(sampleRepo.fileUrl());
@@ -349,7 +350,7 @@ public class ScanningFailuresTest {
 
         when(api.getRepositoryUri(eq(BitbucketRepositoryType.GIT),
                 any(BitbucketRepositoryProtocol.class),
-                any(Integer.class),
+                anyString(),
                 eq("bob"),
                 eq("foo")))
                 .thenReturn(sampleRepo.fileUrl());


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-47283

**Motivation:**
Some Bitbucket Server installations use clone URLs that are completely different from the URLs used for web-based access. The clone URLs are correctly advertised via the REST interface, but the the plugin solely uses them to determine alternate port numbers. This leads to SCM checkout failures during builds, since the SCM remote URLs determined by the plugin are wrong.

**Modifications:**
Pass on the whole clone link to BitbucketApi::getRepositoryUri, instead of just passing on the pre-parsed port number. Let implementors decide what to do with this extra piece of information:

  * Cloud: just ignore
  * Server: Just use if cloning via SSH: Use the scheme and authority (which includes user, host and port number) from the clone link, instead of hard-coding and relying on the URL for web-based access

**Result:**
Cloning via SSH works, even with Bitbucket Server setups that use completely differrent URLs for cloning and web access.