### PR TITLE
The source branch is not set correctly in the PR

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource.java
@@ -666,7 +666,7 @@ public class BitbucketSCMSource extends SCMSource {
                                 repoOwner,
                                 repository,
                                 repositoryType,
-                                branchName,
+                                pull.getSource().getBranch().getName(),
                                 pull,
                                 originOf(pullRepoOwner, pullRepository),
                                 strategy


### PR DESCRIPTION
The source branch is not set correctly for BitBucket server, while it's OK for BitBucket Cloud.

Consequence is that the `CHANGE_BRANCH` environment variable is currently set to the PR name, like `PR-13`, and not to the actual source branch.