### PR TITLE
Name sections consistently

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMNavigator.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMNavigator.java
@@ -715,7 +715,7 @@ public class BitbucketSCMNavigator extends SCMNavigator {
                     return MercurialSCM.class.isAssignableFrom(d.getScmClass());
                 }
             }, true, result);
-            NamedArrayList.select(all, "Additional", null, true, result, insertionPoint);
+            NamedArrayList.select(all, "General", null, true, result, insertionPoint);
             return result;
         }
 


### PR DESCRIPTION
* in BitbucketSCMSource it's named "General"
* both help files use "General"
  * .../BitbucketSCMNavigator/help-traits.html
  * .../BitbucketSCMSource/help-traits.html