### PR TITLE
lower Jackson dependency to 2.7.3 for java 7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -135,9 +135,9 @@
       <version>2.0</version>
     </dependency>
     <dependency>
-      <groupId>com.fasterxml.jackson.jaxrs</groupId>
-      <artifactId>jackson-jaxrs-json-provider</artifactId>
-      <version>2.9.6</version>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>jackson2-api</artifactId>
+      <version>2.7.3</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
We should be using the Jenkins plugin version of Jackson

A extension of #143's discussion