### PR TITLE
Add the ability to use the CHANGE_AUTHOR_EMAIL environment variable

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource.java
@@ -639,7 +639,7 @@ public class BitbucketSCMSource extends SCMSource {
                     .put(pull.getId(), StringUtils.defaultString(pull.getTitle()));
             getPullRequestContributorCache().put(pull.getId(),
                     // TODO get more details on the author
-                    new ContributorMetadataAction(pull.getAuthorLogin(), null, null)
+                    new ContributorMetadataAction(pull.getAuthorLogin(), null, pull.getAuthorEmail())
             );
             try {
                 // We store resolved hashes here so to avoid resolving the commits multiple times

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/BitbucketPullRequest.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/BitbucketPullRequest.java
@@ -53,4 +53,6 @@ public interface BitbucketPullRequest {
 
     String getAuthorLogin();
 
+    String getAuthorEmail();
+
 }

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/pullrequest/BitbucketPullRequestValue.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/pullrequest/BitbucketPullRequestValue.java
@@ -77,6 +77,12 @@ public class BitbucketPullRequestValue implements BitbucketPullRequest {
         return author.username;
     }
 
+    @Override
+    public String getAuthorEmail() {
+        // return null because BitBucket Cloud hides users emails
+        return null;
+    }
+
     public void setTitle(String title) {
         this.title = title;
     }

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/pullrequest/BitbucketServerPullRequest.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/pullrequest/BitbucketServerPullRequest.java
@@ -50,6 +50,8 @@ public class BitbucketServerPullRequest implements BitbucketPullRequest {
     private String link;
 
     private String authorLogin;
+
+    private String authorEmail;
     
     private Boolean canMerge;
 
@@ -108,12 +110,18 @@ public class BitbucketServerPullRequest implements BitbucketPullRequest {
         return authorLogin;
     }
 
+    public String getAuthorEmail() {
+        return authorEmail;
+    }
+
     @JsonProperty
     public void setAuthor(Author author) {
         if (author != null && author.getUser() != null) {
             authorLogin = author.getUser().getDisplayName();
+            authorEmail = author.getUser().getEmailAddress();
         } else {
             authorLogin = null;
+            authorEmail = null;
         }
     }
 


### PR DESCRIPTION
BitBucket server allows us to get a pull request author's email
from pull requests payloads. This means that we're able to set the
CHANGE_AUTHOR_EMAIL Jenkins environment variable. And, using
this, we'll be able to, for example, send emails from pull request
right to pull requests authors.