### PR TITLE
JENKINS-52138 Change the BitBucket status message for "In progress"

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketBuildStatusNotifications.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketBuildStatusNotifications.java
@@ -88,7 +88,7 @@ public class BitbucketBuildStatusNotifications {
             status = new BitbucketBuildStatus(hash, "Something is wrong with the build of this commit", "FAILED", url,
                     key, name);
         } else {
-            status = new BitbucketBuildStatus(hash, "The tests have started...", "INPROGRESS", url, key, name);
+            status = new BitbucketBuildStatus(hash, "The build is in progress...", "INPROGRESS", url, key, name);
         }
         new BitbucketChangesetCommentNotifier(bitbucket).buildStatus(status);
         if (result != null) {


### PR DESCRIPTION
Change the "The tests have started" message to "The build is in
progress". This would be more generic and better, because what we
actually do is we start some Jenkins build, that can include tests,
deployment, etc.