### PR TITLE
Fix bad Jenkins root URL for Bitbucket API

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketBuildStatusNotifications.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketBuildStatusNotifications.java
@@ -38,7 +38,6 @@ import hudson.scm.SCM;
 import hudson.scm.SCMRevisionState;
 import java.io.File;
 import java.io.IOException;
-import java.net.InetAddress;
 import java.net.MalformedURLException;
 import java.net.URL;
 import javax.annotation.CheckForNull;
@@ -78,7 +77,9 @@ public class BitbucketBuildStatusNotifications {
      * @return the url if it is valid
      */
     static String checkURL(String url) {
-        /*  */
+        if (url != null && url.equals("http://unconfigured-jenkins-location/")) {
+            throw new IllegalStateException("Could not determine Jenkins URL.");
+        }
         try {
             URL u = new URL(url);
             if (!u.getHost().contains(".")) {
@@ -86,9 +87,6 @@ public class BitbucketBuildStatusNotifications {
             }
         } catch (MalformedURLException e) {
             throw new IllegalStateException("Bad Jenkins URL");
-        }
-        if (url.equals("http://unconfigured-jenkins-location/")) {
-            throw new IllegalStateException("Could not determine Jenkins URL.");
         }
         return url;
     }

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketBuildStatusNotifications.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketBuildStatusNotifications.java
@@ -38,6 +38,9 @@ import hudson.scm.SCM;
 import hudson.scm.SCMRevisionState;
 import java.io.File;
 import java.io.IOException;
+import java.net.InetAddress;
+import java.net.MalformedURLException;
+import java.net.URL;
 import javax.annotation.CheckForNull;
 import jenkins.model.JenkinsLocationConfiguration;
 import jenkins.plugins.git.AbstractGitSCMSource;
@@ -63,14 +66,30 @@ public class BitbucketBuildStatusNotifications {
         }
 
         String url = DisplayURLProvider.get().getRunURL(build);
+        return checkURL(url);
+    }
 
-        if (url.startsWith("http://localhost")) {
-            throw new IllegalStateException("Jenkins URL cannot start with http://localhost");
+    /**
+     * Check if the build URL is compatible with Bitbucket API.
+     * For example, Bitbucket API doesn't accept simple hostnames as URLs host value
+     * Throws an IllegalStateException if it is not valid, or return the url otherwise
+     *
+     * @param url the URL of the build to check
+     * @return the url if it is valid
+     */
+    static String checkURL(String url) {
+        /*  */
+        try {
+            URL u = new URL(url);
+            if (!u.getHost().contains(".")) {
+                throw new IllegalStateException("Please use a fully qualified name or an IP address for Jenkins URL");
+            }
+        } catch (MalformedURLException e) {
+            throw new IllegalStateException("Bad Jenkins URL");
         }
         if (url.equals("http://unconfigured-jenkins-location/")) {
             throw new IllegalStateException("Could not determine Jenkins URL.");
         }
-
         return url;
     }
 

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketBuildStatusNotifications.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketBuildStatusNotifications.java
@@ -101,7 +101,8 @@ public class BitbucketBuildStatusNotifications {
         try {
             url = getRootURL(build);
         } catch (IllegalStateException e) {
-            listener.getLogger().println("Can not determine Jenkins root URL. " +
+            listener.getLogger().println("Can not determine Jenkins root URL " +
+                    "or Jenkins URL is not a valid URL regarding Bitbucket API. " +
                     "Commit status notifications are disabled until a root URL is " +
                     "configured in Jenkins global configuration.");
             return;

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketBuildStatusNotifications.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketBuildStatusNotifications.java
@@ -77,7 +77,7 @@ public class BitbucketBuildStatusNotifications {
      * @return the url if it is valid
      */
     static String checkURL(String url) {
-        if (url != null && url.equals("http://unconfigured-jenkins-location/")) {
+        if (url == null || url.equals("http://unconfigured-jenkins-location/")) {
             throw new IllegalStateException("Could not determine Jenkins URL.");
         }
         try {

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketBuildStatusNotifications.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketBuildStatusNotifications.java
@@ -77,7 +77,7 @@ public class BitbucketBuildStatusNotifications {
      * @return the url if it is valid
      */
     static String checkURL(@NonNull String url) {
-        if (url.equals("http://unconfigured-jenkins-location/")) {
+        if (url.startsWith("http://unconfigured-jenkins-location/")) {
             throw new IllegalStateException("Could not determine Jenkins URL.");
         }
         try {

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketBuildStatusNotifications.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketBuildStatusNotifications.java
@@ -76,8 +76,8 @@ public class BitbucketBuildStatusNotifications {
      * @param url the URL of the build to check
      * @return the url if it is valid
      */
-    static String checkURL(String url) {
-        if (url == null || url.equals("http://unconfigured-jenkins-location/")) {
+    static String checkURL(@NonNull String url) {
+        if (url.equals("http://unconfigured-jenkins-location/")) {
             throw new IllegalStateException("Could not determine Jenkins URL.");
         }
         try {

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketBuildStatusNotificationsTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketBuildStatusNotificationsTest.java
@@ -1,26 +1,3 @@
-/*
- * The MIT License
- *
- * Copyright (c) 2018, Nikolas Falco
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
- */
 package com.cloudbees.jenkins.plugins.bitbucket;
 
 import org.junit.Rule;

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketBuildStatusNotificationsTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketBuildStatusNotificationsTest.java
@@ -1,0 +1,74 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2018, Nikolas Falco
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.cloudbees.jenkins.plugins.bitbucket;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.assertNotNull;
+
+public class BitbucketBuildStatusNotificationsTest {
+
+    private void checkURLReturnException(String s) {
+        thrown.expect(IllegalStateException.class);
+        BitbucketBuildStatusNotifications.checkURL(s);
+    }
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @Test
+    public void test_checkURL_localhost() {
+        checkURLReturnException("http://localhost/build/sample");
+    }
+
+    @Test
+    public void test_checkURL_noJenkinsURL() {
+        checkURLReturnException("http://unconfigured-jenkins-location/");
+    }
+
+    @Test
+    public void test_checkURL_intranet() {
+        checkURLReturnException("http://intranet/build/sample");
+    }
+
+    @Test
+    public void test_checkURL_intranetWithPort() {
+        checkURLReturnException("http://intranet:8080/build/sample");
+    }
+
+    @Test
+    public void test_checkURL_intranetWithPortAndHttps() {
+        checkURLReturnException("https://intranet:8080/build/sample");
+    }
+
+    @Test
+    public void test_checkURL_isOk() {
+        assertNotNull(BitbucketBuildStatusNotifications.checkURL("http://localhost.local/build/sample"));
+        assertNotNull(BitbucketBuildStatusNotifications.checkURL("http://intranet.local:8080/build/sample"));
+        assertNotNull(BitbucketBuildStatusNotifications.checkURL("http://www.mydomain.com:8000/build/sample"));
+        assertNotNull(BitbucketBuildStatusNotifications.checkURL("https://www.mydomain.com/build/sample"));
+    }
+}

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketBuildStatusNotificationsTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketBuildStatusNotificationsTest.java
@@ -27,6 +27,11 @@ public class BitbucketBuildStatusNotificationsTest {
     }
 
     @Test
+    public void test_checkURL_noJenkinsURL_BlueOceanCase() {
+        checkURLReturnException("http://unconfigured-jenkins-location/blue");
+    }
+
+    @Test
     public void test_checkURL_intranet() {
         checkURLReturnException("http://intranet/build/sample");
     }

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketBuildStatusNotificationsTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketBuildStatusNotificationsTest.java
@@ -17,11 +17,6 @@ public class BitbucketBuildStatusNotificationsTest {
     public ExpectedException thrown = ExpectedException.none();
 
     @Test
-    public void test_checkURL_null() {
-        checkURLReturnException(null);
-    }
-
-    @Test
     public void test_checkURL_localhost() {
         checkURLReturnException("http://localhost/build/sample");
     }

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketBuildStatusNotificationsTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketBuildStatusNotificationsTest.java
@@ -40,6 +40,11 @@ public class BitbucketBuildStatusNotificationsTest {
     public ExpectedException thrown = ExpectedException.none();
 
     @Test
+    public void test_checkURL_null() {
+        checkURLReturnException(null);
+    }
+
+    @Test
     public void test_checkURL_localhost() {
         checkURLReturnException("http://localhost/build/sample");
     }


### PR DESCRIPTION
Fix case when the Jenkins URL is a hostname but not localhost, and the Bitbucket API doesn't allow it

For example, my Jenkins instance runs at http://intranet:8080.

When calling directly Bitbucket API with this URL, the API response is :
`{"type": "error", "error": {"fields": {"url": ["Enter a valid URL."]}, "message": "url: Enter a valid URL."}}`

So I propose to change the Jenkins root URL verification check to handle this case.