### PR TITLE
Fix JENKINS-47891

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/HookEventType.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/HookEventType.java
@@ -37,6 +37,11 @@ public enum HookEventType {
     PUSH("repo:push", PushHookProcessor.class),
 
     /**
+    * See <a href="https://confluence.atlassian.com/bitbucketserver/event-payload-938025882.html">EventPayloads-Bitbucket-server-after-5.4-Push</a>
+    */
+    PUSH("repo:refs-changed", PushHookProcessor.class),
+    
+    /**
      * See <a href="https://confluence.atlassian.com/bitbucket/event-payloads-740262817.html#EventPayloads-Created.1">EventPayloads-Created</a>
      */
     PULL_REQUEST_CREATED("pullrequest:created", PullRequestHookProcessor.class),

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/HookEventType.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/HookEventType.java
@@ -39,7 +39,7 @@ public enum HookEventType {
     /**
     * See <a href="https://confluence.atlassian.com/bitbucketserver/event-payload-938025882.html">EventPayloads-Bitbucket-server-after-5.4-Push</a>
     */
-    PUSH("repo:refs-changed", PushHookProcessor.class),
+    REFS_CHANGED("repo:refs-changed", PushHookProcessor.class),
     
     /**
      * See <a href="https://confluence.atlassian.com/bitbucket/event-payloads-740262817.html#EventPayloads-Created.1">EventPayloads-Created</a>

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/WebhookConfiguration.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/WebhookConfiguration.java
@@ -51,6 +51,7 @@ public class WebhookConfiguration {
      */
     private static final List<String> CLOUD_EVENTS = Collections.unmodifiableList(Arrays.asList(
             HookEventType.PUSH.getKey(),
+            HookEventType.REFS_CHANGED.getKey(),
             HookEventType.PULL_REQUEST_CREATED.getKey(),
             HookEventType.PULL_REQUEST_UPDATED.getKey(),
             HookEventType.PULL_REQUEST_MERGED.getKey(),


### PR DESCRIPTION
Bitbucket server version 5.5 and greater does not send 'repo:push' as an X-Event-Key anymore. Instead it sends 'repo:refs-changed' https://confluence.atlassian.com/bitbucketserver/event-payload-938025882.html Here is a ticket opened up with Jenkins https://issues.jenkins-ci.org/browse/JENKINS-47891