### PR TITLE
JENKINS-50390 Stripped the scheme:// from the host when doing a proxy lookup

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/BitbucketServerAPIClient.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/BitbucketServerAPIClient.java
@@ -70,6 +70,8 @@ import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.regex.Pattern;
+import java.util.regex.Matcher;
 import jenkins.model.Jenkins;
 import jenkins.scm.api.SCMFile;
 import net.sf.json.JSONObject;
@@ -671,6 +673,14 @@ public class BitbucketServerAPIClient implements BitbucketApi {
         if (jenkins != null) {
             proxyConfig = jenkins.proxy;
         }
+
+        // Create pattern to remove 'scheme://' from the host parameter
+        Pattern r = Pattern.compile("^.*?://(.*)");
+        Matcher m = r.matcher(host);
+    
+        if (m.find()) {
+            host = m.group(1);
+        }	
 
         Proxy proxy = Proxy.NO_PROXY;
         if (proxyConfig != null) {


### PR DESCRIPTION
Proposing a fix for https://issues.jenkins-ci.org/browse/JENKINS-50390

I'm using a regular expression to match the scheme:// and strip it when configuring a proxy right before the getRequest. This is required to allow Jenkins to match the server address to the proxy ignore list and safely ignore the proxy.