### PR TITLE
Do not use Bitbucket Server pull request branches (they lag)

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketGitSCMBuilder.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketGitSCMBuilder.java
@@ -94,14 +94,8 @@ public class BitbucketGitSCMBuilder extends GitSCMBuilder<BitbucketGitSCMBuilder
         super(head, revision, /*dummy value*/scmSource.getServerUrl(), credentialsId);
         withoutRefSpecs();
         if (head instanceof PullRequestSCMHead) {
-            if (scmSource.buildBitbucketClient() instanceof BitbucketCloudApiClient) {
-                // TODO fix once Bitbucket Cloud has a fix for https://bitbucket.org/site/master/issues/5814
-                String branchName = ((PullRequestSCMHead) head).getBranchName();
-                withRefSpec("+refs/heads/" + branchName + ":refs/remotes/@{remote}/" + head.getName());
-            } else {
-                String pullId = ((PullRequestSCMHead) head).getId();
-                withRefSpec("+refs/pull-requests/" + pullId + "/from:refs/remotes/@{remote}/" + head.getName());
-            }
+            String branchName = ((PullRequestSCMHead) head).getBranchName();
+            withRefSpec("+refs/heads/" + branchName + ":refs/remotes/@{remote}/" + head.getName());
         } else if (head instanceof TagSCMHead ){
             withRefSpec("+refs/tags/" + head.getName() + ":refs/tags/" + head.getName());
         } else {

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketGitSCMBuilderTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketGitSCMBuilderTest.java
@@ -1035,7 +1035,7 @@ public class BitbucketGitSCMBuilderTest {
         assertThat(instance.head(), is((SCMHead) head));
         assertThat(instance.revision(), is((SCMRevision) revision));
         assertThat(instance.scmSource(), is(source));
-        assertThat(instance.refSpecs(), contains("+refs/pull-requests/1/from:refs/remotes/@{remote}/PR-1"));
+        assertThat(instance.refSpecs(), contains("+refs/heads/qa-branch:refs/remotes/@{remote}/PR-1"));
         assertThat(instance.cloneLinks(), is(Collections.<BitbucketHref>emptyList()));
         assertThat("expecting dummy value until clone links provided or withBitbucketRemote called",
                 instance.remote(), is("https://bitbucket.test"));
@@ -1055,7 +1055,7 @@ public class BitbucketGitSCMBuilderTest {
         assertThat(actual.getUserRemoteConfigs(), hasSize(1));
         UserRemoteConfig config = actual.getUserRemoteConfigs().get(0);
         assertThat(config.getName(), is("origin"));
-        assertThat(config.getRefspec(), is("+refs/pull-requests/1/from:refs/remotes/origin/PR-1"));
+        assertThat(config.getRefspec(), is("+refs/heads/qa-branch:refs/remotes/origin/PR-1"));
         assertThat(config.getUrl(), is("https://bitbucket.test/scm/tester/test-repo.git"));
         assertThat(config.getCredentialsId(), is(nullValue()));
         RemoteConfig origin = actual.getRepositoryByName("origin");
@@ -1063,7 +1063,7 @@ public class BitbucketGitSCMBuilderTest {
         assertThat(origin.getURIs(), hasSize(1));
         assertThat(origin.getURIs().get(0).toString(), is("https://bitbucket.test/scm/tester/test-repo.git"));
         assertThat(origin.getFetchRefSpecs(), hasSize(1));
-        assertThat(origin.getFetchRefSpecs().get(0).getSource(), is("refs/pull-requests/1/from"));
+        assertThat(origin.getFetchRefSpecs().get(0).getSource(), is("refs/heads/qa-branch"));
         assertThat(origin.getFetchRefSpecs().get(0).getDestination(), is("refs/remotes/origin/PR-1"));
         assertThat(origin.getFetchRefSpecs().get(0).isForceUpdate(), is(true));
         assertThat(origin.getFetchRefSpecs().get(0).isWildcard(), is(false));
@@ -1099,7 +1099,7 @@ public class BitbucketGitSCMBuilderTest {
         assertThat(instance.head(), is((SCMHead) head));
         assertThat(instance.revision(), is((SCMRevision) revision));
         assertThat(instance.scmSource(), is(source));
-        assertThat(instance.refSpecs(), contains("+refs/pull-requests/1/from:refs/remotes/@{remote}/PR-1"));
+        assertThat(instance.refSpecs(), contains("+refs/heads/qa-branch:refs/remotes/@{remote}/PR-1"));
         assertThat(instance.cloneLinks(), is(Collections.<BitbucketHref>emptyList()));
         assertThat("expecting dummy value until clone links provided or withBitbucketRemote called",
                 instance.remote(), is("https://bitbucket.test"));
@@ -1119,7 +1119,7 @@ public class BitbucketGitSCMBuilderTest {
         assertThat(actual.getUserRemoteConfigs(), hasSize(1));
         UserRemoteConfig config = actual.getUserRemoteConfigs().get(0);
         assertThat(config.getName(), is("origin"));
-        assertThat(config.getRefspec(), is("+refs/pull-requests/1/from:refs/remotes/origin/PR-1"));
+        assertThat(config.getRefspec(), is("+refs/heads/qa-branch:refs/remotes/origin/PR-1"));
         assertThat(config.getUrl(), is("https://bitbucket.test/scm/tester/test-repo.git"));
         assertThat(config.getCredentialsId(), is("user-pass"));
         RemoteConfig origin = actual.getRepositoryByName("origin");
@@ -1127,7 +1127,7 @@ public class BitbucketGitSCMBuilderTest {
         assertThat(origin.getURIs(), hasSize(1));
         assertThat(origin.getURIs().get(0).toString(), is("https://bitbucket.test/scm/tester/test-repo.git"));
         assertThat(origin.getFetchRefSpecs(), hasSize(1));
-        assertThat(origin.getFetchRefSpecs().get(0).getSource(), is("refs/pull-requests/1/from"));
+        assertThat(origin.getFetchRefSpecs().get(0).getSource(), is("refs/heads/qa-branch"));
         assertThat(origin.getFetchRefSpecs().get(0).getDestination(), is("refs/remotes/origin/PR-1"));
         assertThat(origin.getFetchRefSpecs().get(0).isForceUpdate(), is(true));
         assertThat(origin.getFetchRefSpecs().get(0).isWildcard(), is(false));
@@ -1162,7 +1162,7 @@ public class BitbucketGitSCMBuilderTest {
         assertThat(instance.head(), is((SCMHead) head));
         assertThat(instance.revision(), is((SCMRevision) revision));
         assertThat(instance.scmSource(), is(source));
-        assertThat(instance.refSpecs(), contains("+refs/pull-requests/1/from:refs/remotes/@{remote}/PR-1"));
+        assertThat(instance.refSpecs(), contains("+refs/heads/qa-branch:refs/remotes/@{remote}/PR-1"));
         assertThat(instance.cloneLinks(), is(Collections.<BitbucketHref>emptyList()));
         assertThat("expecting dummy value until clone links provided or withBitbucketRemote called",
                 instance.remote(), is("https://bitbucket.test"));
@@ -1182,7 +1182,7 @@ public class BitbucketGitSCMBuilderTest {
         assertThat(actual.getUserRemoteConfigs(), hasSize(1));
         UserRemoteConfig config = actual.getUserRemoteConfigs().get(0);
         assertThat(config.getName(), is("origin"));
-        assertThat(config.getRefspec(), is("+refs/pull-requests/1/from:refs/remotes/origin/PR-1"));
+        assertThat(config.getRefspec(), is("+refs/heads/qa-branch:refs/remotes/origin/PR-1"));
         assertThat(config.getUrl(), is("ssh://git@bitbucket.test:7999/tester/test-repo.git"));
         assertThat(config.getCredentialsId(), is("user-key"));
         RemoteConfig origin = actual.getRepositoryByName("origin");
@@ -1190,7 +1190,7 @@ public class BitbucketGitSCMBuilderTest {
         assertThat(origin.getURIs(), hasSize(1));
         assertThat(origin.getURIs().get(0).toString(), is("ssh://git@bitbucket.test:7999/tester/test-repo.git"));
         assertThat(origin.getFetchRefSpecs(), hasSize(1));
-        assertThat(origin.getFetchRefSpecs().get(0).getSource(), is("refs/pull-requests/1/from"));
+        assertThat(origin.getFetchRefSpecs().get(0).getSource(), is("refs/heads/qa-branch"));
         assertThat(origin.getFetchRefSpecs().get(0).getDestination(), is("refs/remotes/origin/PR-1"));
         assertThat(origin.getFetchRefSpecs().get(0).isForceUpdate(), is(true));
         assertThat(origin.getFetchRefSpecs().get(0).isWildcard(), is(false));
@@ -1221,7 +1221,7 @@ public class BitbucketGitSCMBuilderTest {
         assertThat(instance.head(), is((SCMHead) head));
         assertThat(instance.revision(), is(nullValue()));
         assertThat(instance.scmSource(), is(source));
-        assertThat(instance.refSpecs(), contains("+refs/pull-requests/1/from:refs/remotes/@{remote}/PR-1"));
+        assertThat(instance.refSpecs(), contains("+refs/heads/qa-branch:refs/remotes/@{remote}/PR-1"));
         assertThat(instance.cloneLinks(), is(Collections.<BitbucketHref>emptyList()));
         assertThat("expecting dummy value until clone links provided or withBitbucketRemote called",
                 instance.remote(), is("https://bitbucket.test"));
@@ -1241,7 +1241,7 @@ public class BitbucketGitSCMBuilderTest {
         assertThat(actual.getUserRemoteConfigs(), hasSize(1));
         UserRemoteConfig config = actual.getUserRemoteConfigs().get(0);
         assertThat(config.getName(), is("origin"));
-        assertThat(config.getRefspec(), is("+refs/pull-requests/1/from:refs/remotes/origin/PR-1"));
+        assertThat(config.getRefspec(), is("+refs/heads/qa-branch:refs/remotes/origin/PR-1"));
         assertThat(config.getUrl(), is("https://bitbucket.test/scm/tester/test-repo.git"));
         assertThat(config.getCredentialsId(), is(nullValue()));
         RemoteConfig origin = actual.getRepositoryByName("origin");
@@ -1249,7 +1249,7 @@ public class BitbucketGitSCMBuilderTest {
         assertThat(origin.getURIs(), hasSize(1));
         assertThat(origin.getURIs().get(0).toString(), is("https://bitbucket.test/scm/tester/test-repo.git"));
         assertThat(origin.getFetchRefSpecs(), hasSize(1));
-        assertThat(origin.getFetchRefSpecs().get(0).getSource(), is("refs/pull-requests/1/from"));
+        assertThat(origin.getFetchRefSpecs().get(0).getSource(), is("refs/heads/qa-branch"));
         assertThat(origin.getFetchRefSpecs().get(0).getDestination(), is("refs/remotes/origin/PR-1"));
         assertThat(origin.getFetchRefSpecs().get(0).isForceUpdate(), is(true));
         assertThat(origin.getFetchRefSpecs().get(0).isWildcard(), is(false));
@@ -1268,7 +1268,7 @@ public class BitbucketGitSCMBuilderTest {
         assertThat(instance.head(), is((SCMHead) head));
         assertThat(instance.revision(), is(nullValue()));
         assertThat(instance.scmSource(), is(source));
-        assertThat(instance.refSpecs(), contains("+refs/pull-requests/1/from:refs/remotes/@{remote}/PR-1"));
+        assertThat(instance.refSpecs(), contains("+refs/heads/qa-branch:refs/remotes/@{remote}/PR-1"));
         assertThat(instance.cloneLinks(), is(Collections.<BitbucketHref>emptyList()));
         assertThat("expecting dummy value until clone links provided or withBitbucketRemote called",
                 instance.remote(), is("https://bitbucket.test"));
@@ -1288,7 +1288,7 @@ public class BitbucketGitSCMBuilderTest {
         assertThat(actual.getUserRemoteConfigs(), hasSize(1));
         UserRemoteConfig config = actual.getUserRemoteConfigs().get(0);
         assertThat(config.getName(), is("origin"));
-        assertThat(config.getRefspec(), is("+refs/pull-requests/1/from:refs/remotes/origin/PR-1"));
+        assertThat(config.getRefspec(), is("+refs/heads/qa-branch:refs/remotes/origin/PR-1"));
         assertThat(config.getUrl(), is("https://bitbucket.test/scm/tester/test-repo.git"));
         assertThat(config.getCredentialsId(), is("user-pass"));
         RemoteConfig origin = actual.getRepositoryByName("origin");
@@ -1296,7 +1296,7 @@ public class BitbucketGitSCMBuilderTest {
         assertThat(origin.getURIs(), hasSize(1));
         assertThat(origin.getURIs().get(0).toString(), is("https://bitbucket.test/scm/tester/test-repo.git"));
         assertThat(origin.getFetchRefSpecs(), hasSize(1));
-        assertThat(origin.getFetchRefSpecs().get(0).getSource(), is("refs/pull-requests/1/from"));
+        assertThat(origin.getFetchRefSpecs().get(0).getSource(), is("refs/heads/qa-branch"));
         assertThat(origin.getFetchRefSpecs().get(0).getDestination(), is("refs/remotes/origin/PR-1"));
         assertThat(origin.getFetchRefSpecs().get(0).isForceUpdate(), is(true));
         assertThat(origin.getFetchRefSpecs().get(0).isWildcard(), is(false));
@@ -1315,7 +1315,7 @@ public class BitbucketGitSCMBuilderTest {
         assertThat(instance.head(), is((SCMHead) head));
         assertThat(instance.revision(), is(nullValue()));
         assertThat(instance.scmSource(), is(source));
-        assertThat(instance.refSpecs(), contains("+refs/pull-requests/1/from:refs/remotes/@{remote}/PR-1"));
+        assertThat(instance.refSpecs(), contains("+refs/heads/qa-branch:refs/remotes/@{remote}/PR-1"));
         assertThat(instance.cloneLinks(), is(Collections.<BitbucketHref>emptyList()));
         assertThat("expecting dummy value until clone links provided or withBitbucketRemote called",
                 instance.remote(), is("https://bitbucket.test"));
@@ -1335,7 +1335,7 @@ public class BitbucketGitSCMBuilderTest {
         assertThat(actual.getUserRemoteConfigs(), hasSize(1));
         UserRemoteConfig config = actual.getUserRemoteConfigs().get(0);
         assertThat(config.getName(), is("origin"));
-        assertThat(config.getRefspec(), is("+refs/pull-requests/1/from:refs/remotes/origin/PR-1"));
+        assertThat(config.getRefspec(), is("+refs/heads/qa-branch:refs/remotes/origin/PR-1"));
         assertThat(config.getUrl(), is("ssh://git@bitbucket.test:7999/tester/test-repo.git"));
         assertThat(config.getCredentialsId(), is("user-key"));
         RemoteConfig origin = actual.getRepositoryByName("origin");
@@ -1343,7 +1343,7 @@ public class BitbucketGitSCMBuilderTest {
         assertThat(origin.getURIs(), hasSize(1));
         assertThat(origin.getURIs().get(0).toString(), is("ssh://git@bitbucket.test:7999/tester/test-repo.git"));
         assertThat(origin.getFetchRefSpecs(), hasSize(1));
-        assertThat(origin.getFetchRefSpecs().get(0).getSource(), is("refs/pull-requests/1/from"));
+        assertThat(origin.getFetchRefSpecs().get(0).getSource(), is("refs/heads/qa-branch"));
         assertThat(origin.getFetchRefSpecs().get(0).getDestination(), is("refs/remotes/origin/PR-1"));
         assertThat(origin.getFetchRefSpecs().get(0).isForceUpdate(), is(true));
         assertThat(origin.getFetchRefSpecs().get(0).isWildcard(), is(false));
@@ -1811,7 +1811,7 @@ public class BitbucketGitSCMBuilderTest {
         assertThat(instance.head(), is((SCMHead) head));
         assertThat(instance.revision(), is((SCMRevision) revision));
         assertThat(instance.scmSource(), is(source));
-        assertThat(instance.refSpecs(), contains("+refs/pull-requests/1/from:refs/remotes/@{remote}/PR-1"));
+        assertThat(instance.refSpecs(), contains("+refs/heads/qa-branch:refs/remotes/@{remote}/PR-1"));
         assertThat(instance.cloneLinks(), is(Collections.<BitbucketHref>emptyList()));
         assertThat("expecting dummy value until clone links provided or withBitbucketRemote called",
                 instance.remote(), is("https://bitbucket.test"));
@@ -1831,7 +1831,7 @@ public class BitbucketGitSCMBuilderTest {
         assertThat(actual.getUserRemoteConfigs(), hasSize(2));
         UserRemoteConfig config = actual.getUserRemoteConfigs().get(0);
         assertThat(config.getName(), is("origin"));
-        assertThat(config.getRefspec(), is("+refs/pull-requests/1/from:refs/remotes/origin/PR-1"));
+        assertThat(config.getRefspec(), is("+refs/heads/qa-branch:refs/remotes/origin/PR-1"));
         assertThat(config.getUrl(), is("https://bitbucket.test/scm/tester/test-repo.git"));
         assertThat(config.getCredentialsId(), is(nullValue()));
         config = actual.getUserRemoteConfigs().get(1);
@@ -1844,7 +1844,7 @@ public class BitbucketGitSCMBuilderTest {
         assertThat(origin.getURIs(), hasSize(1));
         assertThat(origin.getURIs().get(0).toString(), is("https://bitbucket.test/scm/tester/test-repo.git"));
         assertThat(origin.getFetchRefSpecs(), hasSize(1));
-        assertThat(origin.getFetchRefSpecs().get(0).getSource(), is("refs/pull-requests/1/from"));
+        assertThat(origin.getFetchRefSpecs().get(0).getSource(), is("refs/heads/qa-branch"));
         assertThat(origin.getFetchRefSpecs().get(0).getDestination(), is("refs/remotes/origin/PR-1"));
         assertThat(origin.getFetchRefSpecs().get(0).isForceUpdate(), is(true));
         assertThat(origin.getFetchRefSpecs().get(0).isWildcard(), is(false));
@@ -1895,7 +1895,7 @@ public class BitbucketGitSCMBuilderTest {
         assertThat(instance.head(), is((SCMHead) head));
         assertThat(instance.revision(), is((SCMRevision) revision));
         assertThat(instance.scmSource(), is(source));
-        assertThat(instance.refSpecs(), contains("+refs/pull-requests/1/from:refs/remotes/@{remote}/PR-1"));
+        assertThat(instance.refSpecs(), contains("+refs/heads/qa-branch:refs/remotes/@{remote}/PR-1"));
         assertThat(instance.cloneLinks(), is(Collections.<BitbucketHref>emptyList()));
         assertThat("expecting dummy value until clone links provided or withBitbucketRemote called",
                 instance.remote(), is("https://bitbucket.test"));
@@ -1915,7 +1915,7 @@ public class BitbucketGitSCMBuilderTest {
         assertThat(actual.getUserRemoteConfigs(), hasSize(2));
         UserRemoteConfig config = actual.getUserRemoteConfigs().get(0);
         assertThat(config.getName(), is("origin"));
-        assertThat(config.getRefspec(), is("+refs/pull-requests/1/from:refs/remotes/origin/PR-1"));
+        assertThat(config.getRefspec(), is("+refs/heads/qa-branch:refs/remotes/origin/PR-1"));
         assertThat(config.getUrl(), is("https://bitbucket.test/scm/tester/test-repo.git"));
         assertThat(config.getCredentialsId(), is("user-pass"));
         config = actual.getUserRemoteConfigs().get(1);
@@ -1928,7 +1928,7 @@ public class BitbucketGitSCMBuilderTest {
         assertThat(origin.getURIs(), hasSize(1));
         assertThat(origin.getURIs().get(0).toString(), is("https://bitbucket.test/scm/tester/test-repo.git"));
         assertThat(origin.getFetchRefSpecs(), hasSize(1));
-        assertThat(origin.getFetchRefSpecs().get(0).getSource(), is("refs/pull-requests/1/from"));
+        assertThat(origin.getFetchRefSpecs().get(0).getSource(), is("refs/heads/qa-branch"));
         assertThat(origin.getFetchRefSpecs().get(0).getDestination(), is("refs/remotes/origin/PR-1"));
         assertThat(origin.getFetchRefSpecs().get(0).isForceUpdate(), is(true));
         assertThat(origin.getFetchRefSpecs().get(0).isWildcard(), is(false));
@@ -1978,7 +1978,7 @@ public class BitbucketGitSCMBuilderTest {
         assertThat(instance.head(), is((SCMHead) head));
         assertThat(instance.revision(), is((SCMRevision) revision));
         assertThat(instance.scmSource(), is(source));
-        assertThat(instance.refSpecs(), contains("+refs/pull-requests/1/from:refs/remotes/@{remote}/PR-1"));
+        assertThat(instance.refSpecs(), contains("+refs/heads/qa-branch:refs/remotes/@{remote}/PR-1"));
         assertThat(instance.cloneLinks(), is(Collections.<BitbucketHref>emptyList()));
         assertThat("expecting dummy value until clone links provided or withBitbucketRemote called",
                 instance.remote(), is("https://bitbucket.test"));
@@ -1998,7 +1998,7 @@ public class BitbucketGitSCMBuilderTest {
         assertThat(actual.getUserRemoteConfigs(), hasSize(2));
         UserRemoteConfig config = actual.getUserRemoteConfigs().get(0);
         assertThat(config.getName(), is("origin"));
-        assertThat(config.getRefspec(), is("+refs/pull-requests/1/from:refs/remotes/origin/PR-1"));
+        assertThat(config.getRefspec(), is("+refs/heads/qa-branch:refs/remotes/origin/PR-1"));
         assertThat(config.getUrl(), is("ssh://git@bitbucket.test:7999/tester/test-repo.git"));
         assertThat(config.getCredentialsId(), is("user-key"));
         config = actual.getUserRemoteConfigs().get(1);
@@ -2011,7 +2011,7 @@ public class BitbucketGitSCMBuilderTest {
         assertThat(origin.getURIs(), hasSize(1));
         assertThat(origin.getURIs().get(0).toString(), is("ssh://git@bitbucket.test:7999/tester/test-repo.git"));
         assertThat(origin.getFetchRefSpecs(), hasSize(1));
-        assertThat(origin.getFetchRefSpecs().get(0).getSource(), is("refs/pull-requests/1/from"));
+        assertThat(origin.getFetchRefSpecs().get(0).getSource(), is("refs/heads/qa-branch"));
         assertThat(origin.getFetchRefSpecs().get(0).getDestination(), is("refs/remotes/origin/PR-1"));
         assertThat(origin.getFetchRefSpecs().get(0).isForceUpdate(), is(true));
         assertThat(origin.getFetchRefSpecs().get(0).isWildcard(), is(false));
@@ -2057,7 +2057,7 @@ public class BitbucketGitSCMBuilderTest {
         assertThat(instance.head(), is((SCMHead) head));
         assertThat(instance.revision(), is(nullValue()));
         assertThat(instance.scmSource(), is(source));
-        assertThat(instance.refSpecs(), contains("+refs/pull-requests/1/from:refs/remotes/@{remote}/PR-1"));
+        assertThat(instance.refSpecs(), contains("+refs/heads/qa-branch:refs/remotes/@{remote}/PR-1"));
         assertThat(instance.cloneLinks(), is(Collections.<BitbucketHref>emptyList()));
         assertThat("expecting dummy value until clone links provided or withBitbucketRemote called",
                 instance.remote(), is("https://bitbucket.test"));
@@ -2077,7 +2077,7 @@ public class BitbucketGitSCMBuilderTest {
         assertThat(actual.getUserRemoteConfigs(), hasSize(2));
         UserRemoteConfig config = actual.getUserRemoteConfigs().get(0);
         assertThat(config.getName(), is("origin"));
-        assertThat(config.getRefspec(), is("+refs/pull-requests/1/from:refs/remotes/origin/PR-1"));
+        assertThat(config.getRefspec(), is("+refs/heads/qa-branch:refs/remotes/origin/PR-1"));
         assertThat(config.getUrl(), is("https://bitbucket.test/scm/tester/test-repo.git"));
         assertThat(config.getCredentialsId(), is(nullValue()));
         config = actual.getUserRemoteConfigs().get(1);
@@ -2090,7 +2090,7 @@ public class BitbucketGitSCMBuilderTest {
         assertThat(origin.getURIs(), hasSize(1));
         assertThat(origin.getURIs().get(0).toString(), is("https://bitbucket.test/scm/tester/test-repo.git"));
         assertThat(origin.getFetchRefSpecs(), hasSize(1));
-        assertThat(origin.getFetchRefSpecs().get(0).getSource(), is("refs/pull-requests/1/from"));
+        assertThat(origin.getFetchRefSpecs().get(0).getSource(), is("refs/heads/qa-branch"));
         assertThat(origin.getFetchRefSpecs().get(0).getDestination(), is("refs/remotes/origin/PR-1"));
         assertThat(origin.getFetchRefSpecs().get(0).isForceUpdate(), is(true));
         assertThat(origin.getFetchRefSpecs().get(0).isWildcard(), is(false));
@@ -2125,7 +2125,7 @@ public class BitbucketGitSCMBuilderTest {
         assertThat(instance.head(), is((SCMHead) head));
         assertThat(instance.revision(), is(nullValue()));
         assertThat(instance.scmSource(), is(source));
-        assertThat(instance.refSpecs(), contains("+refs/pull-requests/1/from:refs/remotes/@{remote}/PR-1"));
+        assertThat(instance.refSpecs(), contains("+refs/heads/qa-branch:refs/remotes/@{remote}/PR-1"));
         assertThat(instance.cloneLinks(), is(Collections.<BitbucketHref>emptyList()));
         assertThat("expecting dummy value until clone links provided or withBitbucketRemote called",
                 instance.remote(), is("https://bitbucket.test"));
@@ -2145,7 +2145,7 @@ public class BitbucketGitSCMBuilderTest {
         assertThat(actual.getUserRemoteConfigs(), hasSize(2));
         UserRemoteConfig config = actual.getUserRemoteConfigs().get(0);
         assertThat(config.getName(), is("origin"));
-        assertThat(config.getRefspec(), is("+refs/pull-requests/1/from:refs/remotes/origin/PR-1"));
+        assertThat(config.getRefspec(), is("+refs/heads/qa-branch:refs/remotes/origin/PR-1"));
         assertThat(config.getUrl(), is("https://bitbucket.test/scm/tester/test-repo.git"));
         assertThat(config.getCredentialsId(), is("user-pass"));
         config = actual.getUserRemoteConfigs().get(1);
@@ -2158,7 +2158,7 @@ public class BitbucketGitSCMBuilderTest {
         assertThat(origin.getURIs(), hasSize(1));
         assertThat(origin.getURIs().get(0).toString(), is("https://bitbucket.test/scm/tester/test-repo.git"));
         assertThat(origin.getFetchRefSpecs(), hasSize(1));
-        assertThat(origin.getFetchRefSpecs().get(0).getSource(), is("refs/pull-requests/1/from"));
+        assertThat(origin.getFetchRefSpecs().get(0).getSource(), is("refs/heads/qa-branch"));
         assertThat(origin.getFetchRefSpecs().get(0).getDestination(), is("refs/remotes/origin/PR-1"));
         assertThat(origin.getFetchRefSpecs().get(0).isForceUpdate(), is(true));
         assertThat(origin.getFetchRefSpecs().get(0).isWildcard(), is(false));
@@ -2193,7 +2193,7 @@ public class BitbucketGitSCMBuilderTest {
         assertThat(instance.head(), is((SCMHead) head));
         assertThat(instance.revision(), is(nullValue()));
         assertThat(instance.scmSource(), is(source));
-        assertThat(instance.refSpecs(), contains("+refs/pull-requests/1/from:refs/remotes/@{remote}/PR-1"));
+        assertThat(instance.refSpecs(), contains("+refs/heads/qa-branch:refs/remotes/@{remote}/PR-1"));
         assertThat(instance.cloneLinks(), is(Collections.<BitbucketHref>emptyList()));
         assertThat("expecting dummy value until clone links provided or withBitbucketRemote called",
                 instance.remote(), is("https://bitbucket.test"));
@@ -2213,7 +2213,7 @@ public class BitbucketGitSCMBuilderTest {
         assertThat(actual.getUserRemoteConfigs(), hasSize(2));
         UserRemoteConfig config = actual.getUserRemoteConfigs().get(0);
         assertThat(config.getName(), is("origin"));
-        assertThat(config.getRefspec(), is("+refs/pull-requests/1/from:refs/remotes/origin/PR-1"));
+        assertThat(config.getRefspec(), is("+refs/heads/qa-branch:refs/remotes/origin/PR-1"));
         assertThat(config.getUrl(), is("ssh://git@bitbucket.test:7999/tester/test-repo.git"));
         assertThat(config.getCredentialsId(), is("user-key"));
         config = actual.getUserRemoteConfigs().get(1);
@@ -2226,7 +2226,7 @@ public class BitbucketGitSCMBuilderTest {
         assertThat(origin.getURIs(), hasSize(1));
         assertThat(origin.getURIs().get(0).toString(), is("ssh://git@bitbucket.test:7999/tester/test-repo.git"));
         assertThat(origin.getFetchRefSpecs(), hasSize(1));
-        assertThat(origin.getFetchRefSpecs().get(0).getSource(), is("refs/pull-requests/1/from"));
+        assertThat(origin.getFetchRefSpecs().get(0).getSource(), is("refs/heads/qa-branch"));
         assertThat(origin.getFetchRefSpecs().get(0).getDestination(), is("refs/remotes/origin/PR-1"));
         assertThat(origin.getFetchRefSpecs().get(0).isForceUpdate(), is(true));
         assertThat(origin.getFetchRefSpecs().get(0).isWildcard(), is(false));


### PR DESCRIPTION
Hello :)

Reasons for this simplification:

* Bitbucket Server does not update pull request branches (`refs/pull-requests/*`) in a timely manner.
  They implement lazy merges "for performance reasons": the branches are updated on demand only (when someone opens a pull request web page).
  See https://jira.atlassian.com/browse/BSERV-3196 for details.

  When you push a new commit to the branch from which
  a pull request is open, the following happens:
  1. The branch (`refs/heads/branch-name`) is updated;
  2. The PR branch (`refs/pull-requests/{id}/from`) does not change;
  2. Jenkins starts a new build;
  3. Jenkins fetches the PR branch (`refs/pull-requests/{id}/from`);
  4. The branch still points to the previous commit;
  5. Jenkins tries to check out the new commit:

         Merging remotes/upstream/master commit {master_sha} into PR head commit {new_sha}

  6. It fails with the following error message:

         hudson.plugins.git.GitException: Command "git checkout -f {new_sha}" returned status code 128:
         stdout:
         stderr: fatal: reference is not a tree: {new_sha}

* The pull request branches are considered an implementation detail and Atlassian staff discourages users from using them directly. They do not give any guarantees about these branches.

It is better not to use these branches altogether and rely on regular branches for this plugin's operation.

This plugin merges upstream into the branch anyway.

What do you think?