### PR TITLE
JENKINS-51063 the PushHookProcessor does not handle correctly webhook of kind tag

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/JsonParser.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/JsonParser.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright (c) 2016-2017, CloudBees, Inc.
+ * Copyright (c) 2018, CloudBees, Inc., Nikolas Falco
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -23,25 +23,69 @@
  */
 package com.cloudbees.jenkins.plugins.bitbucket;
 
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.base.Charsets;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.io.StringReader;
-import java.text.SimpleDateFormat;
-import java.util.TimeZone;
+import java.text.ParsePosition;
+import java.util.Date;
+
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
+import com.fasterxml.jackson.databind.util.StdDateFormat;
+import com.google.common.base.Charsets;
 
 /**
  * Jackson based JSON parser
  */
 @Restricted(NoExternalUse.class)
 public final class JsonParser {
-    private static final String DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSS";
+
+    /**
+     * Date formatter is because {@link StdDateFormat} and the
+     * ISO8601DateFormat fails to parse some data format returned by the
+     * Bitbucket REST APIs.
+     * 
+     * <p>
+     * The ISO8601DateFormat parser fail if there are more than 3 milliseconds.
+     * The StdDateFormat parser before 2.9.2 returns null when the timezone is expressed in
+     * the extended form [+-]hh:mm. and there are more than 3 milliseconds.
+     * 
+     * @author nikolasfalco
+     */
+    // TODO remove this class when update jackson2 (api plugin) to version greater than 2.9.2
+    /*package*/ static class BitbucketDateFormat extends ISO8601DateFormat {
+        private static final long serialVersionUID = 1L;
+
+        /*
+         * ISO-8601 yyyy-MM-ddThh:mm:ss[.sss][Z|[+-]hh:mm]
+         */
+        @Override
+        public Date parse(String source, ParsePosition pos) {
+            String iso8601 = source;
+
+            int msIdx = source.lastIndexOf('.');
+            if (msIdx != -1) {
+                int plusIdx = source.indexOf('+', msIdx);
+                int minusIdx = source.indexOf('-', msIdx);
+                int gmtIdx = source.indexOf('Z', msIdx);
+                int lastMsIdx = Math.max(Math.max(plusIdx, minusIdx), gmtIdx);
+                if (lastMsIdx != -1) {
+                    // there are too many milliseconds
+                    iso8601 = source.substring(0, msIdx + 4) + source.substring(lastMsIdx);
+                }
+            }
+
+            return super.parse(iso8601, pos);
+        }
+
+    }
+
     public static final ObjectMapper mapper = createObjectMapper();
 
     public static <T> T toJava(String data, Class<T> type) throws IOException {
@@ -62,9 +106,8 @@ public final class JsonParser {
 
     private static ObjectMapper createObjectMapper(){
         ObjectMapper mapper = new ObjectMapper();
-        SimpleDateFormat format = new SimpleDateFormat(DATE_FORMAT);
-        format.setTimeZone(TimeZone.getTimeZone("UTC"));
-        mapper.setDateFormat(format);
+        // TODO remove date format when update jackson2 (api plugin) to version greater than 2.9.2
+        mapper.setDateFormat(new BitbucketDateFormat());
         mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
         return mapper;
     }

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/BitbucketApi.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/BitbucketApi.java
@@ -41,12 +41,16 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
 public interface BitbucketApi {
 
     /**
+     * Returns the owner name for the repository.
+     * 
      * @return the repository owner name.
      */
     @NonNull
     String getOwner();
 
     /**
+     * Returns the repository name.
+     * 
      * @return the repository name.
      */
     @CheckForNull
@@ -60,7 +64,7 @@ public interface BitbucketApi {
      * @param protocolPortOverride the port to override or {@code null} to use the default.
      * @param owner the owner
      * @param repository the repository.
-     * @return the URI.
+     * @return the repository URI.
      */
     @NonNull
     String getRepositoryUri(@NonNull BitbucketRepositoryType type,
@@ -264,21 +268,25 @@ public interface BitbucketApi {
      */
     boolean isPrivate() throws IOException, InterruptedException;
     
-	/**
-	 * @param parent
-	 * @return
-	 * @throws IOException
-	 * @throws InterruptedException
-	 */
+    /**
+     * Returns a list of all children file for the given folder.
+     * 
+     * @param parent to list
+     * @return a iterable of {@link SCMFile} children of the given folder.
+     * @throws IOException if there was a network communications error.
+     * @throws InterruptedException if interrupted while waiting on remote communications.
+     */
 	@Restricted(NoExternalUse.class)
 	public Iterable<SCMFile> getDirectoryContent(BitbucketSCMFile parent) throws IOException, InterruptedException;
 	
-	/**
-	 * @param file
-	 * @return
-	 * @throws IOException
-	 * @throws InterruptedException
-	 */
+    /**
+     * Return an input stream for the given file.
+     * 
+     * @param file and instance of SCM file
+     * @return the stream of the given {@link SCMFile}
+     * @throws IOException if there was a network communications error.
+     * @throws InterruptedException if interrupted while waiting on remote communications.
+     */
     @Restricted(NoExternalUse.class)
 	public InputStream getFileContent(BitbucketSCMFile file) throws IOException, InterruptedException;
 }

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/BitbucketPushEvent.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/BitbucketPushEvent.java
@@ -1,5 +1,6 @@
 package com.cloudbees.jenkins.plugins.bitbucket.api;
 
+import java.util.Date;
 import java.util.List;
 
 /**
@@ -21,6 +22,7 @@ public interface BitbucketPushEvent {
     }
 
     interface Reference {
+        Date getDate();
         String getType();
         String getName();
         Target getTarget();
@@ -28,5 +30,6 @@ public interface BitbucketPushEvent {
 
     interface Target {
         String getHash();
+        Date getDate();
     }
 }

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/events/BitbucketCloudPushEvent.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/events/BitbucketCloudPushEvent.java
@@ -29,6 +29,7 @@ import com.cloudbees.jenkins.plugins.bitbucket.client.repository.BitbucketCloudR
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Date;
 import java.util.List;
 
 public class BitbucketCloudPushEvent implements BitbucketPushEvent {
@@ -38,6 +39,7 @@ public class BitbucketCloudPushEvent implements BitbucketPushEvent {
     @JsonProperty
     private Push push;
 
+    @Override
     public BitbucketRepository getRepository() {
         return repository;
     }
@@ -70,6 +72,7 @@ public class BitbucketCloudPushEvent implements BitbucketPushEvent {
         private boolean created;
         private boolean closed;
 
+        @Override
         public ReferenceImpl getNew() {
             return newRef;
         }
@@ -78,6 +81,7 @@ public class BitbucketCloudPushEvent implements BitbucketPushEvent {
             this.newRef = newRef;
         }
 
+        @Override
         public ReferenceImpl getOld() {
             return oldRef;
         }
@@ -107,6 +111,7 @@ public class BitbucketCloudPushEvent implements BitbucketPushEvent {
     }
 
     public static class ReferenceImpl implements Reference {
+        private Date date;
         private String type;
         private String name;
         private TargetImpl target;
@@ -137,11 +142,20 @@ public class BitbucketCloudPushEvent implements BitbucketPushEvent {
         public void setTarget(TargetImpl target) {
             this.target = target;
         }
+
+        @Override
+        public Date getDate() {
+            return date != null ? (Date) date.clone() : null;
+        }
+
+        public void setDate(Date date) {
+            this.date = (date != null ? (Date) date.clone() : null);
+        }
     }
 
     public static class TargetImpl implements Target {
-
         private String hash;
+        private Date date;
 
         @Override
         public String getHash() {
@@ -150,6 +164,15 @@ public class BitbucketCloudPushEvent implements BitbucketPushEvent {
 
         public void setHash(String hash) {
             this.hash = hash;
+        }
+
+        @Override
+        public Date getDate() {
+            return date != null ? (Date) date.clone() : null;
+        }
+
+        public void setDate(Date date) {
+            this.date = (date != null ? (Date) date.clone() : null);
         }
     }
 

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/filesystem/BitbucketSCMFileSystem.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/filesystem/BitbucketSCMFileSystem.java
@@ -63,9 +63,9 @@ public class BitbucketSCMFileSystem extends SCMFileSystem {
     }
 
     /**
+     * Return timestamp of last commit or of tag if its annotated tag.
      *
-     * @return Return timestamp of last commit or of tag if its annotated tag
-     * @throws IOException
+     * @return timestamp of last commit or of tag if its annotated tag
      */
     @Override
     public long lastModified() throws IOException {

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/events/BitbucketServerPushEvent.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/events/BitbucketServerPushEvent.java
@@ -29,6 +29,7 @@ import com.cloudbees.jenkins.plugins.bitbucket.server.client.repository.Bitbucke
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Date;
 import java.util.List;
 
 public class BitbucketServerPushEvent implements BitbucketPushEvent{
@@ -38,6 +39,7 @@ public class BitbucketServerPushEvent implements BitbucketPushEvent{
     @JsonProperty
     private Push push;
 
+    @Override
     public BitbucketRepository getRepository() {
         return repository;
     }
@@ -109,6 +111,7 @@ public class BitbucketServerPushEvent implements BitbucketPushEvent{
     }
 
     public static class ReferenceImpl implements Reference {
+        private Date date;
         private String type;
         private String name;
         private TargetImpl target;
@@ -139,11 +142,20 @@ public class BitbucketServerPushEvent implements BitbucketPushEvent{
         public void setTarget(TargetImpl target) {
             this.target = target;
         }
+
+        @Override
+        public Date getDate() {
+            return date != null ? (Date) date.clone() : null;
+        }
+
+        public void setDate(Date date) {
+            this.date = (date != null) ? (Date) date.clone() : null;
+        }
     }
 
     public static class TargetImpl implements Target {
-
         private String hash;
+        private Date date;
 
         @Override
         public String getHash() {
@@ -152,6 +164,15 @@ public class BitbucketServerPushEvent implements BitbucketPushEvent{
 
         public void setHash(String hash) {
             this.hash = hash;
+        }
+
+        @Override
+        public Date getDate() {
+            return date != null ? (Date) date.clone() : null;
+        }
+
+        public void setDate(Date date) {
+            this.date = (date != null) ? (Date) date.clone() : null;
         }
     }
 

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketDateFormatTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketDateFormatTest.java
@@ -1,0 +1,46 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2018, Nikolas Falco
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.cloudbees.jenkins.plugins.bitbucket;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+import com.cloudbees.jenkins.plugins.bitbucket.JsonParser.BitbucketDateFormat;
+import com.cloudbees.jenkins.plugins.bitbucket.client.DateUtils;
+
+// TODO remove this class after update to jackson2 (api-plugin) version 2.9.2
+public class BitbucketDateFormatTest {
+
+    @Test
+    public void test_custom_bitbucket_ISO8601_date_format() throws Exception {
+        BitbucketDateFormat bdf = new BitbucketDateFormat();
+
+        assertThat(bdf.parse("2018-09-12T14:56:34.008922+00:00"), is(DateUtils.getDate(2018, 9, 12, 14, 56, 34, 8)));
+        assertThat(bdf.parse("2018-09-12T14:56:34.008922-00:00"), is(DateUtils.getDate(2018, 9, 12, 14, 56, 34, 8)));
+        assertThat(bdf.parse("2018-09-12T14:56:34.008922Z"), is(DateUtils.getDate(2018, 9, 12, 14, 56, 34, 8)));
+    }
+
+}

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/client/BitbucketCloudApiClientTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/client/BitbucketCloudApiClientTest.java
@@ -1,0 +1,55 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2018, Nikolas Falco
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.cloudbees.jenkins.plugins.bitbucket.client;
+
+import static org.junit.Assert.*;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Date;
+
+import org.apache.commons.io.IOUtils;
+import org.hamcrest.CoreMatchers;
+import org.junit.Test;
+
+import com.cloudbees.jenkins.plugins.bitbucket.JsonParser;
+import com.cloudbees.jenkins.plugins.bitbucket.client.repository.BitbucketCloudRepository;
+
+public class BitbucketCloudApiClientTest {
+
+    public String loadPayload(String api) throws IOException {
+        try (InputStream is = getClass().getResourceAsStream(getClass().getSimpleName() + "/" + api + "Payload.json")) {
+            return IOUtils.toString(is, "UTF-8");
+        }
+    }
+
+    @Test
+    public void get_repository_parse_correctly_date_from_cloud() throws Exception {
+        BitbucketCloudRepository repository = JsonParser.toJava(loadPayload("getRepository"), BitbucketCloudRepository.class);
+        assertNotNull("update on date is null", repository.getUpdatedOn());
+        Date date = DateUtils.getDate(2018, 4, 27, 15, 32, 8, 356);
+        assertThat(repository.getUpdatedOn().getTime(), CoreMatchers.is(date.getTime()));
+    }
+
+}

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/client/DateUtils.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/client/DateUtils.java
@@ -1,0 +1,47 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2018, Nikolas Falco
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.cloudbees.jenkins.plugins.bitbucket.client;
+
+import java.util.Calendar;
+import java.util.Date;
+import java.util.TimeZone;
+
+public final class DateUtils {
+
+    private DateUtils() {
+    }
+
+    public static Date getDate(int year, int month, int day, int hours, int minutes, int seconds, int milliseconds) {
+        return getDate(year, month, day, hours, minutes, seconds, milliseconds, "UTC");
+    }
+
+    public static Date getDate(int year, int month, int day, int hours, int minutes, int seconds, int milliseconds, String timezoneId) {
+        Calendar cal = Calendar.getInstance(TimeZone.getTimeZone(timezoneId));
+        cal.set(year, month - 1, day, hours, minutes);
+        cal.set(Calendar.SECOND, seconds);
+        cal.set(Calendar.MILLISECOND, milliseconds);
+        return cal.getTime();
+    }
+
+}

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/client/events/BitbucketCloudPushEventTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/client/events/BitbucketCloudPushEventTest.java
@@ -25,8 +25,14 @@ package com.cloudbees.jenkins.plugins.bitbucket.client.events;
 
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketPushEvent;
 import com.cloudbees.jenkins.plugins.bitbucket.client.BitbucketCloudWebhookPayload;
+import com.cloudbees.jenkins.plugins.bitbucket.client.DateUtils;
+
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.TimeZone;
+
 import org.apache.commons.io.IOUtils;
 import org.junit.Before;
 import org.junit.Rule;
@@ -113,6 +119,28 @@ public class BitbucketCloudPushEventTest {
                 is("https://api.bitbucket.org/2.0/repositories/cloudbeers/temp"));
         assertThat(event.getChanges(), containsInAnyOrder());
     }
+
+    @Test
+    public void newTagPayload() throws Exception {
+        BitbucketPushEvent event = BitbucketCloudWebhookPayload.pushEventFromPayload(payload);
+        assertThat(event.getRepository(), notNullValue());
+        assertThat(event.getRepository().getScm(), is("git"));
+        assertThat(event.getRepository().getOwner().getDisplayName(), is("ACME"));
+        assertThat(event.getRepository().getOwner().getUsername(), is("acme"));
+        assertThat(event.getRepository().getRepositoryName(), is("tds.cm.maven.plugins-java"));
+        assertThat(event.getRepository().isPrivate(), is(true));
+        BitbucketPushEvent.Change change = event.getChanges().get(0);
+        assertThat(change.isCreated(), is(true));
+        assertThat(change.isClosed(), is(false));
+        assertThat(change.getNew(), notNullValue());
+        assertThat(change.getNew().getName(), is("test"));
+        assertThat(change.getNew().getType(), is("tag"));
+        Date date = DateUtils.getDate(2018, 4, 27, 9, 4, 24, 0);
+        assertThat(change.getNew().getDate().getTime(), is(date.getTime()));
+        assertThat(change.getNew().getTarget(), notNullValue());
+        assertThat(change.getNew().getTarget().getHash(), is("fee1dcdb330d1318502f303ccd4792531c28dc8e"));
+    }
+
     @Test
     public void multipleChangesPayload() throws Exception {
         BitbucketPushEvent event = BitbucketCloudWebhookPayload.pushEventFromPayload(payload);

--- a/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/client/BitbucketCloudApiClientTest/getRepositoryPayload.json
+++ b/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/client/BitbucketCloudApiClientTest/getRepositoryPayload.json
@@ -1,0 +1,104 @@
+{
+	"scm": "git",
+	"website": "",
+	"has_wiki": false,
+	"uuid": "{ff487924-8721-4ab7-8d5c-e482d4b0eb13}",
+	"links": {
+		"watchers": {
+			"href": "https://api.bitbucket.org/2.0/repositories/acme/tds.cm.maven.plugins-java/watchers"
+		},
+		"branches": {
+			"href": "https://api.bitbucket.org/2.0/repositories/acme/tds.cm.maven.plugins-java/refs/branches"
+		},
+		"tags": {
+			"href": "https://api.bitbucket.org/2.0/repositories/acme/tds.cm.maven.plugins-java/refs/tags"
+		},
+		"commits": {
+			"href": "https://api.bitbucket.org/2.0/repositories/acme/tds.cm.maven.plugins-java/commits"
+		},
+		"clone": [
+			{
+				"href": "https://nfalco79@bitbucket.org/acme/tds.cm.maven.plugins-java.git",
+				"name": "https"
+			},
+			{
+				"href": "git@bitbucket.org:acme/tds.cm.maven.plugins-java.git",
+				"name": "ssh"
+			}
+		],
+		"self": {
+			"href": "https://api.bitbucket.org/2.0/repositories/acme/tds.cm.maven.plugins-java"
+		},
+		"source": {
+			"href": "https://api.bitbucket.org/2.0/repositories/acme/tds.cm.maven.plugins-java/src"
+		},
+		"html": {
+			"href": "https://bitbucket.org/acme/tds.cm.maven.plugins-java"
+		},
+		"avatar": {
+			"href": "https://bitbucket.org/acme/tds.cm.maven.plugins-java/avatar/32/"
+		},
+		"hooks": {
+			"href": "https://api.bitbucket.org/2.0/repositories/acme/tds.cm.maven.plugins-java/hooks"
+		},
+		"forks": {
+			"href": "https://api.bitbucket.org/2.0/repositories/acme/tds.cm.maven.plugins-java/forks"
+		},
+		"downloads": {
+			"href": "https://api.bitbucket.org/2.0/repositories/acme/tds.cm.maven.plugins-java/downloads"
+		},
+		"pullrequests": {
+			"href": "https://api.bitbucket.org/2.0/repositories/acme/tds.cm.maven.plugins-java/pullrequests"
+		}
+	},
+	"fork_policy": "no_forks",
+	"name": "tds.cm.maven.plugins-java",
+	"project": {
+		"key": "THIRDPL",
+		"type": "project",
+		"uuid": "{645d71c9-e01c-40ab-976c-3992b9b695a4}",
+		"links": {
+			"self": {
+				"href": "https://api.bitbucket.org/2.0/teams/acme/projects/THIRDPL"
+			},
+			"html": {
+				"href": "https://bitbucket.org/account/user/acme/projects/THIRDPL"
+			},
+			"avatar": {
+				"href": "https://bitbucket.org/account/user/acme/projects/THIRDPL/avatar/32"
+			}
+		},
+		"name": "3rd Party Libraries"
+	},
+	"language": "java",
+	"created_on": "2016-08-17T11:00:23.063614+00:00",
+	"mainbranch": {
+		"type": "branch",
+		"name": "master"
+	},
+	"full_name": "acme/tds.cm.maven.plugins-java",
+	"has_issues": false,
+	"owner": {
+		"username": "acme",
+		"display_name": "ACME",
+		"type": "team",
+		"uuid": "{7f41da2d-686c-4187-9b70-9eb5f71368a6}",
+		"links": {
+			"self": {
+				"href": "https://api.bitbucket.org/2.0/teams/acme"
+			},
+			"html": {
+				"href": "https://bitbucket.org/acme/"
+			},
+			"avatar": {
+				"href": "https://bitbucket.org/account/acme/avatar/32/"
+			}
+		}
+	},
+	"updated_on": "2018-04-27T15:32:08.356155+00:00",
+	"size": 136381135,
+	"type": "repository",
+	"slug": "tds.cm.maven.plugins-java",
+	"is_private": true,
+	"description": "The acme maven plugins for build system"
+}

--- a/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/client/events/BitbucketCloudPushEventTest/newTagPayload.json
+++ b/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/client/events/BitbucketCloudPushEventTest/newTagPayload.json
@@ -1,0 +1,162 @@
+{
+  "push": {
+    "changes": [
+      {
+        "forced": false,
+        "old": null,
+        "links": {
+          "commits": {
+            "href": "https://api.bitbucket.org/2.0/repositories/acme/tds.cm.maven.plugins-java/commits?include=fee1dcdb330d1318502f303ccd4792531c28dc8e"
+          }
+        },
+        "truncated": false,
+        "created": true,
+        "closed": false,
+        "new": {
+          "name": "test",
+          "links": {
+            "commits": {
+              "href": "https://api.bitbucket.org/2.0/repositories/acme/tds.cm.maven.plugins-java/commits/test"
+            },
+            "self": {
+              "href": "https://api.bitbucket.org/2.0/repositories/acme/tds.cm.maven.plugins-java/refs/tags/test"
+            },
+            "html": {
+              "href": "https://bitbucket.org/acme/tds.cm.maven.plugins-java/commits/tag/test"
+            }
+          },
+          "tagger": {},
+          "date": "2018-04-27T09:04:24+00:00",
+          "message": "test\n",
+          "type": "tag",
+          "target": {
+            "hash": "fee1dcdb330d1318502f303ccd4792531c28dc8e",
+            "links": {
+              "self": {
+                "href": "https://api.bitbucket.org/2.0/repositories/acme/tds.cm.maven.plugins-java/commit/fee1dcdb330d1318502f303ccd4792531c28dc8e"
+              },
+              "html": {
+                "href": "https://bitbucket.org/acme/tds.cm.maven.plugins-java/commits/fee1dcdb330d1318502f303ccd4792531c28dc8e"
+              }
+            },
+            "author": {
+              "raw": "Nikolas Falco <nikolas.falco@acme.com>",
+              "type": "author",
+              "user": {
+                "username": "nfalco79",
+                "type": "user",
+                "display_name": "Nikolas Falco",
+                "uuid": "{644c7fc2-b15a-4445-9f89-35390694fac9}",
+                "links": {
+                  "self": {
+                    "href": "https://api.bitbucket.org/2.0/users/nfalco79"
+                  },
+                  "html": {
+                    "href": "https://bitbucket.org/nfalco79/"
+                  },
+                  "avatar": {
+                    "href": "https://bitbucket.org/account/nfalco79/avatar/32/"
+                  }
+                }
+              }
+            },
+            "summary": {
+              "raw": "Defect RCBA-13 Maven plugin permits uppercase letters in addUniqueConstraint\n\nUse a better log message in case of violation of changeset.\n",
+              "markup": "markdown",
+              "html": "<p>Defect RCBA-13 Maven plugin permits uppercase letters in addUniqueConstraint</p>\n<p>Use a better log message in case of violation of changeset.</p>",
+              "type": "rendered"
+            },
+            "parents": [
+              {
+                "type": "commit",
+                "hash": "e307a7d996212a537b0648b15d0d59fe3c98c963",
+                "links": {
+                  "self": {
+                    "href": "https://api.bitbucket.org/2.0/repositories/acme/tds.cm.maven.plugins-java/commit/e307a7d996212a537b0648b15d0d59fe3c98c963"
+                  },
+                  "html": {
+                    "href": "https://bitbucket.org/acme/tds.cm.maven.plugins-java/commits/e307a7d996212a537b0648b15d0d59fe3c98c963"
+                  }
+                }
+              }
+            ],
+            "date": "2018-04-06T14:47:43+00:00",
+            "message": "Defect RCBA-13 Maven plugin permits uppercase letters in addUniqueConstraint\n\nUse a better log message in case of violation of changeset.\n",
+            "type": "commit"
+          }
+        }
+      }
+    ]
+  },
+  "repository": {
+    "scm": "git",
+    "website": "",
+    "name": "tds.cm.maven.plugins-java",
+    "links": {
+      "self": {
+        "href": "https://api.bitbucket.org/2.0/repositories/acme/tds.cm.maven.plugins-java"
+      },
+      "html": {
+        "href": "https://bitbucket.org/acme/tds.cm.maven.plugins-java"
+      },
+      "avatar": {
+        "href": "https://bitbucket.org/acme/tds.cm.maven.plugins-java/avatar/32/"
+      }
+    },
+    "project": {
+      "links": {
+        "self": {
+          "href": "https://api.bitbucket.org/2.0/teams/acme/projects/THIRDPL"
+        },
+        "html": {
+          "href": "https://bitbucket.org/account/user/acme/projects/THIRDPL"
+        },
+        "avatar": {
+          "href": "https://bitbucket.org/account/user/acme/projects/THIRDPL/avatar/32"
+        }
+      },
+      "type": "project",
+      "uuid": "{645d71c9-e01c-40ab-976c-3992b9b695a4}",
+      "key": "THIRDPL",
+      "name": "3rd Party Libraries"
+    },
+    "full_name": "acme/tds.cm.maven.plugins-java",
+    "owner": {
+      "username": "acme",
+      "type": "team",
+      "display_name": "ACME",
+      "uuid": "{7f41da2d-686c-4187-9b70-9eb5f71368a6}",
+      "links": {
+        "self": {
+          "href": "https://api.bitbucket.org/2.0/teams/acme"
+        },
+        "html": {
+          "href": "https://bitbucket.org/acme/"
+        },
+        "avatar": {
+          "href": "https://bitbucket.org/account/acme/avatar/32/"
+        }
+      }
+    },
+    "type": "repository",
+    "is_private": true,
+    "uuid": "{ff487924-8721-4ab7-8d5c-e482d4b0eb13}"
+  },
+  "actor": {
+    "username": "nfalco79",
+    "type": "user",
+    "display_name": "Nikolas Falco",
+    "uuid": "{644c7fc2-b15a-4445-9f89-35390694fac9}",
+    "links": {
+      "self": {
+        "href": "https://api.bitbucket.org/2.0/users/nfalco79"
+      },
+      "html": {
+        "href": "https://bitbucket.org/nfalco79/"
+      },
+      "avatar": {
+        "href": "https://bitbucket.org/account/nfalco79/avatar/32/"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Manage TagSCMHead correctly when bitbucket payload webhook is of king create tag.
Fix parsing of ISO8601 date in BB payload. Handle also non ISO8601 standard date for updateOn field.
To avoid too regression only the new date fields are of kind Date the other one are keep as is. If changed to Date in the future they works, otherwise in case the Bitbucket date format can be enhanced to handle other cases.