### PR TITLE
JENKINS-52134: check correct rev class when sending build status

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketBuildStatusNotifications.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketBuildStatusNotifications.java
@@ -129,8 +129,8 @@ public class BitbucketBuildStatusNotifications {
             // unwrap
             revision = ((PullRequestSCMRevision) revision).getPull();
         }
-        if (revision instanceof MercurialSCMSource.MercurialRevision) {
-            return ((MercurialSCMSource.MercurialRevision) revision).getHash();
+        if (revision instanceof BitbucketSCMSource.MercurialRevision) {
+            return ((BitbucketSCMSource.MercurialRevision) revision).getHash();
         } else if (revision instanceof AbstractGitSCMSource.SCMRevisionImpl) {
             return ((AbstractGitSCMSource.SCMRevisionImpl) revision).getHash();
         }

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketBuildStatusNotifications.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketBuildStatusNotifications.java
@@ -131,6 +131,8 @@ public class BitbucketBuildStatusNotifications {
         }
         if (revision instanceof BitbucketSCMSource.MercurialRevision) {
             return ((BitbucketSCMSource.MercurialRevision) revision).getHash();
+        } else if (revision instanceof MercurialSCMSource.MercurialRevision) {
+            return ((MercurialSCMSource.MercurialRevision) revision).getHash();
         } else if (revision instanceof AbstractGitSCMSource.SCMRevisionImpl) {
             return ((AbstractGitSCMSource.SCMRevisionImpl) revision).getHash();
         }


### PR DESCRIPTION
It looks like a confusion of BitbucketSCMSource.MercurialRevision and MercurialSCMSource.MercurialRevision.
