### PR TITLE
Avoid build status API calls if the server is running on localhost

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketBuildStatusNotifications.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketBuildStatusNotifications.java
@@ -54,29 +54,27 @@ import org.jenkinsci.plugins.displayurlapi.DisplayURLProvider;
  */
 public class BitbucketBuildStatusNotifications {
 
+    private static final String INVALID_URL_LOG_MESSAGE = "Can not determine Jenkins root URL. " +
+        "Commit status notifications are disabled until a root URL is " +
+        "configured in Jenkins global configuration.";
+
     private static void createStatus(@NonNull Run<?, ?> build, @NonNull TaskListener listener,
                                      @NonNull BitbucketApi bitbucket, @NonNull String hash)
             throws IOException, InterruptedException {
         JenkinsLocationConfiguration cfg = JenkinsLocationConfiguration.get();
         if (cfg == null || cfg.getUrl() == null) {
-            listener.getLogger().println(
-                    "Can not determine Jenkins root URL. Commit status notifications are disabled until a root URL is"
-                            + " configured in Jenkins global configuration.");
+            listener.getLogger().println(INVALID_URL_LOG_MESSAGE);
             return;
         }
         String url;
         try {
             url = DisplayURLProvider.get().getRunURL(build);
         } catch (IllegalStateException e) {
-            listener.getLogger().println(
-                    "Can not determine Jenkins root URL. Commit status notifications are disabled until a root URL is"
-                            + " configured in Jenkins global configuration.");
+            listener.getLogger().println(INVALID_URL_LOG_MESSAGE);
             return;
         }
-        if (url.startsWith("http://localhost")) {
-            listener.getLogger().println(
-                    "Invalid Jenkins root URL. URL is pointing to http://localhost. "
-                            + "Commit status notifications are disabled until a valid root URL is configured.");
+        if (url.startsWith("http://localhost") || url.startsWith("http://unconfigured-jenkins-location")) {
+            listener.getLogger().println(INVALID_URL_LOG_MESSAGE);
             return;
         }
 

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketBuildStatusNotifications.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketBuildStatusNotifications.java
@@ -73,6 +73,13 @@ public class BitbucketBuildStatusNotifications {
                             + " configured in Jenkins global configuration.");
             return;
         }
+        if (url.startsWith("http://localhost")) {
+            listener.getLogger().println(
+                    "Invalid Jenkins root URL. URL is pointing to http://localhost. "
+                            + "Commit status notifications are disabled until a valid root URL is configured.");
+            return;
+        }
+
         String key = build.getParent().getFullName(); // use the job full name as the key for the status
         String name = build.getFullDisplayName(); // use the build number as the display name of the status
         BitbucketBuildStatus status;


### PR DESCRIPTION
Avoid build status API calls if the server is running on localhost. 

That is because this is displayed on the Bitbucket UI with a link, that will fail if pointing to localhost. 

This serves as a protection in case developers are testing something on their machines, and therefor might not want to notify the server. 

A similar protection already exists for registering web-hooks on WebhookAutoRegisterListener.