### PR TITLE
Append build description to bitbucket status description

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketBuildStatusNotifications.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketBuildStatusNotifications.java
@@ -45,6 +45,7 @@ import jenkins.scm.api.SCMHeadObserver;
 import jenkins.scm.api.SCMRevision;
 import jenkins.scm.api.SCMRevisionAction;
 import jenkins.scm.api.SCMSource;
+import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.displayurlapi.DisplayURLProvider;
 
 /**
@@ -91,19 +92,26 @@ public class BitbucketBuildStatusNotifications {
         String name = build.getFullDisplayName(); // use the build number as the display name of the status
         BitbucketBuildStatus status;
         Result result = build.getResult();
+        String buildDescription = build.getDescription();
+        String statusDescription;
+        String state;
         if (Result.SUCCESS.equals(result)) {
-            status = new BitbucketBuildStatus(hash, "This commit looks good", "SUCCESSFUL", url, key, name);
+            statusDescription = StringUtils.defaultIfBlank(buildDescription, "This commit looks good.");
+            state = "SUCCESSFUL";
         } else if (Result.UNSTABLE.equals(result)) {
-            status = new BitbucketBuildStatus(hash, "This commit has test failures", "FAILED", url, key, name);
+            statusDescription = StringUtils.defaultIfBlank(buildDescription, "This commit has test failures.");
+            state = "FAILED";
         } else if (Result.FAILURE.equals(result)) {
-            status = new BitbucketBuildStatus(hash, "There was a failure building this commit", "FAILED", url, key,
-                    name);
+            statusDescription = StringUtils.defaultIfBlank(buildDescription, "There was a failure building this commit.");
+            state = "FAILED";
         } else if (result != null) { // ABORTED etc.
-            status = new BitbucketBuildStatus(hash, "Something is wrong with the build of this commit", "FAILED", url,
-                    key, name);
+            statusDescription = StringUtils.defaultIfBlank(buildDescription, "Something is wrong with the build of this commit.");
+            state = "FAILED";
         } else {
-            status = new BitbucketBuildStatus(hash, "The build is in progress...", "INPROGRESS", url, key, name);
+            statusDescription = StringUtils.defaultIfBlank(buildDescription, "The build is in progress...");
+            state = "INPROGRESS";
         }
+        status = new BitbucketBuildStatus(hash, statusDescription, state, url, key, name);
         new BitbucketChangesetCommentNotifier(bitbucket).buildStatus(status);
         if (result != null) {
             listener.getLogger().println("[Bitbucket] Build result notified");


### PR DESCRIPTION
Bitbucket allows providing a description in the status, currently this gets set as a default hard coded string. For backwards compatibility, but allowing for detailed messages, use the hard coded string with the build description appended.