### PR TITLE
Adding a trait to allow disabling build notifications.

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/SkipNotificationsTrait.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/SkipNotificationsTrait.java
@@ -1,0 +1,65 @@
+package com.cloudbees.jenkins.plugins.bitbucket;
+
+import hudson.Extension;
+import jenkins.scm.api.SCMSource;
+import jenkins.scm.api.trait.SCMSourceContext;
+import jenkins.scm.api.trait.SCMSourceTrait;
+import jenkins.scm.api.trait.SCMSourceTraitDescriptor;
+import jenkins.scm.impl.trait.Discovery;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+public class SkipNotificationsTrait extends SCMSourceTrait {
+
+    /**
+     * Constructor for stapler.
+     *
+     */
+    @DataBoundConstructor
+    public SkipNotificationsTrait() {
+        //empty
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected void decorateContext(SCMSourceContext<?, ?> context) {
+        if (context instanceof BitbucketSCMSourceContext) {
+            BitbucketSCMSourceContext ctx = (BitbucketSCMSourceContext) context;
+            ctx.withNotificationsDisabled(true);
+        }
+    }
+
+    /**
+     * Our descriptor.
+     */
+    @Extension
+    @Discovery
+    public static class DescriptorImpl extends SCMSourceTraitDescriptor {
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public String getDisplayName() {
+            return Messages.SkipNotificationsTrait_displayName();
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public Class<? extends SCMSourceContext> getContextClass() {
+            return BitbucketSCMSourceContext.class;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public Class<? extends SCMSource> getSourceClass() {
+            return BitbucketSCMSource.class;
+        }
+
+    }
+}

--- a/src/main/resources/com/cloudbees/jenkins/plugins/bitbucket/Messages.properties
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/bitbucket/Messages.properties
@@ -40,4 +40,4 @@ PullRequestSCMHead.Pronoun=Pull Request
 BranchSCMHead.Pronoun=Branch
 BitBucketTagSCMHead.Pronoun=Tag
 TagDiscoveryTrait.authorityDisplayName=Trust origin tags
-
+SkipNotificationsTrait.displayName=Skip build status notifications

--- a/src/main/resources/com/cloudbees/jenkins/plugins/bitbucket/SkipNotificationsTrait/config.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/bitbucket/SkipNotificationsTrait/config.jelly
@@ -1,0 +1,2 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core"  xmlns:f="/lib/form"/>

--- a/src/main/resources/com/cloudbees/jenkins/plugins/bitbucket/SkipNotificationsTrait/help.html
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/bitbucket/SkipNotificationsTrait/help.html
@@ -1,0 +1,3 @@
+<div>
+    Allows disabling build status notifications.
+</div>


### PR DESCRIPTION
We rely heavily on BitBucket Branch Source plugin, but for couple of root builds we need to disable notifications. These builds are verifying custom scenarios and failure of a build is not an unexpected scenario, though it results in multiple build statuses being posted back to repository which is confusing and annoying. I noticed that there is already parameter which disables build notifications and decided to add a trait to expose it.