### PR TITLE
[JENKINS-53707] Allow commit message and author of head commit

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
     <changelist>-SNAPSHOT</changelist>
     <jenkins.version>1.642.3</jenkins.version>
     <java.level>7</java.level>
-    <scm-api.version>2.2.0</scm-api.version>
+    <scm-api.version>2.2.7</scm-api.version>
     <git.version>3.6.0</git.version>
   </properties>
 
@@ -151,7 +151,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>branch-api</artifactId>
-      <version>2.0.11</version>
+      <version>2.0.20</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketBuildStatusNotifications.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketBuildStatusNotifications.java
@@ -148,7 +148,7 @@ public class BitbucketBuildStatusNotifications {
                 .notificationsDisabled()) {
             return;
         }
-        SCMRevision r = SCMRevisionAction.getRevision(build);  // TODO JENKINS-44648 getRevision(s, build)
+        SCMRevision r = SCMRevisionAction.getRevision(s, build);
         String hash = getHash(r);
         if (hash == null) {
             return;

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketGitSCMRevision.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketGitSCMRevision.java
@@ -1,0 +1,113 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2018, Nikolas Falco
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.cloudbees.jenkins.plugins.bitbucket;
+
+import com.cloudbees.jenkins.plugins.bitbucket.JsonParser.BitbucketDateFormat;
+import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketCommit;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.text.ParseException;
+import java.util.Date;
+import jenkins.plugins.git.AbstractGitSCMSource.SCMRevisionImpl;
+import jenkins.scm.api.SCMHead;
+import org.apache.commons.lang.StringUtils;
+
+/**
+ * Represents a specific revision of a bitbucket {@link SCMHead}.
+ *
+ * @author Nikolas Falco
+ * @since 2.2.14
+ */
+public class BitbucketGitSCMRevision extends SCMRevisionImpl {
+    private static final long serialVersionUID = 1L;
+
+    private final String message;
+    private final String author;
+    private final Date date;
+
+    /**
+     * Construct a Bitbucket revision.
+     *
+     * @param head the {@link SCMHead} that represent this revision
+     * @param commit head
+     */
+    public BitbucketGitSCMRevision(@NonNull SCMHead head, @NonNull BitbucketCommit commit) {
+        super(head, commit.getHash());
+        this.message = commit.getMessage();
+        this.author = commit.getAuthor();
+        Date commitDate;
+        try {
+            commitDate = new BitbucketDateFormat().parse(commit.getDate());
+        } catch (ParseException e) {
+            commitDate = null;
+        }
+        this.date = commitDate;
+    }
+
+    /**
+     * Returns the author of this revision in GIT format.
+     * 
+     * @return commit author in the following format &gt;name&lt; &gt;email&lt;
+     */
+    public String getAuthor() {
+        return author;
+    }
+
+    /**
+     * Returns the message associated with this revision.
+     * 
+     * @return revision message
+     */
+    public String getMessage() {
+        return message;
+    }
+
+    /**
+     * Return the revision date in ISO format.
+     * 
+     * @return date for this revision
+     */
+    public Date getDate() {
+        return (Date) date.clone();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || !(o instanceof SCMRevisionImpl)) {
+            return false;
+        }
+
+        SCMRevisionImpl that = (SCMRevisionImpl) o;
+
+        return StringUtils.equals(getHash(), that.getHash()) && getHead().equals(that.getHead());
+    }
+
+    @Override
+    public int hashCode() {
+        return super.hashCode();
+    }
+
+}

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMNavigator.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMNavigator.java
@@ -219,7 +219,7 @@ public class BitbucketSCMNavigator extends SCMNavigator {
 
     @NonNull
     public List<SCMTrait<?>> getTraits() {
-        return Collections.unmodifiableList(traits);
+        return Collections.<SCMTrait<?>>unmodifiableList(traits);
     }
 
     @DataBoundSetter
@@ -315,7 +315,7 @@ public class BitbucketSCMNavigator extends SCMNavigator {
     @RestrictedSince("2.2.0")
     @DataBoundSetter
     public void setCheckoutCredentialsId(String checkoutCredentialsId) {
-        for (Iterator<SCMTrait<?>> iterator = traits.iterator(); iterator.hasNext(); ) {
+        for (Iterator<SCMTrait<? extends SCMTrait<?>>> iterator = traits.iterator(); iterator.hasNext(); ) {
             if (iterator.next() instanceof SSHCheckoutTrait) {
                 iterator.remove();
             }

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSourceRequest.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSourceRequest.java
@@ -158,7 +158,7 @@ public class BitbucketSCMSourceRequest extends SCMSourceRequest {
                     if (((PullRequestSCMHead) h).getCheckoutStrategy() == ChangeRequestCheckoutStrategy.MERGE) {
                         branchNames.add(((PullRequestSCMHead) h).getTarget().getName());
                     }
-                } else if (h instanceof TagSCMHead) { // TODO replace with concrete class when tag support added
+                } else if (h instanceof BitbucketTagSCMHead) {
                     tagNames.add(h.getName());
                 }
             }

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketTagSCMRevision.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketTagSCMRevision.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright (c) 2016, CloudBees, Inc.
+ * Copyright (c) 2018, Nikolas Falco
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,46 +21,29 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package com.cloudbees.jenkins.plugins.bitbucket.api;
+package com.cloudbees.jenkins.plugins.bitbucket;
+
+import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketCommit;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import jenkins.scm.api.SCMHead;
 
 /**
- * Bitbucket Branch.
+ * Represents a specific revision of a bitbucket {@link BitbucketTagSCMRevision}.
  *
- * It's used to represent branches to be built and source branches for pull requests.
+ * @author Nikolas Falco
+ * @since 2.2.14
  */
-public interface BitbucketBranch {
+public class BitbucketTagSCMRevision extends BitbucketGitSCMRevision {
+    private static final long serialVersionUID = 1L;
 
     /**
-     * @return the head commit node of this branch
-     */
-    String getRawNode();
-
-    /**
-     * @return the branch name
-     */
-    String getName();
-
-    /**
-     * @return the commit milliseconds from epoch
-     */
-    long getDateMillis();
-
-    /**
-     * Returns the head commit message for this branch.
+     * Construct a Bitbucket tag revision.
      *
-     * @return the head commit message of this branch
-     * @author Nikolas Falco
-     * @since 2.2.14
+     * @param head the {@link SCMHead} that represent this tag
+     * @param commit head
      */
-    String getMessage();
-
-    /**
-     * Returns the head commit author for this branch.
-     *
-     * @return the head commit author of this branch
-     * @author Nikolas Falco
-     * @since 2.2.14
-     */
-    String getAuthor();
+    public BitbucketTagSCMRevision(@NonNull BitbucketTagSCMHead head, @NonNull BitbucketCommit commit) {
+        super(head, commit);
+    }
 
 }

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/JsonParser.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/JsonParser.java
@@ -56,10 +56,14 @@ public final class JsonParser {
      * The StdDateFormat parser before 2.9.2 returns null when the timezone is expressed in
      * the extended form [+-]hh:mm. and there are more than 3 milliseconds.
      * 
+     * @deprecated Replace with {@link StdDateFormat} when update jackson2 (api
+     *             plugin) to version greater than 2.9.2
      * @author nikolasfalco
      */
     // TODO remove this class when update jackson2 (api plugin) to version greater than 2.9.2
-    /*package*/ static class BitbucketDateFormat extends ISO8601DateFormat {
+    @Deprecated
+    @Restricted(NoExternalUse.class)
+    public static class BitbucketDateFormat extends ISO8601DateFormat {
         private static final long serialVersionUID = 1L;
 
         /*

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/PullRequestSCMHead.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/PullRequestSCMHead.java
@@ -216,6 +216,7 @@ public class PullRequestSCMHead extends SCMHead implements ChangeRequestSCMHead2
      *
      * @deprecated used for data migration.
      */
+    @Deprecated
     @Restricted(NoExternalUse.class)
     @Extension
     public static class FixLegacyMigration1 extends
@@ -257,6 +258,7 @@ public class PullRequestSCMHead extends SCMHead implements ChangeRequestSCMHead2
      *
      * @deprecated used for data migration.
      */
+    @Deprecated
     @Restricted(NoExternalUse.class)
     @Extension
     public static class FixLegacyMigration2 extends
@@ -287,7 +289,7 @@ public class PullRequestSCMHead extends SCMHead implements ChangeRequestSCMHead2
                     head,
                     // ChangeRequestCheckoutStrategy.HEAD means we ignore the target revision
                     // so we can leave it null as a placeholder
-                    new BitbucketSCMSource.MercurialRevision(head.getTarget(), null),
+                    new BitbucketSCMSource.MercurialRevision(head.getTarget(), (String) null),
                     new BitbucketSCMSource.MercurialRevision(head, revision.getHash())
             ) : null;
         }

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/SCMHeadWithOwnerAndRepo.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/SCMHeadWithOwnerAndRepo.java
@@ -165,7 +165,7 @@ public class SCMHeadWithOwnerAndRepo extends SCMHead {
                     head,
                     // ChangeRequestCheckoutStrategy.HEAD means we ignore the target revision
                     // so we can leave it null as a placeholder
-                    new BitbucketSCMSource.MercurialRevision(head.getTarget(), null),
+                    new BitbucketSCMSource.MercurialRevision(head.getTarget(), (String) null),
                     new BitbucketSCMSource.MercurialRevision(head, revision.getHash())
             ) : null;
         }

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/BitbucketApi.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/BitbucketApi.java
@@ -169,6 +169,18 @@ public interface BitbucketApi {
     BitbucketCommit resolveCommit(@NonNull String hash) throws IOException, InterruptedException;
 
     /**
+     * Resolve the head commit object of the pull request source repository branch.
+     *
+     * @param pull the pull request to resolve the source hash from
+     * @return the source head commit object
+     * @throws IOException if there was a network communications error.
+     * @throws InterruptedException if interrupted while waiting on remote communications.
+     * @since 2.2.14
+     */
+    @NonNull
+    BitbucketCommit resolveCommit(@NonNull BitbucketPullRequest pull) throws IOException, InterruptedException;
+
+    /**
      * Resolve the head commit hash of the pull request source repository branch.
      *
      * @param pull the pull request to resolve the source hash from

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/BitbucketCommit.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/BitbucketCommit.java
@@ -29,6 +29,15 @@ package com.cloudbees.jenkins.plugins.bitbucket.api;
 public interface BitbucketCommit {
 
     /**
+     * Returns the head commit author for this branch.
+     *
+     * @return the head commit author of this branch
+     * @author Nikolas Falco
+     * @since 2.2.14
+     */
+    String getAuthor();
+
+    /**
      * @return commit message
      */
     String getMessage();

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/branch/BitbucketCloudAuthor.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/branch/BitbucketCloudAuthor.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright (c) 2016, CloudBees, Inc.
+ * Copyright (c) 2018, Nikolas Falco
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,46 +21,32 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package com.cloudbees.jenkins.plugins.bitbucket.api;
+package com.cloudbees.jenkins.plugins.bitbucket.client.branch;
 
 /**
- * Bitbucket Branch.
- *
- * It's used to represent branches to be built and source branches for pull requests.
+ * Represents the author information given by Bitbucket Cloud.
+ * 
+ * @author Nikolas Falco
+ * @since 2.2.14
  */
-public interface BitbucketBranch {
+public class BitbucketCloudAuthor {
+    private String raw;
 
     /**
-     * @return the head commit node of this branch
+     * Returns the raw author string provided by the commit.
+     * 
+     * @return the commit author, typically in the form &lt;name&gt; &lt;email&gt;
      */
-    String getRawNode();
+    public String getRaw() {
+        return raw;
+    }
 
     /**
-     * @return the branch name
+     * Sets the raw author string provided by the commit.
+     * 
+     * @param raw the commit author
      */
-    String getName();
-
-    /**
-     * @return the commit milliseconds from epoch
-     */
-    long getDateMillis();
-
-    /**
-     * Returns the head commit message for this branch.
-     *
-     * @return the head commit message of this branch
-     * @author Nikolas Falco
-     * @since 2.2.14
-     */
-    String getMessage();
-
-    /**
-     * Returns the head commit author for this branch.
-     *
-     * @return the head commit author of this branch
-     * @author Nikolas Falco
-     * @since 2.2.14
-     */
-    String getAuthor();
-
+    public void setRaw(String raw) {
+        this.raw = raw;
+    }
 }

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/branch/BitbucketCloudBranch.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/branch/BitbucketCloudBranch.java
@@ -24,28 +24,31 @@
 package com.cloudbees.jenkins.plugins.bitbucket.client.branch;
 
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketBranch;
-import com.cloudbees.jenkins.plugins.bitbucket.client.repository.BitbucketCloudRepository;
-
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import java.util.Date;
 import java.util.List;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 
 public class BitbucketCloudBranch implements BitbucketBranch {
     private final String name;
     private final boolean isActive;
     private long dateInMillis;
     private String hash;
+    private String author;
+    private String message;
 
     @JsonCreator
-    public BitbucketCloudBranch(@Nonnull @JsonProperty("name") String name,
+    public BitbucketCloudBranch(@NonNull @JsonProperty("name") String name,
                                 @Nullable @JsonProperty("target") BitbucketCloudBranch.Target target,
                                 @Nullable @JsonProperty("heads") List<Head> heads) {
         this.name = name;
-        if(target != null) {
-            this.dateInMillis = target.repo.getUpdatedOn() != null ? target.repo.getUpdatedOn().getTime() : 0;
+        if (target != null) {
+            this.dateInMillis = target.date.getTime();
             this.hash = target.hash;
+            this.author = target.author.getRaw();
+            this.message = target.message;
         }
 
         // For Hg repositories, Bitbucket returns all branches, including the closed/inactive ones.
@@ -56,13 +59,14 @@ public class BitbucketCloudBranch implements BitbucketBranch {
         this.isActive = heads == null || !heads.isEmpty();
     }
 
-    public BitbucketCloudBranch(@Nonnull String name, String hash, long dateInMillis) {
+    public BitbucketCloudBranch(@NonNull String name, String hash, long dateInMillis) {
         this.name = name;
         this.dateInMillis = dateInMillis;
         this.hash = hash;
         this.isActive = true;
     }
 
+    @Override
     public String getRawNode() {
         return hash;
     }
@@ -89,14 +93,39 @@ public class BitbucketCloudBranch implements BitbucketBranch {
         return isActive;
     }
 
+    @Override
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    @Override
+    public String getAuthor() {
+        return author;
+    }
+
+    public void setAuthor(String authorName) {
+        this.author = authorName;
+    }
+
     public static class Target {
         private final String hash;
-        private final BitbucketCloudRepository repo;
+        private final String message;
+        private final Date date;
+        private final BitbucketCloudAuthor author;
 
         @JsonCreator
-        public Target(@Nonnull @JsonProperty("hash") String hash, @Nonnull @JsonProperty("repository") BitbucketCloudRepository repo) {
+        public Target(@NonNull @JsonProperty("hash") String hash, //
+                      @NonNull @JsonProperty("message") String message, //
+                      @NonNull @JsonProperty("date") Date date, //
+                      @NonNull @JsonProperty("author") BitbucketCloudAuthor author) {
             this.hash = hash;
-            this.repo = repo;
+            this.message = message;
+            this.author = author;
+            this.date = (Date) date.clone();
         }
     }
 
@@ -104,7 +133,7 @@ public class BitbucketCloudBranch implements BitbucketBranch {
         private final String hash;
 
         @JsonCreator
-        public Head(@Nonnull @JsonProperty("hash") String hash) {
+        public Head(@NonNull @JsonProperty("hash") String hash) {
             this.hash = hash;
         }
     }

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/branch/BitbucketCloudCommit.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/branch/BitbucketCloudCommit.java
@@ -23,18 +23,33 @@
  */
 package com.cloudbees.jenkins.plugins.bitbucket.client.branch;
 
+import com.cloudbees.jenkins.plugins.bitbucket.JsonParser.BitbucketDateFormat;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketCommit;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 import java.text.ParseException;
-import java.text.SimpleDateFormat;
-import java.util.TimeZone;
 
 public class BitbucketCloudCommit implements BitbucketCommit {
 
     private String message;
-
     private String date;
-
     private String hash;
+    private String author;
+
+    @JsonCreator
+    public BitbucketCloudCommit(@Nullable @JsonProperty("message") String message,
+                                @Nullable @JsonProperty("date") String date,
+                                @NonNull @JsonProperty("hash") String hash,
+                                @Nullable @JsonProperty("author") BitbucketCloudAuthor author) {
+        this.message = message;
+        this.date = date;
+        this.hash = hash;
+        if (author != null) {
+            this.author = author.getRaw();
+        }
+    }
 
     @Override
     public String getMessage() {
@@ -65,14 +80,20 @@ public class BitbucketCloudCommit implements BitbucketCommit {
 
     @Override
     public long getDateMillis() {
-        // 2013-10-21T07:21:51+00:00
-        final SimpleDateFormat dateParser = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
-        dateParser.setTimeZone(TimeZone.getTimeZone("GMT"));
         try {
-            return dateParser.parse(date).getTime();
+            return new BitbucketDateFormat().parse(date).getTime();
         } catch (ParseException e) {
             return 0;
         }
+    }
+
+    @Override
+    public String getAuthor() {
+        return author;
+    }
+
+    public void setAuthor(String author) {
+        this.author = author;
     }
 
 }

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/pullrequest/BitbucketPullRequestCommit.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/pullrequest/BitbucketPullRequestCommit.java
@@ -1,8 +1,40 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2018, Nikolas Falco
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package com.cloudbees.jenkins.plugins.bitbucket.client.pullrequest;
 
-public class BitbucketPullRequestCommit {
-    private String hash;
+import com.cloudbees.jenkins.plugins.bitbucket.JsonParser.BitbucketDateFormat;
+import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketCommit;
+import com.cloudbees.jenkins.plugins.bitbucket.client.branch.BitbucketCloudAuthor;
+import java.util.Date;
 
+public class BitbucketPullRequestCommit implements BitbucketCommit {
+    private String hash;
+    private BitbucketCloudAuthor author;
+    private Date date;
+    private String message;
+
+    @Override
     public String getHash() {
         return hash;
     }
@@ -10,4 +42,40 @@ public class BitbucketPullRequestCommit {
     public void setHash(String hash) {
         this.hash = hash;
     }
+
+    @Override
+    public String getAuthor() {
+        return author != null ? author.getRaw() : null;
+    }
+
+    public void setAuthor(String author) {
+        if (this.author == null) {
+            this.author = new BitbucketCloudAuthor();
+        }
+        this.author.setRaw(author);
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    @Override
+    public String getDate() {
+        return date != null ? new BitbucketDateFormat().format(date) : null;
+    }
+
+    public void setDate(Date date) {
+        this.date = (Date) date.clone();
+    }
+
+    @Override
+    public long getDateMillis() {
+        return date != null ? date.getTime() : 0;
+    }
+
 }

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/PullRequestHookProcessor.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/PullRequestHookProcessor.java
@@ -185,6 +185,7 @@ public class PullRequestHookProcessor extends HookProcessor {
                             if (strategies.size() > 1) {
                                 branchName = branchName + "-" + strategy.name().toLowerCase(Locale.ENGLISH);
                             }
+                            String originalBranchName = pull.getSource().getBranch().getName();
                             PullRequestSCMHead head;
                             if (instanceType == BitbucketType.CLOUD) {
                                 head = new PullRequestSCMHead(
@@ -192,7 +193,7 @@ public class PullRequestHookProcessor extends HookProcessor {
                                         pullRepoOwner,
                                         pullRepository,
                                         type,
-                                        pull.getSource().getBranch().getName(),
+                                        originalBranchName,
                                         pull,
                                         headOrigin,
                                         strategy
@@ -203,7 +204,7 @@ public class PullRequestHookProcessor extends HookProcessor {
                                         src.getRepoOwner(),
                                         src.getRepository(),
                                         type,
-                                        pull.getSource().getBranch().getName(),
+                                        originalBranchName,
                                         pull,
                                         headOrigin,
                                         strategy

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/BitbucketServerAPIClient.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/BitbucketServerAPIClient.java
@@ -479,14 +479,10 @@ public class BitbucketServerAPIClient implements BitbucketApi {
                 branches.addAll(page.getValues());
             }
             for (final BitbucketServerBranch branch: branches) {
-                branch.setTimestampClosure(new Callable<Long>() {
+                branch.setCommitClosure(new Callable<BitbucketCommit>() {
                     @Override
-                    public Long call() throws Exception {
-                        BitbucketCommit commit = resolveCommit(branch.getRawNode());
-                        if (commit != null) {
-                            return commit.getDateMillis();
-                        }
-                        return 0L;
+                    public BitbucketCommit call() throws Exception {
+                        return resolveCommit(branch.getRawNode());
                     }
                 });
             }
@@ -518,6 +514,11 @@ public class BitbucketServerAPIClient implements BitbucketApi {
     @Override
     public String resolveSourceFullHash(@NonNull BitbucketPullRequest pull) {
         return pull.getSource().getCommit().getHash();
+    }
+
+    @Override
+    public BitbucketCommit resolveCommit(BitbucketPullRequest pull) {
+        return pull.getSource().getCommit();
     }
 
     @Override
@@ -644,7 +645,7 @@ public class BitbucketServerAPIClient implements BitbucketApi {
         return getRepository().isPrivate();
     }
 
-    private String getRequest(String path) throws IOException {
+    protected String getRequest(String path) throws IOException {
         HttpGet httpget = new HttpGet(this.baseURL + path);
 
         try(CloseableHttpClient client = getHttpClient(httpget);

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/branch/BitbucketServerAuthor.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/branch/BitbucketServerAuthor.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright (c) 2016, CloudBees, Inc.
+ * Copyright (c) 2018, Nikolas Falco
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,46 +21,55 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package com.cloudbees.jenkins.plugins.bitbucket.api;
+package com.cloudbees.jenkins.plugins.bitbucket.server.client.branch;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
- * Bitbucket Branch.
- *
- * It's used to represent branches to be built and source branches for pull requests.
+ * Represents the author information given by Bitbucket Server.
+ * 
+ * @author Nikolas Falco
+ * @since 2.2.14
  */
-public interface BitbucketBranch {
+public class BitbucketServerAuthor {
+    private String name;
+    @JsonProperty("emailAddress")
+    private String email;
 
     /**
-     * @return the head commit node of this branch
+     * Returns the author name provided by the commit.
+     * 
+     * @return the commit author name
      */
-    String getRawNode();
+    public String getName() {
+        return name;
+    }
 
     /**
-     * @return the branch name
+     * Sets the author name provided by the commit.
+     * 
+     * @param name the commit author name
      */
-    String getName();
+    public void setName(String name) {
+        this.name = name;
+    }
 
     /**
-     * @return the commit milliseconds from epoch
+     * Returns the author email provided by the commit.
+     * 
+     * @return the commit author email
      */
-    long getDateMillis();
+    public String getEmail() {
+        return email;
+    }
 
     /**
-     * Returns the head commit message for this branch.
-     *
-     * @return the head commit message of this branch
-     * @author Nikolas Falco
-     * @since 2.2.14
+     * Sets the author email provided by the commit.
+     * 
+     * @param email the commit author email
      */
-    String getMessage();
-
-    /**
-     * Returns the head commit author for this branch.
-     *
-     * @return the head commit author of this branch
-     * @author Nikolas Falco
-     * @since 2.2.14
-     */
-    String getAuthor();
+    public void setEmail(String email) {
+        this.email = email;
+    }
 
 }

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/branch/BitbucketServerBranch.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/branch/BitbucketServerBranch.java
@@ -24,6 +24,7 @@
 package com.cloudbees.jenkins.plugins.bitbucket.server.client.branch;
 
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketBranch;
+import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketCommit;
 import java.util.concurrent.Callable;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -37,8 +38,12 @@ public class BitbucketServerBranch implements BitbucketBranch {
 
     private String latestCommit;
 
+    // initialised by callable
+    private String message;
+    private String author;
     private Long timestamp;
-    private Callable<Long> timestampClosure;
+    private Callable<BitbucketCommit> commitClosure;
+    private boolean callableInitialised = false;
 
     public BitbucketServerBranch() {
     }
@@ -88,24 +93,61 @@ public class BitbucketServerBranch implements BitbucketBranch {
     }
 
     @Restricted(NoExternalUse.class)
-    public void setTimestampClosure(Callable<Long> timestampClosure) {
-        this.timestampClosure = timestampClosure;
+    public void setCommitClosure(Callable<BitbucketCommit> commitClosure) {
+        this.commitClosure = commitClosure;
     }
 
     private long timestamp() {
         if (timestamp == null) {
-            if (timestampClosure == null) {
+            if (commitClosure == null) {
                 timestamp = 0L;
             } else {
-                try {
-                    timestamp = timestampClosure.call();
-                } catch (Exception e) {
-                    LOGGER.log(Level.FINER, "Could not determine timestamp", e);
-                    timestamp = 0L;
-                }
+                initHeadCommitInfo();
             }
         }
         return timestamp;
     }
 
+    @Override
+    public String getMessage() {
+        if (message == null && commitClosure != null) {
+            initHeadCommitInfo();
+        }
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    @Override
+    public String getAuthor() {
+        if (author == null && commitClosure != null) {
+            initHeadCommitInfo();
+        }
+        return author;
+    }
+
+    public void setAuthor(String author) {
+        this.author = author;
+    }
+
+    private void initHeadCommitInfo() {
+        if (callableInitialised) {
+            return;
+        }
+
+        callableInitialised = true;
+        try {
+            BitbucketCommit commit = commitClosure.call();
+
+            this.timestamp = commit.getDateMillis();
+            this.message = commit.getMessage();
+            this.author = commit.getAuthor();
+        } catch (Exception e) {
+            LOGGER.log(Level.FINER, "Could not determine head commit details", e);
+            // fallback on default values
+            timestamp = 0L;
+        }
+    }
 }

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/branch/BitbucketServerCommit.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/branch/BitbucketServerCommit.java
@@ -24,9 +24,16 @@
 package com.cloudbees.jenkins.plugins.bitbucket.server.client.branch;
 
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketCommit;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.util.StdDateFormat;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import java.text.MessageFormat;
+import java.util.Date;
 
 public class BitbucketServerCommit implements BitbucketCommit {
+    private static final String GIT_COMMIT_AUTHOR = "{0} <{1}>";
 
     private String message;
 
@@ -34,10 +41,21 @@ public class BitbucketServerCommit implements BitbucketCommit {
 
     private String hash;
 
-    @JsonProperty("authorTimestamp")
     private long dateMillis;
 
-    public BitbucketServerCommit() {
+    private String author;
+
+    @JsonCreator
+    public BitbucketServerCommit(@NonNull @JsonProperty("message") String message, //
+                                 @NonNull @JsonProperty("id") String hash, //
+                                 @NonNull @JsonProperty("authorTimestamp") long dateMillis, //
+                                 @Nullable @JsonProperty("author") BitbucketServerAuthor author) {
+        this(message, null, hash, dateMillis);
+        // date it is not in the payload
+        this.date = new StdDateFormat().format(new Date(dateMillis));
+        if (author != null) {
+            this.author = MessageFormat.format(GIT_COMMIT_AUTHOR, author.getName(), author.getEmail());
+        }
     }
 
     public BitbucketServerCommit(String message, String date, String hash, long dateMillis) {
@@ -85,6 +103,15 @@ public class BitbucketServerCommit implements BitbucketCommit {
 
     public void setDateMillis(long dateMillis) {
         this.dateMillis = dateMillis;
+    }
+
+    @Override
+    public String getAuthor() {
+        return author;
+    }
+
+    public void setAuthor(String author) {
+        this.author = author;
     }
 
 }

--- a/src/main/resources/com/cloudbees/jenkins/plugins/bitbucket/Messages.properties
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/bitbucket/Messages.properties
@@ -40,4 +40,3 @@ PullRequestSCMHead.Pronoun=Pull Request
 BranchSCMHead.Pronoun=Branch
 BitBucketTagSCMHead.Pronoun=Tag
 TagDiscoveryTrait.authorityDisplayName=Trust origin tags
-

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketClientMockUtils.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketClientMockUtils.java
@@ -28,6 +28,7 @@ import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketHref;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketRepositoryProtocol;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketRepositoryType;
 import com.cloudbees.jenkins.plugins.bitbucket.client.BitbucketCloudApiClient;
+import com.cloudbees.jenkins.plugins.bitbucket.client.branch.BitbucketCloudAuthor;
 import com.cloudbees.jenkins.plugins.bitbucket.client.branch.BitbucketCloudBranch;
 import com.cloudbees.jenkins.plugins.bitbucket.client.branch.BitbucketCloudCommit;
 import com.cloudbees.jenkins.plugins.bitbucket.client.pullrequest.BitbucketPullRequestValue;
@@ -38,19 +39,16 @@ import com.cloudbees.jenkins.plugins.bitbucket.client.repository.BitbucketCloudT
 import com.cloudbees.jenkins.plugins.bitbucket.client.repository.BitbucketRepositoryHook;
 import com.cloudbees.jenkins.plugins.bitbucket.hooks.BitbucketSCMSourcePushHookReceiver;
 import hudson.model.TaskListener;
-import jenkins.model.Jenkins;
-
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import jenkins.model.Jenkins;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.Matchers.*;
+import static org.mockito.Mockito.*;
 
 public class BitbucketClientMockUtils {
 
@@ -76,6 +74,13 @@ public class BitbucketClientMockUtils {
                     .thenReturn(true);
             when(bitbucket.resolveSourceFullHash(any(BitbucketPullRequestValue.class)))
                     .thenReturn("e851558f77c098d21af6bb8cc54a423f7cf12147");
+
+            BitbucketCloudAuthor author = new BitbucketCloudAuthor();
+            author.setRaw("amuniz <amuniz@mail.com");
+            when(bitbucket.resolveCommit("e851558f77c098d21af6bb8cc54a423f7cf12147"))
+                .thenReturn(new BitbucketCloudCommit("no message", "2018-09-13T15:29:23+00:00", "e851558f77c098d21af6bb8cc54a423f7cf12147", author));
+            when(bitbucket.resolveCommit("52fc8e220d77ec400f7fc96a91d2fd0bb1bc553a"))
+                .thenReturn(new BitbucketCloudCommit("initial commit", "2018-09-10T15:29:23+00:00", "52fc8e220d77ec400f7fc96a91d2fd0bb1bc553a", author));
         }
 
         // mock file exists
@@ -181,8 +186,10 @@ public class BitbucketClientMockUtils {
         BitbucketCloudBranch branch = new BitbucketCloudBranch("my-feature-branch", null, 0);
         source.setBranch(branch);
 
-        BitbucketCloudCommit commit = new BitbucketCloudCommit();
-        commit.setHash("e851558f77c098d21af6bb8cc54a423f7cf12147");
+        BitbucketCloudAuthor author = new BitbucketCloudAuthor();
+        author.setRaw("amuniz <amuniz@mail.com>");
+
+        BitbucketCloudCommit commit = new BitbucketCloudCommit("no message", "2018-09-13T15:29:23+00:00", "e851558f77c098d21af6bb8cc54a423f7cf12147", author);
         source.setCommit(commit);
 
         BitbucketCloudRepository repository = new BitbucketCloudRepository();
@@ -192,6 +199,7 @@ public class BitbucketClientMockUtils {
         pr.setSource(source);
 
         BitbucketPullRequestValueDestination destination = new BitbucketPullRequestValueDestination();
+        destination.setCommit(new BitbucketCloudCommit("initial commit", "2018-09-10T15:29:23+00:00", "52fc8e220d77ec400f7fc96a91d2fd0bb1bc553a", author));
         branch = new BitbucketCloudBranch("branch1", null, 0);
         destination.setBranch(branch);
         repository = new BitbucketCloudRepository();

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketCommitInformationTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketCommitInformationTest.java
@@ -1,0 +1,180 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2018, Nikolas Falco
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.cloudbees.jenkins.plugins.bitbucket;
+
+import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketApi;
+import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketBranch;
+import com.cloudbees.jenkins.plugins.bitbucket.client.BitbucketIntegrationClientFactory;
+import com.cloudbees.jenkins.plugins.bitbucket.endpoints.BitbucketCloudEndpoint;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Extension;
+import hudson.Util;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import jenkins.scm.api.SCMHead;
+import jenkins.scm.api.SCMHeadObserver;
+import jenkins.scm.api.SCMRevision;
+import jenkins.scm.api.trait.SCMHeadFilter;
+import jenkins.scm.api.trait.SCMSourceContext;
+import jenkins.scm.api.trait.SCMSourceRequest;
+import jenkins.scm.api.trait.SCMSourceTrait;
+import jenkins.scm.api.trait.SCMSourceTraitDescriptor;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
+
+public class BitbucketCommitInformationTest {
+
+    private final class SCMHeadObserverImpl extends SCMHeadObserver {
+
+        public List<SCMRevision> revisions = new ArrayList<>();
+
+        @Override
+        public void observe(@NonNull SCMHead head, @NonNull SCMRevision revision) {
+            revisions.add(revision);
+        }
+
+        public List<SCMRevision> getRevisions() {
+            return revisions;
+        }
+    }
+
+    private static class SCMHeadFilterTrait extends SCMSourceTrait {
+        private final SCMHeadFilter headFilter;
+
+        public SCMHeadFilterTrait(SCMHeadFilter headFilter) {
+            this.headFilter = headFilter;
+        }
+
+        @Override
+        protected void decorateContext(SCMSourceContext<?, ?> context) {
+            context.withFilter(headFilter);
+        }
+
+        @Extension
+        public static class DescriptorImpl extends SCMSourceTraitDescriptor {
+        }
+    }
+
+    private static abstract class BranchSCMFilter<R> extends SCMHeadFilter {
+        private Set<String> matches = new HashSet<>();
+
+        public abstract void assertBranch(BitbucketBranch branch);
+
+        @Override
+        public boolean isExcluded(SCMSourceRequest request, SCMHead head) throws IOException, InterruptedException {
+            BitbucketSCMSourceRequest bbRequest = (BitbucketSCMSourceRequest) request;
+            for (BitbucketBranch branch : bbRequest.getBranches()) {
+                assertBranch(branch);
+                // if not failure increments the count of branches that matches
+                matches.add(branch.getName());
+            }
+            return false;
+        }
+
+        public int getMatches() {
+            return matches.size();
+        }
+    }
+
+    @ClassRule
+    public static JenkinsRule j = new JenkinsRule();
+
+    @Before
+    public void setup() {
+        BitbucketMockApiFactory.clear();
+    }
+
+    @Test
+    public void verify_that_commit_informations_are_valued_on_cloud() throws Exception {
+        BitbucketMockApiFactory.add(BitbucketCloudEndpoint.SERVER_URL, getApiMockClient(BitbucketCloudEndpoint.SERVER_URL));
+        BitbucketSCMSource source = new BitbucketSCMSource("amuniz", "test-repos");
+
+        BranchSCMFilter<Integer> commitFilter = spy(new BranchSCMFilter<Integer>() {
+            @Override
+            public void assertBranch(BitbucketBranch branch) {
+                assertThat("commit message is not valued", Util.fixEmptyAndTrim(branch.getMessage()), notNullValue());
+                assertThat("commit author is not valued", Util.fixEmptyAndTrim(branch.getAuthor()), notNullValue());
+                assertTrue("commit date is not valued", branch.getDateMillis() > 0);
+            }
+        });
+
+        source.setTraits(Arrays.<SCMSourceTrait> asList( //
+                new BranchDiscoveryTrait(true, true), //
+                new SCMHeadFilterTrait(commitFilter)));
+        SCMHeadObserverImpl observer = new SCMHeadObserverImpl();
+        source.fetch(observer, BitbucketClientMockUtils.getTaskListenerMock());
+
+        // verify that the filter was called at least one time
+        verify(commitFilter, atLeastOnce()).isExcluded(any(SCMSourceRequest.class), any(SCMHead.class));
+
+        // the head branch should observe only branches which head commit was not filtered out
+        assertThat(observer.getRevisions().size(), equalTo(commitFilter.getMatches()));
+    }
+
+    @Test
+    public void verify_that_commit_informations_are_valued_on_server() throws Exception {
+        String serverUrl = "localhost";
+        BitbucketMockApiFactory.add(serverUrl, getApiMockClient(serverUrl));
+
+        BitbucketSCMSource source = new BitbucketSCMSource("amuniz", "test-repos");
+        source.setServerUrl(serverUrl);
+
+        BranchSCMFilter<Integer> commitFilter = spy(new BranchSCMFilter<Integer>() {
+            @Override
+            public void assertBranch(BitbucketBranch branch) {
+                assertThat("commit message is not valued", Util.fixEmptyAndTrim(branch.getMessage()), notNullValue());
+                assertThat("commit author is not valued", Util.fixEmptyAndTrim(branch.getAuthor()), notNullValue());
+                assertTrue("commit date is not valued", branch.getDateMillis() > 0);
+            }
+        });
+
+        source.setTraits(Arrays.<SCMSourceTrait> asList( //
+                new BranchDiscoveryTrait(true, true), //
+                new SCMHeadFilterTrait(commitFilter)));
+        SCMHeadObserverImpl observer = new SCMHeadObserverImpl();
+        source.fetch(observer, BitbucketClientMockUtils.getTaskListenerMock());
+
+        // verify that the filter was called at least one time
+        verify(commitFilter, atLeastOnce()).isExcluded(any(SCMSourceRequest.class), any(SCMHead.class));
+
+        // the head branch should observe only branches which head commit was not filtered out
+        assertThat(observer.getRevisions().size(), equalTo(commitFilter.getMatches()));
+    }
+
+    private BitbucketApi getApiMockClient(String serverURL) {
+        return BitbucketIntegrationClientFactory.getClient(serverURL, "amuniz", "test-repos");
+    }
+
+}

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketGitSCMRevisionTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketGitSCMRevisionTest.java
@@ -1,0 +1,163 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2018, Nikolas Falco
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.cloudbees.jenkins.plugins.bitbucket;
+
+import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketApi;
+import com.cloudbees.jenkins.plugins.bitbucket.client.BitbucketIntegrationClientFactory;
+import com.cloudbees.jenkins.plugins.bitbucket.endpoints.BitbucketCloudEndpoint;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Extension;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.EnumSet;
+import java.util.List;
+import jenkins.scm.api.SCMHead;
+import jenkins.scm.api.SCMHeadObserver;
+import jenkins.scm.api.SCMRevision;
+import jenkins.scm.api.mixin.ChangeRequestCheckoutStrategy;
+import jenkins.scm.api.trait.SCMHeadFilter;
+import jenkins.scm.api.trait.SCMSourceContext;
+import jenkins.scm.api.trait.SCMSourceRequest;
+import jenkins.scm.api.trait.SCMSourceTrait;
+import jenkins.scm.api.trait.SCMSourceTraitDescriptor;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
+
+public class BitbucketGitSCMRevisionTest {
+
+    private final class SCMHeadObserverImpl extends SCMHeadObserver {
+
+        public List<SCMRevision> revisions = new ArrayList<>();
+
+        @Override
+        public void observe(@NonNull SCMHead head, @NonNull SCMRevision revision) {
+            revisions.add(revision);
+        }
+
+        public List<SCMRevision> getRevisions() {
+            return revisions;
+        }
+    }
+
+    private static class SCMHeadFilterTrait extends SCMSourceTrait {
+        private String branchName;
+
+        public SCMHeadFilterTrait(String branchName) {
+            this.branchName = branchName;
+        }
+
+        @Override
+        protected void decorateContext(SCMSourceContext<?, ?> context) {
+            context.withFilter(new SCMHeadFilter() {
+                
+                @Override
+                public boolean isExcluded(SCMSourceRequest request, SCMHead head) throws IOException, InterruptedException {
+                    return !(branchName.equals(head.getName()));
+                }
+            });
+        }
+
+        @Extension
+        public static class DescriptorImpl extends SCMSourceTraitDescriptor {
+        }
+    }
+
+    @ClassRule
+    public static JenkinsRule j = new JenkinsRule();
+
+    @Before
+    public void setup() {
+        BitbucketMockApiFactory.clear();
+    }
+
+    @Test
+    public void verify_that_revision_is_valued_for_PRs_on_cloud() throws Exception {
+        BitbucketMockApiFactory.add(BitbucketCloudEndpoint.SERVER_URL, getApiMockClient(BitbucketCloudEndpoint.SERVER_URL));
+        BitbucketSCMSource source = new BitbucketSCMSource("amuniz", "test-repos");
+
+        source.setTraits(Arrays.<SCMSourceTrait> asList( //
+                new OriginPullRequestDiscoveryTrait(EnumSet.of(ChangeRequestCheckoutStrategy.HEAD)), //
+                new SCMHeadFilterTrait("PR-1")));
+        SCMHeadObserverImpl observer = new SCMHeadObserverImpl();
+        source.fetch(observer, BitbucketClientMockUtils.getTaskListenerMock());
+
+        // the PR observed should be only branches that matches PR-1
+        assertThat(observer.getRevisions().size(), equalTo(1));
+
+        PullRequestSCMRevision<?> pullRev = (PullRequestSCMRevision<?>) observer.getRevisions().get(0);
+
+        // check that PR has correct revision with full info
+        BitbucketGitSCMRevision sourceRevision = (BitbucketGitSCMRevision) pullRev.getPull();
+        assertThat(sourceRevision.getHash(), equalTo("bf0e8b7962c024026ad01ae09d3a11732e26c0d4"));
+        assertThat(sourceRevision.getMessage(), equalTo("[CI] Release version 1.0.0"));
+        assertThat(sourceRevision.getAuthor(), equalTo("Builder <no-reply@acme.com>"));
+
+        BitbucketGitSCMRevision targetRevision = (BitbucketGitSCMRevision) pullRev.getTarget();
+        assertThat(targetRevision.getHash(), equalTo("bf4f4ce8a3a8d5c7dbfe7d609973a81a6c6664cf"));
+        assertThat(targetRevision.getMessage(), equalTo("Add sample script hello world"));
+        assertThat(targetRevision.getAuthor(), equalTo("Antonio Muniz <amuniz@example.com>"));
+    }
+
+    @Test
+    public void verify_that_revision_is_valued_for_PRs_on_server() throws Exception {
+        String serverUrl = "localhost";
+        BitbucketMockApiFactory.add(serverUrl, getApiMockClient(serverUrl));
+
+        BitbucketSCMSource source = new BitbucketSCMSource("amuniz", "test-repos");
+        source.setServerUrl(serverUrl);
+
+        source.setTraits(Arrays.<SCMSourceTrait> asList( //
+                new OriginPullRequestDiscoveryTrait(EnumSet.of(ChangeRequestCheckoutStrategy.HEAD)), //
+                new SCMHeadFilterTrait("PR-1")));
+        SCMHeadObserverImpl observer = new SCMHeadObserverImpl();
+        source.fetch(observer, BitbucketClientMockUtils.getTaskListenerMock());
+
+        // the PR observed should be only branches that matches PR-1
+        assertThat(observer.getRevisions().size(), equalTo(1));
+
+        PullRequestSCMRevision<?> pullRev = (PullRequestSCMRevision<?>) observer.getRevisions().get(0);
+
+        // check that PR has correct revision with full info
+        BitbucketGitSCMRevision sourceRevision = (BitbucketGitSCMRevision) pullRev.getPull();
+        assertThat(sourceRevision.getHash(), equalTo("bf0e8b7962c024026ad01ae09d3a11732e26c0d4"));
+        assertThat(sourceRevision.getMessage(), equalTo("[CI] Release version 1.0.0"));
+        assertThat(sourceRevision.getAuthor(), equalTo("Builder <no-reply@acme.com>"));
+
+        BitbucketGitSCMRevision targetRevision = (BitbucketGitSCMRevision) pullRev.getTarget();
+        assertThat(targetRevision.getHash(), equalTo("bf4f4ce8a3a8d5c7dbfe7d609973a81a6c6664cf"));
+        assertThat(targetRevision.getMessage(), equalTo("Add sample script hello world"));
+        assertThat(targetRevision.getAuthor(), equalTo("Antonio Muniz <amuniz@example.com>"));
+    }
+
+    private BitbucketApi getApiMockClient(String serverURL) {
+        return BitbucketIntegrationClientFactory.getClient(serverURL, "amuniz", "test-repos");
+    }
+
+}

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/client/BitbucketIntegrationClientFactory.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/client/BitbucketIntegrationClientFactory.java
@@ -1,0 +1,114 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2018, Nikolas Falco
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.cloudbees.jenkins.plugins.bitbucket.client;
+
+import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketApi;
+import com.cloudbees.jenkins.plugins.bitbucket.endpoints.BitbucketCloudEndpoint;
+import com.cloudbees.jenkins.plugins.bitbucket.server.client.BitbucketServerAPIClient;
+import java.io.IOException;
+import java.io.InputStream;
+import org.apache.commons.io.IOUtils;
+
+public class BitbucketIntegrationClientFactory {
+
+    public static BitbucketApi getClient(String payloadRootPath, String serverURL, String owner, String repositoryName) {
+        if (BitbucketCloudEndpoint.SERVER_URL.equals(serverURL) ||
+                BitbucketCloudEndpoint.BAD_SERVER_URL.equals(serverURL)) {
+            return new BitbucketCouldIntegrationClient(payloadRootPath, owner, repositoryName);
+        } else {
+            return new BitbucketServerIntegrationClient(payloadRootPath, serverURL, owner, repositoryName);
+        }
+    }
+
+    public static BitbucketApi getClient(String serverURL, String owner, String repositoryName) {
+        return getClient(null, serverURL, owner, repositoryName);
+    }
+
+    private static class BitbucketServerIntegrationClient extends BitbucketServerAPIClient {
+        private static final String PAYLOAD_RESOURCE_ROOTPATH = "/com/cloudbees/jenkins/plugins/bitbucket/server/payload/";
+
+        private final String payloadRootPath;
+
+        public BitbucketServerIntegrationClient(String payloadRootPath, String baseURL, String owner, String repositoryName) {
+            super(baseURL, owner, repositoryName, null, false);
+
+            if (payloadRootPath == null) {
+                this.payloadRootPath = PAYLOAD_RESOURCE_ROOTPATH;
+            } else if (!payloadRootPath.startsWith("/")) {
+                this.payloadRootPath = '/' + payloadRootPath;
+            } else {
+                this.payloadRootPath = payloadRootPath;
+            }
+        }
+
+        @Override
+        protected String getRequest(String path) throws IOException {
+            String payloadPath = path.replace("/rest/api/", "").replace('/', '-').replaceAll("[=%&?]", "_");
+            payloadPath = payloadRootPath + payloadPath + ".json";
+
+            try (InputStream json = this.getClass().getResourceAsStream(payloadPath)) {
+                if (json == null) {
+                    throw new IllegalStateException("Payload for the REST path " + path + " could be found");
+                }
+                return IOUtils.toString(json);
+            }
+        }
+    }
+
+    private static class BitbucketCouldIntegrationClient extends BitbucketCloudApiClient {
+        private static final String PAYLOAD_RESOURCE_ROOTPATH = "/com/cloudbees/jenkins/plugins/bitbucket/client/payload/";
+        private static final String API_ENDPOINT = "https://api.bitbucket.org/";
+
+        private final String payloadRootPath;
+
+        public BitbucketCouldIntegrationClient(String payloadRootPath, String owner, String repositoryName) {
+            super(false, 0, 0, owner, repositoryName, null);
+
+            if (payloadRootPath == null) {
+                this.payloadRootPath = PAYLOAD_RESOURCE_ROOTPATH;
+            } else if (!payloadRootPath.startsWith("/")) {
+                if (!payloadRootPath.endsWith("/")) {
+                    this.payloadRootPath = '/' + payloadRootPath + '/';
+                } else {
+                    this.payloadRootPath = '/' + payloadRootPath;
+                }
+            } else {
+                this.payloadRootPath = payloadRootPath;
+            }
+        }
+
+        @Override
+        protected String getRequest(String path) throws IOException, InterruptedException {
+            String payloadPath = path.replace(API_ENDPOINT, "").replace('/', '-').replaceAll("[=%&?]", "_");
+            payloadPath = payloadRootPath + payloadPath + ".json";
+
+            try (InputStream json = this.getClass().getResourceAsStream(payloadPath)) {
+                if (json == null) {
+                    throw new IllegalStateException("Payload for the REST path " + path + " could be found");
+                }
+                return IOUtils.toString(json);
+            }
+        }
+    }
+}

--- a/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/client/payload/2.0-repositories-amuniz-test-repos-commit-bf0e8b7962c0.json
+++ b/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/client/payload/2.0-repositories-amuniz-test-repos-commit-bf0e8b7962c0.json
@@ -1,0 +1,68 @@
+{
+  "hash": "bf0e8b7962c024026ad01ae09d3a11732e26c0d4",
+  "repository": {
+    "links": {
+      "self": {
+        "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos"
+      },
+      "html": {
+        "href": "https://bitbucket.org/amuniz/test-repos"
+      },
+      "avatar": {
+        "href": "https://bytebucket.org/ravatar/%7B3deb8c29-778a-450c-8f69-3e50a18079df%7D?ts=default"
+      }
+    },
+    "type": "repository",
+    "name": "test-repos",
+    "full_name": "amuniz/test-repos",
+    "uuid": "{3deb8c29-778a-450c-8f69-3e50a18079df}"
+  },
+  "links": {
+    "self": {
+      "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/commit/bf0e8b7962c024026ad01ae09d3a11732e26c0d4"
+    },
+    "comments": {
+      "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/commit/bf0e8b7962c024026ad01ae09d3a11732e26c0d4/comments"
+    },
+    "patch": {
+      "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/patch/bf0e8b7962c024026ad01ae09d3a11732e26c0d4"
+    },
+    "html": {
+      "href": "https://bitbucket.org/amuniz/test-repos/commits/bf0e8b7962c024026ad01ae09d3a11732e26c0d4"
+    },
+    "diff": {
+      "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/diff/bf0e8b7962c024026ad01ae09d3a11732e26c0d4"
+    },
+    "approve": {
+      "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/commit/bf0e8b7962c024026ad01ae09d3a11732e26c0d4/approve"
+    },
+    "statuses": {
+      "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/commit/bf0e8b7962c024026ad01ae09d3a11732e26c0d4/statuses"
+    }
+  },
+  "author": {
+    "raw": "Builder <no-reply@acme.com>"
+  },
+  "summary": {
+    "raw": "[CI] Release version 1.0.0",
+    "markup": "markdown",
+    "html": "<p>[CI] Release version 1.0.0</p>",
+    "type": "rendered"
+  },
+  "participants": [],
+  "parents": [{
+    "hash": "4bec6858eade48522da1d2f295a9d1b2360982ba",
+    "type": "commit",
+    "links": {
+      "self": {
+        "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/commit/4bec6858eade48522da1d2f295a9d1b2360982ba"
+      },
+      "html": {
+        "href": "https://bitbucket.org/amuniz/test-repos/commits/4bec6858eade48522da1d2f295a9d1b2360982ba"
+      }
+    }
+  }],
+  "date": "2018-09-21T14:53:12+00:00",
+  "message": "[CI] Release version 1.0.0",
+  "type": "commit"
+}

--- a/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/client/payload/2.0-repositories-amuniz-test-repos-commit-bf4f4ce8a3a8.json
+++ b/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/client/payload/2.0-repositories-amuniz-test-repos-commit-bf4f4ce8a3a8.json
@@ -1,0 +1,68 @@
+{
+  "hash": "bf4f4ce8a3a8d5c7dbfe7d609973a81a6c6664cf",
+  "repository": {
+    "links": {
+      "self": {
+        "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos"
+      },
+      "html": {
+        "href": "https://bitbucket.org/amuniz/test-repos"
+      },
+      "avatar": {
+        "href": "https://bytebucket.org/ravatar/%7B3deb8c29-778a-450c-8f69-3e50a18079df%7D?ts=default"
+      }
+    },
+    "type": "repository",
+    "name": "test-repos",
+    "full_name": "amuniz/test-repos",
+    "uuid": "{3deb8c29-778a-450c-8f69-3e50a18079df}"
+  },
+  "links": {
+    "self": {
+      "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/commit/bf4f4ce8a3a8d5c7dbfe7d609973a81a6c6664cf"
+    },
+    "comments": {
+      "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/commit/bf4f4ce8a3a8d5c7dbfe7d609973a81a6c6664cf/comments"
+    },
+    "patch": {
+      "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/patch/bf4f4ce8a3a8d5c7dbfe7d609973a81a6c6664cf"
+    },
+    "html": {
+      "href": "https://bitbucket.org/amuniz/test-repos/commits/bf4f4ce8a3a8d5c7dbfe7d609973a81a6c6664cf"
+    },
+    "diff": {
+      "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/diff/bf4f4ce8a3a8d5c7dbfe7d609973a81a6c6664cf"
+    },
+    "approve": {
+      "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/commit/bf4f4ce8a3a8d5c7dbfe7d609973a81a6c6664cf/approve"
+    },
+    "statuses": {
+      "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/commit/bf4f4ce8a3a8d5c7dbfe7d609973a81a6c6664cf/statuses"
+    }
+  },
+  "author": {
+    "raw": "Antonio Muniz <amuniz@example.com>"
+  },
+  "summary": {
+    "raw": "Add sample script hello world",
+    "markup": "markdown",
+    "html": "<p>Add sample script hello world</p>",
+    "type": "rendered"
+  },
+  "participants": [],
+  "parents": [{
+    "hash": "8d0fa145bde5151f1d103ab1c3dc1033e6ec4ac1",
+    "type": "commit",
+    "links": {
+      "self": {
+        "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/commit/8d0fa145bde5151f1d103ab1c3dc1033e6ec4ac1"
+      },
+      "html": {
+        "href": "https://bitbucket.org/amuniz/test-repos/commits/8d0fa145bde5151f1d103ab1c3dc1033e6ec4ac1"
+      }
+    }
+  }],
+  "date": "2018-09-21T14:07:25+00:00",
+  "message": "Add sample script hello world",
+  "type": "commit"
+}

--- a/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/client/payload/2.0-repositories-amuniz-test-repos-pullrequests-1-commits_fields_values.hash_2Cvalues.author.raw_2Cvalues.date_2Cvalues.message_pagelen_1.json
+++ b/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/client/payload/2.0-repositories-amuniz-test-repos-pullrequests-1-commits_fields_values.hash_2Cvalues.author.raw_2Cvalues.date_2Cvalues.message_pagelen_1.json
@@ -1,0 +1,10 @@
+{
+  "values": [{
+    "date": "2018-09-21T14:53:12+00:00",
+    "message": "[CI] Release version 1.0.0",
+    "hash": "bf0e8b7962c024026ad01ae09d3a11732e26c0d4",
+    "author": {
+      "raw": "Builder <no-reply@acme.com>"
+    }
+  }]
+}

--- a/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/client/payload/2.0-repositories-amuniz-test-repos-pullrequests_page_1_pagelen_50.json
+++ b/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/client/payload/2.0-repositories-amuniz-test-repos-pullrequests_page_1_pagelen_50.json
@@ -1,0 +1,144 @@
+{
+  "pagelen": 10,
+  "values": [{
+    "description": "* Add license\r\n\r\n* [CI] Release version 1.0.0",
+    "links": {
+      "decline": {
+        "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/pullrequests/1/decline"
+      },
+      "commits": {
+        "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/pullrequests/1/commits"
+      },
+      "self": {
+        "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/pullrequests/1"
+      },
+      "comments": {
+        "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/pullrequests/1/comments"
+      },
+      "merge": {
+        "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/pullrequests/1/merge"
+      },
+      "html": {
+        "href": "https://bitbucket.org/amuniz/test-repos/pull-requests/1"
+      },
+      "activity": {
+        "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/pullrequests/1/activity"
+      },
+      "diff": {
+        "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/pullrequests/1/diff"
+      },
+      "approve": {
+        "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/pullrequests/1/approve"
+      },
+      "statuses": {
+        "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/pullrequests/1/statuses"
+      }
+    },
+    "title": "Release/release 1",
+    "close_source_branch": true,
+    "type": "pullrequest",
+    "id": 1,
+    "destination": {
+      "commit": {
+        "hash": "bf4f4ce8a3a8",
+        "type": "commit",
+        "links": {
+          "self": {
+            "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/commit/bf4f4ce8a3a8"
+          },
+          "html": {
+            "href": "https://bitbucket.org/amuniz/test-repos/commits/bf4f4ce8a3a8"
+          }
+        }
+      },
+      "repository": {
+        "links": {
+          "self": {
+            "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos"
+          },
+          "html": {
+            "href": "https://bitbucket.org/amuniz/test-repos"
+          },
+          "avatar": {
+            "href": "https://bytebucket.org/ravatar/%7B3deb8c29-778a-450c-8f69-3e50a18079df%7D?ts=default"
+          }
+        },
+        "type": "repository",
+        "name": "test-repos",
+        "full_name": "amuniz/test-repos",
+        "uuid": "{3deb8c29-778a-450c-8f69-3e50a18079df}"
+      },
+      "branch": {
+        "name": "master"
+      }
+    },
+    "created_on": "2018-09-21T14:57:59.455870+00:00",
+    "summary": {
+      "raw": "* Add license\r\n\r\n* [CI] Release version 1.0.0",
+      "markup": "markdown",
+      "html": "<ul>\n<li>\n<p>Add license</p>\n</li>\n<li>\n<p>[CI] Release version 1.0.0</p>\n</li>\n</ul>",
+      "type": "rendered"
+    },
+    "source": {
+      "commit": {
+        "hash": "bf0e8b7962c0",
+        "type": "commit",
+        "links": {
+          "self": {
+            "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/commit/bf0e8b7962c0"
+          },
+          "html": {
+            "href": "https://bitbucket.org/amuniz/test-repos/commits/bf0e8b7962c0"
+          }
+        }
+      },
+      "repository": {
+        "links": {
+          "self": {
+            "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos"
+          },
+          "html": {
+            "href": "https://bitbucket.org/amuniz/test-repos"
+          },
+          "avatar": {
+            "href": "https://bytebucket.org/ravatar/%7B3deb8c29-778a-450c-8f69-3e50a18079df%7D?ts=default"
+          }
+        },
+        "type": "repository",
+        "name": "test-repos",
+        "full_name": "amuniz/test-repos",
+        "uuid": "{3deb8c29-778a-450c-8f69-3e50a18079df}"
+      },
+      "branch": {
+        "name": "release/release-1"
+      }
+    },
+    "comment_count": 0,
+    "state": "OPEN",
+    "task_count": 0,
+    "reason": "",
+    "updated_on": "2018-09-21T14:57:59.488719+00:00",
+    "author": {
+      "username": "amuniz",
+      "display_name": "Nikolas Falco",
+      "account_id": "557058:ca1cd232-2017-4216-94be-99637899e18d",
+      "links": {
+        "self": {
+          "href": "https://api.bitbucket.org/2.0/users/amuniz"
+        },
+        "html": {
+          "href": "https://bitbucket.org/amuniz/"
+        },
+        "avatar": {
+          "href": "https://bitbucket.org/account/amuniz/avatar/"
+        }
+      },
+      "type": "user",
+      "uuid": "{644c7fc2-b15a-4445-9f89-35390694fac9}"
+    },
+    "merge_commit": null,
+    "closed_by": null
+  }],
+  "page": 1,
+  "size": 1
+}

--- a/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/client/payload/2.0-repositories-amuniz-test-repos-refs-branches.json
+++ b/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/client/payload/2.0-repositories-amuniz-test-repos-refs-branches.json
@@ -1,0 +1,318 @@
+{
+  "pagelen": 10,
+  "values": [{
+    "name": "feature/BB-1",
+    "links": {
+      "commits": {
+        "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/commits/feature/BB-1"
+      },
+      "self": {
+        "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/refs/branches/feature/BB-1"
+      },
+      "html": {
+        "href": "https://bitbucket.org/amuniz/test-repos/branch/feature/BB-1"
+      }
+    },
+    "default_merge_strategy": "merge_commit",
+    "merge_strategies": ["merge_commit", "squash", "fast_forward"],
+    "type": "branch",
+    "target": {
+      "hash": "fb522a6f08c7c7df337312e4e65ec1b57710672e",
+      "repository": {
+        "links": {
+          "self": {
+            "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos"
+          },
+          "html": {
+            "href": "https://bitbucket.org/amuniz/test-repos"
+          },
+          "avatar": {
+            "href": "https://bytebucket.org/ravatar/%7B3deb8c29-778a-450c-8f69-3e50a18079df%7D?ts=default"
+          }
+        },
+        "type": "repository",
+        "name": "test-repos",
+        "full_name": "amuniz/test-repos",
+        "uuid": "{3deb8c29-778a-450c-8f69-3e50a18079df}"
+      },
+      "links": {
+        "self": {
+          "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/commit/fb522a6f08c7c7df337312e4e65ec1b57710672e"
+        },
+        "comments": {
+          "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/commit/fb522a6f08c7c7df337312e4e65ec1b57710672e/comments"
+        },
+        "patch": {
+          "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/patch/fb522a6f08c7c7df337312e4e65ec1b57710672e"
+        },
+        "html": {
+          "href": "https://bitbucket.org/amuniz/test-repos/commits/fb522a6f08c7c7df337312e4e65ec1b57710672e"
+        },
+        "diff": {
+          "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/diff/fb522a6f08c7c7df337312e4e65ec1b57710672e"
+        },
+        "approve": {
+          "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/commit/fb522a6f08c7c7df337312e4e65ec1b57710672e/approve"
+        },
+        "statuses": {
+          "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/commit/fb522a6f08c7c7df337312e4e65ec1b57710672e/statuses"
+        }
+      },
+      "author": {
+        "raw": "Antonio Muniz <amuniz@example.com>",
+        "type": "author"
+      },
+      "parents": [{
+        "hash": "ae995d7a37069d0988462a9c92828971e8a42b5d",
+        "type": "commit",
+        "links": {
+          "self": {
+            "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/commit/ae995d7a37069d0988462a9c92828971e8a42b5d"
+          },
+          "html": {
+            "href": "https://bitbucket.org/amuniz/test-repos/commits/ae995d7a37069d0988462a9c92828971e8a42b5d"
+          }
+        }
+      }],
+      "date": "2018-09-21T14:09:51+00:00",
+      "message": "Suppress echo command part",
+      "type": "commit"
+    }
+  }, {
+    "name": "feature/BB-2",
+    "links": {
+      "commits": {
+        "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/commits/feature/BB-2"
+      },
+      "self": {
+        "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/refs/branches/feature/BB-2"
+      },
+      "html": {
+        "href": "https://bitbucket.org/amuniz/test-repos/branch/feature/BB-2"
+      }
+    },
+    "default_merge_strategy": "merge_commit",
+    "merge_strategies": ["merge_commit", "squash", "fast_forward"],
+    "type": "branch",
+    "target": {
+      "hash": "046d9a3c1532acf4cf08fe93235c00e4d673c1d2",
+      "repository": {
+        "links": {
+          "self": {
+            "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos"
+          },
+          "html": {
+            "href": "https://bitbucket.org/amuniz/test-repos"
+          },
+          "avatar": {
+            "href": "https://bytebucket.org/ravatar/%7B3deb8c29-778a-450c-8f69-3e50a18079df%7D?ts=default"
+          }
+        },
+        "type": "repository",
+        "name": "test-repos",
+        "full_name": "amuniz/test-repos",
+        "uuid": "{3deb8c29-778a-450c-8f69-3e50a18079df}"
+      },
+      "links": {
+        "self": {
+          "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/commit/046d9a3c1532acf4cf08fe93235c00e4d673c1d2"
+        },
+        "comments": {
+          "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/commit/046d9a3c1532acf4cf08fe93235c00e4d673c1d2/comments"
+        },
+        "patch": {
+          "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/patch/046d9a3c1532acf4cf08fe93235c00e4d673c1d2"
+        },
+        "html": {
+          "href": "https://bitbucket.org/amuniz/test-repos/commits/046d9a3c1532acf4cf08fe93235c00e4d673c1d2"
+        },
+        "diff": {
+          "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/diff/046d9a3c1532acf4cf08fe93235c00e4d673c1d2"
+        },
+        "approve": {
+          "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/commit/046d9a3c1532acf4cf08fe93235c00e4d673c1d2/approve"
+        },
+        "statuses": {
+          "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/commit/046d9a3c1532acf4cf08fe93235c00e4d673c1d2/statuses"
+        }
+      },
+      "author": {
+        "raw": "Nikolas Falco <amuniz@acme.com>",
+        "type": "author"
+      },
+      "parents": [{
+        "hash": "bf4f4ce8a3a8d5c7dbfe7d609973a81a6c6664cf",
+        "type": "commit",
+        "links": {
+          "self": {
+            "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/commit/bf4f4ce8a3a8d5c7dbfe7d609973a81a6c6664cf"
+          },
+          "html": {
+            "href": "https://bitbucket.org/amuniz/test-repos/commits/bf4f4ce8a3a8d5c7dbfe7d609973a81a6c6664cf"
+          }
+        }
+      }],
+      "date": "2018-09-21T14:49:23+00:00",
+      "message": "Add one message more",
+      "type": "commit"
+    }
+  }, {
+    "name": "master",
+    "links": {
+      "commits": {
+        "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/commits/master"
+      },
+      "self": {
+        "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/refs/branches/master"
+      },
+      "html": {
+        "href": "https://bitbucket.org/amuniz/test-repos/branch/master"
+      }
+    },
+    "default_merge_strategy": "merge_commit",
+    "merge_strategies": ["merge_commit", "squash", "fast_forward"],
+    "type": "branch",
+    "target": {
+      "hash": "bf4f4ce8a3a8d5c7dbfe7d609973a81a6c6664cf",
+      "repository": {
+        "links": {
+          "self": {
+            "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos"
+          },
+          "html": {
+            "href": "https://bitbucket.org/amuniz/test-repos"
+          },
+          "avatar": {
+            "href": "https://bytebucket.org/ravatar/%7B3deb8c29-778a-450c-8f69-3e50a18079df%7D?ts=default"
+          }
+        },
+        "type": "repository",
+        "name": "test-repos",
+        "full_name": "amuniz/test-repos",
+        "uuid": "{3deb8c29-778a-450c-8f69-3e50a18079df}"
+      },
+      "links": {
+        "self": {
+          "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/commit/bf4f4ce8a3a8d5c7dbfe7d609973a81a6c6664cf"
+        },
+        "comments": {
+          "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/commit/bf4f4ce8a3a8d5c7dbfe7d609973a81a6c6664cf/comments"
+        },
+        "patch": {
+          "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/patch/bf4f4ce8a3a8d5c7dbfe7d609973a81a6c6664cf"
+        },
+        "html": {
+          "href": "https://bitbucket.org/amuniz/test-repos/commits/bf4f4ce8a3a8d5c7dbfe7d609973a81a6c6664cf"
+        },
+        "diff": {
+          "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/diff/bf4f4ce8a3a8d5c7dbfe7d609973a81a6c6664cf"
+        },
+        "approve": {
+          "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/commit/bf4f4ce8a3a8d5c7dbfe7d609973a81a6c6664cf/approve"
+        },
+        "statuses": {
+          "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/commit/bf4f4ce8a3a8d5c7dbfe7d609973a81a6c6664cf/statuses"
+        }
+      },
+      "author": {
+        "raw": "Antonio Muniz <amuniz@example.com>",
+        "type": "author"
+      },
+      "parents": [{
+        "hash": "8d0fa145bde5151f1d103ab1c3dc1033e6ec4ac1",
+        "type": "commit",
+        "links": {
+          "self": {
+            "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/commit/8d0fa145bde5151f1d103ab1c3dc1033e6ec4ac1"
+          },
+          "html": {
+            "href": "https://bitbucket.org/amuniz/test-repos/commits/8d0fa145bde5151f1d103ab1c3dc1033e6ec4ac1"
+          }
+        }
+      }],
+      "date": "2018-09-21T14:07:25+00:00",
+      "message": "Add sample script hello world",
+      "type": "commit"
+    }
+  }, {
+    "name": "release/release-1",
+    "links": {
+      "commits": {
+        "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/commits/release/release-1"
+      },
+      "self": {
+        "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/refs/branches/release/release-1"
+      },
+      "html": {
+        "href": "https://bitbucket.org/amuniz/test-repos/branch/release/release-1"
+      }
+    },
+    "default_merge_strategy": "merge_commit",
+    "merge_strategies": ["merge_commit", "squash", "fast_forward"],
+    "type": "branch",
+    "target": {
+      "hash": "bf0e8b7962c024026ad01ae09d3a11732e26c0d4",
+      "repository": {
+        "links": {
+          "self": {
+            "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos"
+          },
+          "html": {
+            "href": "https://bitbucket.org/amuniz/test-repos"
+          },
+          "avatar": {
+            "href": "https://bytebucket.org/ravatar/%7B3deb8c29-778a-450c-8f69-3e50a18079df%7D?ts=default"
+          }
+        },
+        "type": "repository",
+        "name": "test-repos",
+        "full_name": "amuniz/test-repos",
+        "uuid": "{3deb8c29-778a-450c-8f69-3e50a18079df}"
+      },
+      "links": {
+        "self": {
+          "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/commit/bf0e8b7962c024026ad01ae09d3a11732e26c0d4"
+        },
+        "comments": {
+          "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/commit/bf0e8b7962c024026ad01ae09d3a11732e26c0d4/comments"
+        },
+        "patch": {
+          "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/patch/bf0e8b7962c024026ad01ae09d3a11732e26c0d4"
+        },
+        "html": {
+          "href": "https://bitbucket.org/amuniz/test-repos/commits/bf0e8b7962c024026ad01ae09d3a11732e26c0d4"
+        },
+        "diff": {
+          "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/diff/bf0e8b7962c024026ad01ae09d3a11732e26c0d4"
+        },
+        "approve": {
+          "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/commit/bf0e8b7962c024026ad01ae09d3a11732e26c0d4/approve"
+        },
+        "statuses": {
+          "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/commit/bf0e8b7962c024026ad01ae09d3a11732e26c0d4/statuses"
+        }
+      },
+      "author": {
+        "raw": "Builder <no-reply@acme.com>",
+        "type": "author"
+      },
+      "parents": [{
+        "hash": "4bec6858eade48522da1d2f295a9d1b2360982ba",
+        "type": "commit",
+        "links": {
+          "self": {
+            "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/commit/4bec6858eade48522da1d2f295a9d1b2360982ba"
+          },
+          "html": {
+            "href": "https://bitbucket.org/amuniz/test-repos/commits/4bec6858eade48522da1d2f295a9d1b2360982ba"
+          }
+        }
+      }],
+      "date": "2018-09-21T14:53:12+00:00",
+      "message": "[CI] Release version 1.0.0",
+      "type": "commit"
+    }
+  }],
+  "page": 1,
+  "size": 4
+}

--- a/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/client/payload/2.0-repositories-amuniz-test-repos.json
+++ b/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/client/payload/2.0-repositories-amuniz-test-repos.json
@@ -1,0 +1,85 @@
+{
+  "scm": "git",
+  "website": "",
+  "has_wiki": false,
+  "name": "test-repos",
+  "links": {
+    "watchers": {
+      "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/watchers"
+    },
+    "branches": {
+      "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/refs/branches"
+    },
+    "tags": {
+      "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/refs/tags"
+    },
+    "commits": {
+      "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/commits"
+    },
+    "clone": [{
+      "href": "https://amuniz@bitbucket.org/amuniz/test-repos.git",
+      "name": "https"
+    }, {
+      "href": "git@bitbucket.org:amuniz/test-repos.git",
+      "name": "ssh"
+    }],
+    "self": {
+      "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos"
+    },
+    "source": {
+      "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/src"
+    },
+    "html": {
+      "href": "https://bitbucket.org/amuniz/test-repos"
+    },
+    "avatar": {
+      "href": "https://bytebucket.org/ravatar/%7B3deb8c29-778a-450c-8f69-3e50a18079df%7D?ts=default"
+    },
+    "hooks": {
+      "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/hooks"
+    },
+    "forks": {
+      "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/forks"
+    },
+    "downloads": {
+      "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/downloads"
+    },
+    "pullrequests": {
+      "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/pullrequests"
+    }
+  },
+  "fork_policy": "allow_forks",
+  "uuid": "{3deb8c29-778a-450c-8f69-3e50a18079df}",
+  "language": "",
+  "created_on": "2018-09-20T12:49:08.541926+00:00",
+  "mainbranch": {
+    "type": "branch",
+    "name": "master"
+  },
+  "full_name": "amuniz/test-repos",
+  "has_issues": false,
+  "owner": {
+    "username": "amuniz",
+    "display_name": "Nikolas Falco",
+    "account_id": "557058:ca1cd232-2017-4216-94be-99637899e18d",
+    "links": {
+      "self": {
+        "href": "https://api.bitbucket.org/2.0/users/amuniz"
+      },
+      "html": {
+        "href": "https://bitbucket.org/amuniz/"
+      },
+      "avatar": {
+        "href": "https://bitbucket.org/account/amuniz/avatar/"
+      }
+    },
+    "type": "user",
+    "uuid": "{644c7fc2-b15a-4445-9f89-35390694fac9}"
+  },
+  "updated_on": "2018-09-21T15:53:38.794718+00:00",
+  "size": 84351,
+  "type": "repository",
+  "slug": "test-repos",
+  "is_private": false,
+  "description": ""
+}

--- a/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/server/payload/1.0-projects-amuniz-repos-test-repos-branches_start_0_limit_200.json
+++ b/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/server/payload/1.0-projects-amuniz-repos-test-repos-branches_start_0_limit_200.json
@@ -1,0 +1,35 @@
+{
+  "size": 4,
+  "limit": 200,
+  "isLastPage": true,
+  "values": [{
+    "id": "refs/heads/release/release-1",
+    "displayId": "release/release-1",
+    "type": "BRANCH",
+    "latestCommit": "bf0e8b7962c024026ad01ae09d3a11732e26c0d4",
+    "latestChangeset": "bf0e8b7962c024026ad01ae09d3a11732e26c0d4",
+    "isDefault": false
+  }, {
+    "id": "refs/heads/feature/BB-2",
+    "displayId": "feature/BB-2",
+    "type": "BRANCH",
+    "latestCommit": "046d9a3c1532acf4cf08fe93235c00e4d673c1d2",
+    "latestChangeset": "046d9a3c1532acf4cf08fe93235c00e4d673c1d2",
+    "isDefault": false
+  }, {
+    "id": "refs/heads/feature/BB-1",
+    "displayId": "feature/BB-1",
+    "type": "BRANCH",
+    "latestCommit": "fb522a6f08c7c7df337312e4e65ec1b57710672e",
+    "latestChangeset": "fb522a6f08c7c7df337312e4e65ec1b57710672e",
+    "isDefault": false
+  }, {
+    "id": "refs/heads/master",
+    "displayId": "master",
+    "type": "BRANCH",
+    "latestCommit": "bf4f4ce8a3a8d5c7dbfe7d609973a81a6c6664cf",
+    "latestChangeset": "bf4f4ce8a3a8d5c7dbfe7d609973a81a6c6664cf",
+    "isDefault": true
+  }],
+  "start": 0
+}

--- a/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/server/payload/1.0-projects-amuniz-repos-test-repos-commits-046d9a3c1532acf4cf08fe93235c00e4d673c1d2.json
+++ b/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/server/payload/1.0-projects-amuniz-repos-test-repos-commits-046d9a3c1532acf4cf08fe93235c00e4d673c1d2.json
@@ -1,0 +1,34 @@
+{
+  "id": "046d9a3c1532acf4cf08fe93235c00e4d673c1d2",
+  "displayId": "046d9a3c153",
+  "author": {
+    "name": "Nikolas Falco",
+    "emailAddress": "nfalco79@acme.com"
+  },
+  "authorTimestamp": 1537541363000,
+  "committer": {
+    "name": "Nikolas Falco",
+    "emailAddress": "nfalco79@acme.com"
+  },
+  "committerTimestamp": 1537541363000,
+  "message": "Add one message more",
+  "parents": [{
+    "id": "bf4f4ce8a3a8d5c7dbfe7d609973a81a6c6664cf",
+    "displayId": "bf4f4ce8a3a",
+    "author": {
+      "name": "Antonio Muniz",
+      "emailAddress": "amuniz@example.com"
+    },
+    "authorTimestamp": 1537538845000,
+    "committer": {
+      "name": "Antonio Muniz",
+      "emailAddress": "amuniz@example.com"
+    },
+    "committerTimestamp": 1537538845000,
+    "message": "Add sample script hello world",
+    "parents": [{
+      "id": "8d0fa145bde5151f1d103ab1c3dc1033e6ec4ac1",
+      "displayId": "8d0fa145bde"
+    }]
+  }]
+}

--- a/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/server/payload/1.0-projects-amuniz-repos-test-repos-commits-bf0e8b7962c024026ad01ae09d3a11732e26c0d4.json
+++ b/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/server/payload/1.0-projects-amuniz-repos-test-repos-commits-bf0e8b7962c024026ad01ae09d3a11732e26c0d4.json
@@ -1,0 +1,34 @@
+{
+  "id": "bf0e8b7962c024026ad01ae09d3a11732e26c0d4",
+  "displayId": "bf0e8b7962c",
+  "author": {
+    "name": "Builder",
+    "emailAddress": "no-reply@acme.com"
+  },
+  "authorTimestamp": 1537541592000,
+  "committer": {
+    "name": "Builder",
+    "emailAddress": "no-reply@acme.com"
+  },
+  "committerTimestamp": 1537541592000,
+  "message": "[CI] Release version 1.0.0",
+  "parents": [{
+    "id": "4bec6858eade48522da1d2f295a9d1b2360982ba",
+    "displayId": "4bec6858ead",
+    "author": {
+      "name": "Nikolas Falco",
+      "emailAddress": "nfalco79@acme.com"
+    },
+    "authorTimestamp": 1537541543000,
+    "committer": {
+      "name": "Nikolas Falco",
+      "emailAddress": "nfalco79@acme.com"
+    },
+    "committerTimestamp": 1537541543000,
+    "message": "Add license",
+    "parents": [{
+      "id": "bf4f4ce8a3a8d5c7dbfe7d609973a81a6c6664cf",
+      "displayId": "bf4f4ce8a3a"
+    }]
+  }]
+}

--- a/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/server/payload/1.0-projects-amuniz-repos-test-repos-commits-bf4f4ce8a3a8d5c7dbfe7d609973a81a6c6664cf.json
+++ b/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/server/payload/1.0-projects-amuniz-repos-test-repos-commits-bf4f4ce8a3a8d5c7dbfe7d609973a81a6c6664cf.json
@@ -1,0 +1,31 @@
+{
+  "id": "bf4f4ce8a3a8d5c7dbfe7d609973a81a6c6664cf",
+  "displayId": "bf4f4ce8a3a",
+  "author": {
+    "name": "Antonio Muniz",
+    "emailAddress": "amuniz@example.com"
+  },
+  "authorTimestamp": 1537538845000,
+  "committer": {
+    "name": "Antonio Muniz",
+    "emailAddress": "amuniz@example.com"
+  },
+  "committerTimestamp": 1537538845000,
+  "message": "Add sample script hello world",
+  "parents": [{
+    "id": "8d0fa145bde5151f1d103ab1c3dc1033e6ec4ac1",
+    "displayId": "8d0fa145bde",
+    "author": {
+      "name": "Antonio Muniz",
+      "emailAddress": "amuniz@example.com"
+    },
+    "authorTimestamp": 1537538695000,
+    "committer": {
+      "name": "Antonio Muniz",
+      "emailAddress": "amuniz@example.com"
+    },
+    "committerTimestamp": 1537538695000,
+    "message": "Initial commit",
+    "parents": []
+  }]
+}

--- a/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/server/payload/1.0-projects-amuniz-repos-test-repos-commits-fb522a6f08c7c7df337312e4e65ec1b57710672e.json
+++ b/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/server/payload/1.0-projects-amuniz-repos-test-repos-commits-fb522a6f08c7c7df337312e4e65ec1b57710672e.json
@@ -1,0 +1,34 @@
+{
+  "id": "fb522a6f08c7c7df337312e4e65ec1b57710672e",
+  "displayId": "fb522a6f08c",
+  "author": {
+    "name": "Antonio Muniz",
+    "emailAddress": "amuniz@example.com"
+  },
+  "authorTimestamp": 1537538991000,
+  "committer": {
+    "name": "Antonio Muniz",
+    "emailAddress": "amuniz@example.com"
+  },
+  "committerTimestamp": 1537538991000,
+  "message": "Suppress echo command part",
+  "parents": [{
+    "id": "ae995d7a37069d0988462a9c92828971e8a42b5d",
+    "displayId": "ae995d7a370",
+    "author": {
+      "name": "Antonio Muniz",
+      "emailAddress": "amuniz@example.com"
+    },
+    "authorTimestamp": 1537538960000,
+    "committer": {
+      "name": "Antonio Muniz",
+      "emailAddress": "amuniz@example.com"
+    },
+    "committerTimestamp": 1537538960000,
+    "message": "Support also windows environments",
+    "parents": [{
+      "id": "bf4f4ce8a3a8d5c7dbfe7d609973a81a6c6664cf",
+      "displayId": "bf4f4ce8a3a"
+    }]
+  }]
+}

--- a/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/server/payload/1.0-projects-amuniz-repos-test-repos-pull-requests_start_0_limit_200.json
+++ b/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/server/payload/1.0-projects-amuniz-repos-test-repos-pull-requests_start_0_limit_200.json
@@ -1,0 +1,132 @@
+{
+  "size": 1,
+  "limit": 100,
+  "isLastPage": true,
+  "values": [{
+    "id": 1,
+    "version": 0,
+    "title": "Release/release 1",
+    "description": "* Add license\r\n* [CI] Release version 1.0.0",
+    "state": "OPEN",
+    "open": true,
+    "closed": false,
+    "createdDate": 1537885911512,
+    "updatedDate": 1537885911512,
+    "fromRef": {
+      "id": "refs/heads/release/release-1",
+      "displayId": "release/release-1",
+      "latestCommit": "bf0e8b7962c024026ad01ae09d3a11732e26c0d4",
+      "repository": {
+        "slug": "test-repos",
+        "id": 1,
+        "name": "test-repos",
+        "scmId": "git",
+        "state": "AVAILABLE",
+        "statusMessage": "Available",
+        "forkable": false,
+        "project": {
+          "key": "AMUNIZ",
+          "id": 1,
+          "name": "prj",
+          "description": "This is a test repo",
+          "public": true,
+          "type": "NORMAL",
+          "links": {
+            "self": [{
+              "href": "http://localhost:7990/projects/AMUNIZ"
+            }]
+          }
+        },
+        "public": false,
+        "links": {
+          "clone": [{
+            "href": "ssh://git@localhost:7999/amuniz/test-repos.git",
+            "name": "ssh"
+          }, {
+            "href": "http://localhost:7990/scm/amuniz/test-repos.git",
+            "name": "http"
+          }],
+          "self": [{
+            "href": "http://localhost:7990/projects/AMUNIZ/repos/test-repos/browse"
+          }]
+        }
+      }
+    },
+    "toRef": {
+      "id": "refs/heads/master",
+      "displayId": "master",
+      "latestCommit": "bf4f4ce8a3a8d5c7dbfe7d609973a81a6c6664cf",
+      "repository": {
+        "slug": "test-repos",
+        "id": 1,
+        "name": "test-repos",
+        "scmId": "git",
+        "state": "AVAILABLE",
+        "statusMessage": "Available",
+        "forkable": false,
+        "project": {
+          "key": "AMUNIZ",
+          "id": 1,
+          "name": "prj",
+          "description": "This is a test repo",
+          "public": true,
+          "type": "NORMAL",
+          "links": {
+            "self": [{
+              "href": "http://localhost:7990/projects/AMUNIZ"
+            }]
+          }
+        },
+        "public": false,
+        "links": {
+          "clone": [{
+            "href": "ssh://git@localhost:7999/amuniz/test-repos.git",
+            "name": "ssh"
+          }, {
+            "href": "http://localhost:7990/scm/amuniz/test-repos.git",
+            "name": "http"
+          }],
+          "self": [{
+            "href": "http://localhost:7990/projects/AMUNIZ/repos/test-repos/browse"
+          }]
+        }
+      }
+    },
+    "locked": false,
+    "author": {
+      "user": {
+        "name": "amuniz",
+        "emailAddress": "amuniz@acme.com",
+        "id": 2,
+        "displayName": "Antonio Muniz",
+        "active": true,
+        "slug": "amuniz",
+        "type": "NORMAL",
+        "links": {
+          "self": [{
+            "href": "http://localhost:7990/users/amuniz"
+          }]
+        }
+      },
+      "role": "AUTHOR",
+      "approved": false,
+      "status": "UNAPPROVED"
+    },
+    "reviewers": [],
+    "participants": [],
+    "properties": {
+      "mergeResult": {
+        "outcome": "CLEAN",
+        "current": true
+      },
+      "resolvedTaskCount": 0,
+      "openTaskCount": 0
+    },
+    "links": {
+      "self": [{
+        "href": "http://localhost:7990/projects/AMUNIZ/repos/test-repos/pull-requests/1"
+      }]
+    }
+  }],
+  "start": 0
+}

--- a/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/server/payload/1.0-projects-amuniz-repos-test-repos.json
+++ b/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/server/payload/1.0-projects-amuniz-repos-test-repos.json
@@ -1,0 +1,35 @@
+{
+  "slug": "test-repos",
+  "id": 1,
+  "name": "test-repos",
+  "scmId": "git",
+  "state": "AVAILABLE",
+  "statusMessage": "Available",
+  "forkable": false,
+  "project": {
+    "key": "AMUNIZ",
+    "id": 1,
+    "name": "prj",
+    "description": "This is a test repo",
+    "public": true,
+    "type": "NORMAL",
+    "links": {
+      "self": [{
+        "href": "http://localhost:7990/projects/AMUNIZ"
+      }]
+    }
+  },
+  "public": false,
+  "links": {
+    "clone": [{
+      "href": "ssh://git@localhost:7999/amuniz/test-repos.git",
+      "name": "ssh"
+    }, {
+      "href": "http://localhost:7990/scm/amuniz/test-repos.git",
+      "name": "http"
+    }],
+    "self": [{
+      "href": "http://localhost:7990/projects/AMUNIZ/repos/test-repos/browse"
+    }]
+  }
+}


### PR DESCRIPTION
All the data gather from BB (cloud or server) lacks of message and author for HEAD commit. Actually only commit hash is stored, instead commit message and author are ignored.
The PR simply add methods to get move on those information.
As explained in the JIRA issue the goal is avoid trigger a build if the last commit of a branch is performed by the Jenkins user or if the commit message matches some rules (for example [maven-release-plugin]*). This is useful for example when in the pipeline we perform some git push (for example during release). 
The author is in git commit raw format, that mean `author name <author email>` for both client.

Test cases does not use the actual mock api client because during test I got a some NPE in JSON de-serialisation that can be captured only using real REST calls. For this scope I had create a new integration api client that rely on real payloads get from [this](https://bitbucket.org/nfalco79/test-repos/src) sample repository (replicated also on BB server 5.14.0 with a trial license). Each call is translated to a json file on classpath. The client could also take a different root path where place payloads from a different sample repository site.

Eventually the PR could be split into 2 part. The main part is expose message/author information, the second one (optional) is the CommitAuthorFilterTraits. This traits could be also implemented as additional jenkins plugin but the first part of this PR is required.