### PR TITLE
JENKINS-45997: check mergability when retrieving pull requests

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/endpoints/BitbucketServerEndpoint.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/endpoints/BitbucketServerEndpoint.java
@@ -36,6 +36,7 @@ import javax.annotation.Nonnull;
 import jenkins.scm.api.SCMName;
 import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
 
 /**
@@ -71,6 +72,11 @@ public class BitbucketServerEndpoint extends AbstractBitbucketEndpoint {
     private final String serverUrl;
 
     /**
+     * Whether to always call the can merge api when retrieving pull requests.
+     */
+    private boolean callCanMerge = true;
+
+    /**
      * @param displayName   Optional name to use to describe the end-point.
      * @param serverUrl     The URL of this Bitbucket Server
      * @param manageHooks   {@code true} if and only if Jenkins is supposed to auto-manage hooks for this end-point.
@@ -85,6 +91,15 @@ public class BitbucketServerEndpoint extends AbstractBitbucketEndpoint {
         this.displayName = StringUtils.isBlank(displayName)
                 ? SCMName.fromUrl(this.serverUrl, COMMON_PREFIX_HOSTNAMES)
                 : displayName.trim();
+    }
+
+    public boolean isCallCanMerge() {
+        return callCanMerge;
+    }
+
+    @DataBoundSetter
+    public void setCallCanMerge(boolean callCanMerge) {
+        this.callCanMerge = callCanMerge;
     }
 
     /**

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/BitbucketServerAPIClient.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/BitbucketServerAPIClient.java
@@ -35,11 +35,15 @@ import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketRequestException;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketTeam;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketWebHook;
 import com.cloudbees.jenkins.plugins.bitbucket.client.repository.UserRoleInRepository;
+import com.cloudbees.jenkins.plugins.bitbucket.endpoints.AbstractBitbucketEndpoint;
+import com.cloudbees.jenkins.plugins.bitbucket.endpoints.BitbucketEndpointConfiguration;
+import com.cloudbees.jenkins.plugins.bitbucket.endpoints.BitbucketServerEndpoint;
 import com.cloudbees.jenkins.plugins.bitbucket.filesystem.BitbucketSCMFile;
 import com.cloudbees.jenkins.plugins.bitbucket.server.client.branch.BitbucketServerBranch;
 import com.cloudbees.jenkins.plugins.bitbucket.server.client.branch.BitbucketServerBranches;
 import com.cloudbees.jenkins.plugins.bitbucket.server.client.branch.BitbucketServerCommit;
 import com.cloudbees.jenkins.plugins.bitbucket.server.client.pullrequest.BitbucketServerPullRequest;
+import com.cloudbees.jenkins.plugins.bitbucket.server.client.pullrequest.BitbucketServerPullRequestCanMerge;
 import com.cloudbees.jenkins.plugins.bitbucket.server.client.pullrequest.BitbucketServerPullRequests;
 import com.cloudbees.jenkins.plugins.bitbucket.server.client.repository.BitbucketServerProject;
 import com.cloudbees.jenkins.plugins.bitbucket.server.client.repository.BitbucketServerRepositories;
@@ -119,6 +123,7 @@ public class BitbucketServerAPIClient implements BitbucketApi {
     private static final String API_TAGS_PATH = API_REPOSITORY_PATH + "/tags{?start,limit}";
     private static final String API_PULL_REQUESTS_PATH = API_REPOSITORY_PATH + "/pull-requests{?start,limit}";
     private static final String API_PULL_REQUEST_PATH = API_REPOSITORY_PATH + "/pull-requests/{id}";
+    private static final String API_PULL_REQUEST_MERGE_PATH = API_REPOSITORY_PATH + "/pull-requests/{id}/merge";
     private static final String API_BROWSE_PATH = API_REPOSITORY_PATH + "/browse{/path*}{?at}";
     private static final String API_COMMITS_PATH = API_REPOSITORY_PATH + "/commits{/hash}";
     private static final String API_PROJECT_PATH = API_BASE_PATH + "/projects/{owner}";
@@ -289,12 +294,37 @@ public class BitbucketServerAPIClient implements BitbucketApi {
                 page = JsonParser.toJava(response, BitbucketServerPullRequests.class);
                 pullRequests.addAll(page.getValues());
             }
+
+            AbstractBitbucketEndpoint endpointConfig = BitbucketEndpointConfiguration.get().findEndpoint(baseURL);
+            if (endpointConfig instanceof BitbucketServerEndpoint && ((BitbucketServerEndpoint)endpointConfig).isCallCanMerge()) {
+                // This is required for Bitbucket Server to update the refs/pull-requests/* references
+                // See https://community.atlassian.com/t5/Bitbucket-questions/Change-pull-request-refs-after-Commit-instead-of-after-Approval/qaq-p/194702#M6829
+                for (BitbucketServerPullRequest pullRequest : pullRequests) {
+                    pullRequest.setCanMerge(getPullRequestCanMergeById(Integer.parseInt(pullRequest.getId())));
+                }
+            }
+            
             return pullRequests;
         } catch (IOException e) {
             throw new IOException("I/O error when accessing URL: " + url, e);
         }
     }
 
+    private boolean getPullRequestCanMergeById(@NonNull Integer id) throws IOException {
+        String url = UriTemplate
+                .fromTemplate(API_PULL_REQUEST_MERGE_PATH)
+                .set("owner", getUserCentricOwner())
+                .set("repo", repositoryName)
+                .set("id", id)
+                .expand();
+        String response = getRequest(url);
+        try {
+            return JsonParser.toJava(response, BitbucketServerPullRequestCanMerge.class).isCanMerge();
+        } catch (IOException e) {
+            throw new IOException("I/O error when accessing URL: " + url, e);
+        }
+    }
+    
     /**
      * {@inheritDoc}
      */

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/pullrequest/BitbucketServerPullRequest.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/pullrequest/BitbucketServerPullRequest.java
@@ -26,6 +26,7 @@ package com.cloudbees.jenkins.plugins.bitbucket.server.client.pullrequest;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketHref;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketPullRequest;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketPullRequestSource;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -49,6 +50,8 @@ public class BitbucketServerPullRequest implements BitbucketPullRequest {
     private String link;
 
     private String authorLogin;
+    
+    private Boolean canMerge;
 
     @JsonProperty
     @JsonDeserialize(keyAs = String.class, contentUsing = BitbucketHref.Deserializer.class)
@@ -112,6 +115,15 @@ public class BitbucketServerPullRequest implements BitbucketPullRequest {
         } else {
             authorLogin = null;
         }
+    }
+
+    @CheckForNull
+    public Boolean isCanMerge() {
+        return canMerge;
+    }
+    
+    public void setCanMerge(Boolean canMerge) {
+        this.canMerge = canMerge;
     }
 
 

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/pullrequest/BitbucketServerPullRequestCanMerge.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/pullrequest/BitbucketServerPullRequestCanMerge.java
@@ -1,0 +1,17 @@
+package com.cloudbees.jenkins.plugins.bitbucket.server.client.pullrequest;
+
+import org.codehaus.jackson.annotate.JsonProperty;
+
+public class BitbucketServerPullRequestCanMerge {
+    private boolean canMerge;
+
+    public boolean isCanMerge() {
+        return canMerge;
+    }
+
+    @JsonProperty
+    public void setCanMerge(boolean canMerge) {
+        this.canMerge = canMerge;
+    }
+
+}

--- a/src/main/resources/com/cloudbees/jenkins/plugins/bitbucket/endpoints/BitbucketServerEndpoint/config-detail.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/bitbucket/endpoints/BitbucketServerEndpoint/config-detail.jelly
@@ -7,4 +7,7 @@
   <f:entry title="${%Server URL}" field="serverUrl">
     <f:textbox/>
   </f:entry>
+  <f:entry title="${%Call Can Merge}" field="callCanMerge">
+    <f:checkbox default="true"/>
+  </f:entry>
 </j:jelly>

--- a/src/main/resources/com/cloudbees/jenkins/plugins/bitbucket/endpoints/BitbucketServerEndpoint/help-callCanMerge.html
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/bitbucket/endpoints/BitbucketServerEndpoint/help-callCanMerge.html
@@ -1,0 +1,3 @@
+<div>
+    Always call the can merge api on pull requests to ensure the source code references are up to date.
+</div>


### PR DESCRIPTION
This is needed to make sure that the git references are up to date.