### PR TITLE
httpclientbuilder now uses system properties by default

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/BitbucketServerAPIClient.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/BitbucketServerAPIClient.java
@@ -735,6 +735,7 @@ public class BitbucketServerAPIClient implements BitbucketApi {
      */
     private CloseableHttpClient getHttpClient(final HttpRequestBase request) {
         HttpClientBuilder httpClientBuilder = HttpClientBuilder.create();
+        httpClientBuilder.useSystemProperties();
 
         RequestConfig.Builder requestConfig = RequestConfig.custom();
         requestConfig.setConnectTimeout(10 * 1000);


### PR DESCRIPTION
One-liner. Our bitbucket server requires a certificate for access and a username & password to authenticate. Our truststore is set up with our certificate for this but the httpclient the builder created wasn't using the system truststore leading to ssl errors.

Adding this line fixed our use-case. Not sure if it can help others.