### PR TITLE
[JENKINS-55787] Switch labels from entry to checkbox

### DIFF
--- a/src/main/resources/com/cloudbees/jenkins/plugins/bitbucket/endpoints/BitbucketServerEndpoint/config-detail.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/bitbucket/endpoints/BitbucketServerEndpoint/config-detail.jelly
@@ -7,7 +7,7 @@
   <f:entry title="${%Server URL}" field="serverUrl">
     <f:textbox/>
   </f:entry>
-  <f:entry title="${%Call Can Merge}" field="callCanMerge">
-    <f:checkbox default="true"/>
+  <f:entry field="callCanMerge">
+    <f:checkbox title="${%Call Can Merge}" default="true"/>
   </f:entry>
 </j:jelly>


### PR DESCRIPTION
[https://issues.jenkins-ci.org/browse/JENKINS-55787](https://issues.jenkins-ci.org/browse/JENKINS-55787)

Basically checkboxes should have labels, splitting the labels away from their checkboxes is poor UX, poor accessibility. This change brings the layout more inline with how normal settings UIs lay out checkboxes.
