### PR TITLE
Use FullPathName to Project has BitBucket Key Notification

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketBuildStatusNotifications.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketBuildStatusNotifications.java
@@ -106,7 +106,7 @@ public class BitbucketBuildStatusNotifications {
             return;
         }
 
-        String key = build.getParent().getFullName(); // use the job full name as the key for the status
+        String key = build.getParent().getParent().getFullName(); // use the job full name as the key for the status
         String name = build.getFullDisplayName(); // use the build number as the display name of the status
         BitbucketBuildStatus status;
         Result result = build.getResult();


### PR DESCRIPTION
This is to solve misleading BuildStatus in Bitbucket.

Mainly for Branches that become Pull-Request.
If a Branch send a BuildStatus of «Failed», and the Status is solved to «Success» during the PullRequest.
BuildStatus state in BitBucket won't change to success since there is always a linked Build mark has failed.
![bb_buildstatusexample](https://user-images.githubusercontent.com/3663526/47244309-fd349d00-d3c2-11e8-84de-9bc974e9f148.jpg)

Also, Since the «Branch Job» is disable there is no point to keep the BuildStatus history in Bitbucket.