### PR TITLE
Restore timeouts in BitbucketServerAPIClient

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/BitbucketServerAPIClient.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/BitbucketServerAPIClient.java
@@ -651,7 +651,7 @@ public class BitbucketServerAPIClient implements BitbucketApi {
     private String getRequest(String path) throws IOException {
         HttpGet httpget = new HttpGet(this.baseURL + path);
 
-        try(CloseableHttpClient client = getHttpClient(getMethodHost(httpget));
+        try(CloseableHttpClient client = getHttpClient(httpget);
                 CloseableHttpResponse response = client.execute(httpget, context)) {
             String content;
             long len = response.getEntity().getContentLength();
@@ -690,11 +690,13 @@ public class BitbucketServerAPIClient implements BitbucketApi {
 
     /**
      * Create HttpClient from given host/port
-     * @param host must be of format: scheme://host:port. e.g. http://localhost:7990
+     * @param request the {@link HttpRequestBase} for which an HttpClient will be created
      * @return CloseableHttpClient
      */
-    private CloseableHttpClient getHttpClient(String host) {
+    private CloseableHttpClient getHttpClient(final HttpRequestBase request) {
         HttpClientBuilder httpClientBuilder = HttpClientBuilder.create();
+
+        final String host = getMethodHost(request);
 
         if (credentials != null) {
             CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
@@ -749,7 +751,7 @@ public class BitbucketServerAPIClient implements BitbucketApi {
     private int getRequestStatus(String path) throws IOException {
         HttpGet httpget = new HttpGet(this.baseURL + path);
 
-        try(CloseableHttpClient client = getHttpClient(getMethodHost(httpget));
+        try(CloseableHttpClient client = getHttpClient(httpget);
                 CloseableHttpResponse response = client.execute(httpget, context)) {
             EntityUtils.consume(response.getEntity());
             return response.getStatusLine().getStatusCode();
@@ -795,7 +797,7 @@ public class BitbucketServerAPIClient implements BitbucketApi {
         requestConfig.setSocketTimeout(60 * 1000);
         request.setConfig(requestConfig.build());
 
-        try(CloseableHttpClient client = getHttpClient(getMethodHost(request));
+        try(CloseableHttpClient client = getHttpClient(request);
                 CloseableHttpResponse response = client.execute(request, context)) {
             if (response.getStatusLine().getStatusCode() == HttpStatus.SC_NO_CONTENT) {
                 EntityUtils.consume(response.getEntity());

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/BitbucketServerAPIClient.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/BitbucketServerAPIClient.java
@@ -696,6 +696,12 @@ public class BitbucketServerAPIClient implements BitbucketApi {
     private CloseableHttpClient getHttpClient(final HttpRequestBase request) {
         HttpClientBuilder httpClientBuilder = HttpClientBuilder.create();
 
+        RequestConfig.Builder requestConfig = RequestConfig.custom();
+        requestConfig.setConnectTimeout(10 * 1000);
+        requestConfig.setConnectionRequestTimeout(60 * 1000);
+        requestConfig.setSocketTimeout(60 * 1000);
+        request.setConfig(requestConfig.build());
+
         final String host = getMethodHost(request);
 
         if (credentials != null) {
@@ -791,11 +797,6 @@ public class BitbucketServerAPIClient implements BitbucketApi {
     }
 
     private String doRequest(HttpRequestBase request) throws IOException {
-        RequestConfig.Builder requestConfig = RequestConfig.custom();
-        requestConfig.setConnectTimeout(10 * 1000);
-        requestConfig.setConnectionRequestTimeout(60 * 1000);
-        requestConfig.setSocketTimeout(60 * 1000);
-        request.setConfig(requestConfig.build());
 
         try(CloseableHttpClient client = getHttpClient(request);
                 CloseableHttpResponse response = client.execute(request, context)) {


### PR DESCRIPTION
Motivation
----------
When #92 upgraded `HttpClient` to version 4.x, the connection and socket timeouts were [apparently] correctly preserved in `BitbucketCloudApiClient` (see [here](https://github.com/jenkinsci/bitbucket-branch-source-plugin/commit/8f81d4026153e7ee250252180c34ed2eaa7a784f#diff-66513375f9e876a8924d023aea79a71bR147) and [there](https://github.com/jenkinsci/bitbucket-branch-source-plugin/commit/8f81d4026153e7ee250252180c34ed2eaa7a784f#diff-66513375f9e876a8924d023aea79a71bR667)), but `BitbucketServerAPIClient` only had  its timeouts preserved for non-GET requests (i.e. POST, PUT, etc. whatever called `#doRequest`) and the default timeout is `0` (infinite).

This has lead our Jenkins instances to get stuck whenever our Bitbucket Server instance would not answer (which happens surprisingly often - I'm not sure if it's Stash itself or our network).  This would result, at first, in runs for folder and branch indexing never completing, which wasn't terrible, but then some important jobs started getting stuck (also with a stack trace that had `java.net.SocketInputStream.socketRead0(Native Method)` on top) and none could be aborted, terminated, killed, interrupted, whatever (and boy did we try!).  See the attached [Branch Indexing is stuck.txt](https://github.com/jenkinsci/bitbucket-branch-source-plugin/files/2251563/Branch.Indexing.is.stuck.txt) for the full stack trace we would see in thread dumps.

Manual testing
==============
1. Deployed a local development Bitbucket Server instance (using `atlas-run-standalone`, as documented in the `README.adoc`)
2. Configured my local development Jenkins instance with the version of the plugin built from this branch
3. Configured my local development Jenkins instance to consume the `PROJECT_1` default project at http://<workstation>:7990
4. Ran a folder indexing: it was successful.
5. Test the timeout handling:
    1. Attached the debugger to the `java.exe` process corresponding to the Bitbucket server.
    2. Invoked Debug > Break All to suspend execution of Bitbucket Server's `java.exe`. (this is so the socket is open but unresponsive - if you try to hit a server that's not running, the socket won't connect right away - see step 9 below)
    3. Ran a folder indexing. The full log was attached: [Manual testing with new version.txt](https://github.com/jenkinsci/bitbucket-branch-source-plugin/files/2251576/Manual.testing.with.new.version.txt)
        1. After 60 seconds, it reported `Could not refresh actions`.
        2. After another 60 seconds, it reported `Could not fetch sources`.
        3. The console output ends with:
        ```
        [Fri Jul 27 12:28:18 EDT 2018] Finished organization scan. Scan took 2 min 0 sec
        ```
6. Resumed execution of Bitbucket's `java.exe`.
7. Ran a folder indexing: it was successful.
8. Stopped Bitbucket server.
9. Ran a folder indexing: it failed within 3 seconds with `Connection refused`.
10. Reverted my local development Jenkins instance's plugins and repeated from step 5.
    1. After 10 minutes, it was still stuck.

We have deployed the `jpi` resulting from this pull request to our Jenkins instances and since then, no jobs have gotten stuck forever waiting for packets that would never come.

Mission accomplished!