### PR TITLE
Adding Bitbucket repository information to request to allow traits to filter by project

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMNavigatorRequest.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMNavigatorRequest.java
@@ -23,10 +23,16 @@
  */
 package com.cloudbees.jenkins.plugins.bitbucket;
 
+import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketRepository;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import jenkins.scm.api.SCMNavigator;
 import jenkins.scm.api.SCMSourceObserver;
 import jenkins.scm.api.trait.SCMNavigatorRequest;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
 
 /**
  * The {@link SCMNavigatorRequest} for bitbucket.
@@ -34,6 +40,12 @@ import jenkins.scm.api.trait.SCMNavigatorRequest;
  * @since 2.2.0
  */
 public class BitbucketSCMNavigatorRequest extends SCMNavigatorRequest {
+
+    /**
+     * Map of all repositories found by this request
+     */
+    private Map<String, BitbucketRepository> repositoryMap = new TreeMap<>();
+
     /**
      * Constructor.
      *
@@ -46,4 +58,20 @@ public class BitbucketSCMNavigatorRequest extends SCMNavigatorRequest {
                                            @NonNull SCMSourceObserver observer) {
         super(source, context, observer);
     }
+
+    public void withRepositories(List<? extends BitbucketRepository> repositories) {
+        this.repositoryMap.clear();
+        for (BitbucketRepository repository : repositories) {
+            this.repositoryMap.put(repository.getRepositoryName(), repository);
+        }
+    }
+
+    public Collection<BitbucketRepository> repositories() {
+        return this.repositoryMap.values();
+    }
+
+    public BitbucketRepository getBitbucketRepository(String repositoryName) {
+        return this.repositoryMap.get(repositoryName);
+    }
+
 }

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/BitbucketProject.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/BitbucketProject.java
@@ -1,0 +1,31 @@
+package com.cloudbees.jenkins.plugins.bitbucket.api;
+
+import org.codehaus.jackson.annotate.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class BitbucketProject {
+
+    private String key;
+    private String name;
+
+    public String getKey() {
+        return key;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setKey(String key) {
+        this.key = key;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String toString() {
+        return "{ key=" + key + ", name=" + name + "}";
+    }
+}

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/BitbucketRepository.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/BitbucketRepository.java
@@ -41,6 +41,12 @@ public interface BitbucketRepository {
      */
     String getFullName();
 
+
+    /**
+     * @return the project containing the repository
+     */
+    BitbucketProject getProject();
+
     /**
      * @return repository owner (could be a user, a team or a project)
      */

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/repository/BitbucketCloudRepository.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/repository/BitbucketCloudRepository.java
@@ -24,6 +24,7 @@
 package com.cloudbees.jenkins.plugins.bitbucket.client.repository;
 
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketHref;
+import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketProject;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketRepository;
 import java.util.ArrayList;
 import java.util.Date;
@@ -53,6 +54,9 @@ public class BitbucketCloudRepository implements BitbucketRepository {
     @JsonDeserialize(keyAs = String.class, contentUsing = BitbucketHref.Deserializer.class)
     private Map<String,List<BitbucketHref>> links;
 
+    @JsonProperty
+    private BitbucketProject project;
+
     @Override
     public String getScm() {
         return scm;
@@ -78,6 +82,14 @@ public class BitbucketCloudRepository implements BitbucketRepository {
 
     public void setOwner(BitbucketCloudRepositoryOwner owner) {
         this.owner = owner;
+    }
+
+    public void setProject(BitbucketProject project) {
+        this.project = project;
+    }
+
+    public BitbucketProject getProject() {
+        return this.project;
     }
 
     public void setUpdatedOn(Date updatedOn) {

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/repository/BitbucketServerRepository.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/repository/BitbucketServerRepository.java
@@ -26,6 +26,8 @@ package com.cloudbees.jenkins.plugins.bitbucket.server.client.repository;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketHref;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketRepository;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketRepositoryOwner;
+import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketProject;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -39,7 +41,7 @@ public class BitbucketServerRepository implements BitbucketRepository {
     @JsonProperty("scmId")
     private String scm;
 
-    private Project project;
+    private BitbucketProject project;
 
     @JsonProperty("slug")
     private String repositoryName;
@@ -79,8 +81,13 @@ public class BitbucketServerRepository implements BitbucketRepository {
         return repositoryName;
     }
 
-    public void setProject(Project p) {
-        this.project = p;
+    @Override
+    public BitbucketProject getProject() {
+        return this.project;
+    }
+
+    public void setProject(BitbucketProject project) {
+        this.project = project;
     }
 
     @Override
@@ -116,31 +123,6 @@ public class BitbucketServerRepository implements BitbucketRepository {
             for (Map.Entry<String, List<BitbucketHref>> entry : links.entrySet()) {
                 this.links.put(entry.getKey(), new ArrayList<>(entry.getValue()));
             }
-        }
-    }
-
-    public static class Project {
-
-        @JsonProperty
-        private String key;
-
-        @JsonProperty
-        private String name;
-
-        public String getKey() {
-            return key;
-        }
-
-        public void setKey(String key) {
-            this.key = key;
-        }
-
-        public String getName() {
-            return name;
-        }
-
-        public void setName(String name) {
-            this.name = name;
         }
     }
 


### PR DESCRIPTION
Hi,

I have written a trait to filter Bitbucket cloud projects as originally tried on PR https://github.com/jenkinsci/bitbucket-branch-source-plugin/pull/16.

However, it was suggested that such traits could be an extension plugin. I will implement such plugin but I need more information to be available so a trait can filter a project without doing any more additional API calls.

This changes here are adding the BitbucketRepository object to a request, that can later be filtered by a trait. I also included additional JSON fields to parse the project.

I have tested this with both Bitbucket server and cloud.
I have not added or changed any test cases as I do not see any tests testing the parts I have changed, please advise, if necessary I can add them.

Thanks.