### PR TITLE
[JENKINS-54157] Add field passUnstableBuilds

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketBuildStatusNotifications.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketBuildStatusNotifications.java
@@ -92,7 +92,8 @@ public class BitbucketBuildStatusNotifications {
     }
 
     private static void createStatus(@NonNull Run<?, ?> build, @NonNull TaskListener listener,
-                                     @NonNull BitbucketApi bitbucket, @NonNull String hash)
+                                     @NonNull BitbucketApi bitbucket, @NonNull String hash,
+                                     @NonNull Boolean passUnstableBuilds)
             throws IOException, InterruptedException {
 
         String url;
@@ -118,7 +119,11 @@ public class BitbucketBuildStatusNotifications {
             state = "SUCCESSFUL";
         } else if (Result.UNSTABLE.equals(result)) {
             statusDescription = StringUtils.defaultIfBlank(buildDescription, "This commit has test failures.");
-            state = "FAILED";
+            if (passUnstableBuilds) {
+                state = "SUCCESSFUL";
+            } else {
+                state = "FAILED";
+            }
         } else if (Result.FAILURE.equals(result)) {
             statusDescription = StringUtils.defaultIfBlank(buildDescription, "There was a failure building this commit.");
             state = "FAILED";
@@ -155,11 +160,11 @@ public class BitbucketBuildStatusNotifications {
         }
         if (r instanceof PullRequestSCMRevision) {
             listener.getLogger().println("[Bitbucket] Notifying pull request build result");
-            createStatus(build, listener, source.buildBitbucketClient((PullRequestSCMHead) r.getHead()), hash);
+            createStatus(build, listener, source.buildBitbucketClient((PullRequestSCMHead) r.getHead()), hash, source.getPassUnstableBuilds());
 
         } else {
             listener.getLogger().println("[Bitbucket] Notifying commit build result");
-            createStatus(build, listener, source.buildBitbucketClient(), hash);
+            createStatus(build, listener, source.buildBitbucketClient(), hash, source.getPassUnstableBuilds());
         }
     }
 

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMNavigator.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMNavigator.java
@@ -118,6 +118,8 @@ public class BitbucketSCMNavigator extends SCMNavigator {
     @NonNull
     private final String repoOwner;
     @NonNull
+    private boolean passUnstableBuilds;
+    @NonNull
     private List<SCMTrait<? extends SCMTrait<?>>> traits;
     @Deprecated
     @Restricted(NoExternalUse.class)
@@ -151,6 +153,7 @@ public class BitbucketSCMNavigator extends SCMNavigator {
         this.repoOwner = repoOwner;
         this.traits = new ArrayList<>();
         this.credentialsId = null; // highlighting the default is anonymous unless you configure explicitly
+        this.passUnstableBuilds = false;
     }
 
     @Deprecated // retained for binary compatibility
@@ -220,6 +223,17 @@ public class BitbucketSCMNavigator extends SCMNavigator {
     @NonNull
     public List<SCMTrait<?>> getTraits() {
         return Collections.unmodifiableList(traits);
+    }
+
+    @NonNull
+    public boolean getPassUnstableBuilds() {
+        return passUnstableBuilds;
+    }
+
+    @NonNull
+    @DataBoundSetter
+    public void setPassUnstableBuilds(boolean status) {
+        this.passUnstableBuilds = status;
     }
 
     @DataBoundSetter
@@ -884,7 +898,8 @@ public class BitbucketSCMNavigator extends SCMNavigator {
                     serverUrl,
                     credentialsId,
                     repoOwner,
-                    projectName)
+                    projectName,
+                    passUnstableBuilds)
                     .withRequest(request)
                     .build();
         }

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource.java
@@ -170,6 +170,12 @@ public class BitbucketSCMSource extends SCMSource {
     private List<SCMSourceTrait> traits;
 
     /**
+     * Whether unstable Jenkins build shall be reported PASS or FAIL in Bitbucket
+     */
+    @NonNull
+    private boolean passUnstableBuilds = false;
+
+    /**
      * Credentials used to clone the repository/repositories.
      */
     @Deprecated
@@ -338,6 +344,16 @@ public class BitbucketSCMSource extends SCMSource {
     @DataBoundSetter
     public void setTraits(@CheckForNull List<SCMSourceTrait> traits) {
         this.traits = new ArrayList<>(Util.fixNull(traits));
+    }
+
+    @DataBoundSetter
+    public void setPassUnstableBuilds(boolean passUnstableBuilds) {
+        this.passUnstableBuilds = passUnstableBuilds;
+    }
+
+    @NonNull
+    public boolean getPassUnstableBuilds() {
+        return passUnstableBuilds;
     }
 
     @Deprecated

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSourceBuilder.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSourceBuilder.java
@@ -54,24 +54,31 @@ public class BitbucketSCMSourceBuilder extends SCMSourceBuilder<BitbucketSCMSour
      */
     @NonNull
     private final String repoOwner;
+    /**
+     * Whether unstable Jenkins build shall be reported PASS or FAIL in Bitbucket
+     */
+    @NonNull
+    private final boolean passUnstableBuilds;
 
     /**
      * Constructor.
      *
-     * @param id            the {@link BitbucketSCMSource#getId()}
-     * @param serverUrl     the {@link BitbucketSCMSource#getServerUrl()}
-     * @param credentialsId the credentials id.
-     * @param repoOwner     the repository owner.
-     * @param repoName      the project name.
+     * @param id                    the {@link BitbucketSCMSource#getId()}
+     * @param serverUrl             the {@link BitbucketSCMSource#getServerUrl()}
+     * @param credentialsId         the credentials id.
+     * @param repoOwner             the repository owner.
+     * @param repoName              the project name.
+     * @param passUnstableBuilds    whether unstable Jenkins build shall be reported PASS or FAIL in Bitbucket
      */
     public BitbucketSCMSourceBuilder(@CheckForNull String id, @NonNull String serverUrl,
                                      @CheckForNull String credentialsId, @NonNull String repoOwner,
-                                     @NonNull String repoName) {
+                                     @NonNull String repoName, @NonNull boolean passUnstableBuilds) {
         super(BitbucketSCMSource.class, repoName);
         this.id = id;
         this.serverUrl = BitbucketEndpointConfiguration.normalizeServerUrl(serverUrl);
         this.credentialsId = credentialsId;
         this.repoOwner = repoOwner;
+        this.passUnstableBuilds = passUnstableBuilds;
     }
 
     /**
@@ -115,6 +122,16 @@ public class BitbucketSCMSourceBuilder extends SCMSourceBuilder<BitbucketSCMSour
     }
 
     /**
+     * Whether an unstable Jenkins build shall be reported as PASS or FAILED in Bitbucket
+     *
+     * @return  whether an unstable Jenkins build shall be reported as PASS or FAILED in Bitbucket
+     */
+    @NonNull
+    public boolean passUnstableBuilds() {
+        return passUnstableBuilds;
+    }
+
+    /**
      * {@inheritDoc}
      */
     @NonNull
@@ -125,6 +142,7 @@ public class BitbucketSCMSourceBuilder extends SCMSourceBuilder<BitbucketSCMSour
         result.setServerUrl(serverUrl());
         result.setCredentialsId(credentialsId());
         result.setTraits(traits());
+        result.setPassUnstableBuilds(passUnstableBuilds());
         return result;
     }
 }

--- a/src/main/resources/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMNavigator/config.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMNavigator/config.jelly
@@ -22,4 +22,7 @@
   <f:entry title="${%Behaviours}" field="traits">
     <scm:traits field="traits"/>
   </f:entry>
+  <f:entry title="${%PassUnstableBuilds}" field="passUnstableBuilds">
+    <f:checkbox/>
+  </f:entry>
 </j:jelly>

--- a/src/main/resources/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMNavigator/config_en.properties
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMNavigator/config_en.properties
@@ -1,1 +1,2 @@
 Behaviours=Behaviours
+PassUnstableBuilds=Pass 'unstable'

--- a/src/main/resources/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMNavigator/config_en_US.properties
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMNavigator/config_en_US.properties
@@ -1,1 +1,2 @@
 Behaviours=Behaviors
+PassUnstableBuilds=Pass 'unstable'

--- a/src/main/resources/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMNavigator/help-passUnstableBuilds.html
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMNavigator/help-passUnstableBuilds.html
@@ -1,0 +1,3 @@
+<div>
+    If set to true it overrides the default behaviour and reports unstable Jenkins builds as SUCCESSFUL instead of FAILED
+</div>

--- a/src/main/resources/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource/config-detail.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource/config-detail.jelly
@@ -27,4 +27,7 @@
   <f:entry title="${%Behaviours}" field="traits">
     <scm:traits field="traits"/>
   </f:entry>
+  <f:entry title="${%PassUnstableBuilds}" field="passUnstableBuilds">
+    <f:checkbox/>
+  </f:entry>
 </j:jelly>

--- a/src/main/resources/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource/config-detail_en.properties
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource/config-detail_en.properties
@@ -1,1 +1,2 @@
 Behaviours=Behaviours
+PassUnstableBuilds=Pass 'unstable'

--- a/src/main/resources/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource/config-detail_en_US.properties
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource/config-detail_en_US.properties
@@ -1,1 +1,2 @@
 Behaviours=Behaviors
+PassUnstableBuilds=Pass 'unstable'

--- a/src/main/resources/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource/help-passUnstableBuilds.html
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource/help-passUnstableBuilds.html
@@ -1,0 +1,3 @@
+<div>
+    If set to true it overrides the default behaviour and reports unstable Jenkins builds as SUCCESSFUL instead of FAILED
+</div>


### PR DESCRIPTION
According to [my bug report](https://issues.jenkins-ci.org/browse/JENKINS-54157) I've added an additional field (checkbox)
If set to true it overrides the default behaviour and reports unstable Jenkins builds as SUCCESSFUL instead of FAILED