### PR TITLE
JENKINS-48737 Fixing lightweight pull request checkouts, also for files in subdirectories

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/filesystem/BitbucketSCMFile.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/filesystem/BitbucketSCMFile.java
@@ -24,61 +24,40 @@
 
 package com.cloudbees.jenkins.plugins.bitbucket.filesystem;
 
-import com.cloudbees.jenkins.plugins.bitbucket.BranchSCMHead;
-import com.cloudbees.jenkins.plugins.bitbucket.JsonParser;
-import com.cloudbees.jenkins.plugins.bitbucket.PullRequestSCMHead;
-import java.util.Map;
-
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketApi;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
 import java.io.InputStream;
 import jenkins.scm.api.SCMFile;
-import jenkins.scm.api.SCMHead;
-import jenkins.scm.api.mixin.ChangeRequestCheckoutStrategy;
 
 public class BitbucketSCMFile  extends SCMFile {
 
     private final BitbucketApi api;
-    private SCMHead head;
+    private  String ref;
     private final String hash;
 
     public String getRef() {
-        if (head instanceof BranchSCMHead) {
-            return head.getName();
-        }
-        if (head instanceof PullRequestSCMHead) {
-            // working on a pull request - can be either "HEAD" or "MERGE"
-            PullRequestSCMHead pr = (PullRequestSCMHead) head;
-            if (pr.getRepository() == null) { // not clear when this happens
-                return null;
-            }
+        return ref;
+    }
 
-            // else build the bitbucket API compatible ref spec:
-            if (pr.getCheckoutStrategy() == ChangeRequestCheckoutStrategy.HEAD) {
-                return "pull-requests/" + pr.getId() + "/from";
-            } else if (pr.getCheckoutStrategy() == ChangeRequestCheckoutStrategy.MERGE) {
-                return "pull-requests/" + pr.getId() + "/merge";
-            }
-        }
-        return null;
-
+    public void setRef(String ref) {
+        this.ref = ref;
     }
 
     @Deprecated
     public BitbucketSCMFile(BitbucketSCMFileSystem bitBucketSCMFileSystem,
                             BitbucketApi api,
-                            SCMHead head) {
-        this(bitBucketSCMFileSystem, api, head, null);
+                            String ref) {
+        this(bitBucketSCMFileSystem, api, ref, null);
     }
 
     public BitbucketSCMFile(BitbucketSCMFileSystem bitBucketSCMFileSystem,
                             BitbucketApi api,
-                            SCMHead head, String hash) {
+                            String ref, String hash) {
         super();
         type(Type.DIRECTORY);
         this.api = api;
-        this.head = head;
+        this.ref = ref;
         this.hash = hash;
     }
 
@@ -90,7 +69,7 @@ public class BitbucketSCMFile  extends SCMFile {
     public BitbucketSCMFile(@NonNull BitbucketSCMFile parent, String name, Type type, String hash) {
         super(parent, name);
         this.api = parent.api;
-        this.head = parent.head;
+        this.ref = parent.ref;
         this.hash = hash;
         type(type);
     }
@@ -115,13 +94,8 @@ public class BitbucketSCMFile  extends SCMFile {
     public InputStream content() throws IOException, InterruptedException {
         if (this.isDirectory()) {
             throw new IOException("Cannot get raw content from a directory");
-        }
-        try {
+        } else {
             return api.getFileContent(this);
-        } catch (IOException e)
-        {
-            // TODO: Disable light-weight fallback to full checkout on merge conflicts
-            throw e;
         }
     }
 

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/filesystem/BitbucketSCMFile.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/filesystem/BitbucketSCMFile.java
@@ -25,19 +25,17 @@
 package com.cloudbees.jenkins.plugins.bitbucket.filesystem;
 
 import com.cloudbees.jenkins.plugins.bitbucket.BranchSCMHead;
-import com.cloudbees.jenkins.plugins.bitbucket.JsonParser;
 import com.cloudbees.jenkins.plugins.bitbucket.PullRequestSCMHead;
-import java.util.Map;
-
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketApi;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import java.io.IOException;
-import java.io.InputStream;
 import jenkins.scm.api.SCMFile;
 import jenkins.scm.api.SCMHead;
 import jenkins.scm.api.mixin.ChangeRequestCheckoutStrategy;
 
-public class BitbucketSCMFile  extends SCMFile {
+import java.io.IOException;
+import java.io.InputStream;
+
+public class BitbucketSCMFile extends SCMFile {
 
     private final BitbucketApi api;
     private SCMHead head;
@@ -118,8 +116,7 @@ public class BitbucketSCMFile  extends SCMFile {
         }
         try {
             return api.getFileContent(this);
-        } catch (IOException e)
-        {
+        } catch (IOException e) {
             // TODO: Disable light-weight fallback to full checkout on merge conflicts
             throw e;
         }
@@ -134,7 +131,7 @@ public class BitbucketSCMFile  extends SCMFile {
     @Override
     @NonNull
     protected SCMFile newChild(String name, boolean assumeIsDirectory) {
-        return new BitbucketSCMFile(this, name, assumeIsDirectory?Type.DIRECTORY:Type.REGULAR_FILE, hash);
+        return new BitbucketSCMFile(this, name, assumeIsDirectory ? Type.DIRECTORY : Type.REGULAR_FILE, hash);
     }
 
     @Override

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/filesystem/BitbucketSCMFile.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/filesystem/BitbucketSCMFile.java
@@ -25,17 +25,19 @@
 package com.cloudbees.jenkins.plugins.bitbucket.filesystem;
 
 import com.cloudbees.jenkins.plugins.bitbucket.BranchSCMHead;
+import com.cloudbees.jenkins.plugins.bitbucket.JsonParser;
 import com.cloudbees.jenkins.plugins.bitbucket.PullRequestSCMHead;
+import java.util.Map;
+
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketApi;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.io.IOException;
+import java.io.InputStream;
 import jenkins.scm.api.SCMFile;
 import jenkins.scm.api.SCMHead;
 import jenkins.scm.api.mixin.ChangeRequestCheckoutStrategy;
 
-import java.io.IOException;
-import java.io.InputStream;
-
-public class BitbucketSCMFile extends SCMFile {
+public class BitbucketSCMFile  extends SCMFile {
 
     private final BitbucketApi api;
     private SCMHead head;
@@ -116,7 +118,8 @@ public class BitbucketSCMFile extends SCMFile {
         }
         try {
             return api.getFileContent(this);
-        } catch (IOException e) {
+        } catch (IOException e)
+        {
             // TODO: Disable light-weight fallback to full checkout on merge conflicts
             throw e;
         }
@@ -131,7 +134,7 @@ public class BitbucketSCMFile extends SCMFile {
     @Override
     @NonNull
     protected SCMFile newChild(String name, boolean assumeIsDirectory) {
-        return new BitbucketSCMFile(this, name, assumeIsDirectory ? Type.DIRECTORY : Type.REGULAR_FILE, hash);
+        return new BitbucketSCMFile(this, name, assumeIsDirectory?Type.DIRECTORY:Type.REGULAR_FILE, hash);
     }
 
     @Override

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/filesystem/BitbucketSCMFileSystem.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/filesystem/BitbucketSCMFileSystem.java
@@ -147,7 +147,7 @@ public class BitbucketSCMFileSystem extends SCMFileSystem {
             } else if (head instanceof PullRequestSCMHead) {
                 // working on a pull request - can be either "HEAD" or "MERGE"
                 PullRequestSCMHead pr = (PullRequestSCMHead) head;
-                if (pr.getRepository() == null) { // check access to repository (forked with no access)
+                if (pr.getRepository() == null) { // check access to repository (might be forked)
                     return null;
                 }
 
@@ -156,7 +156,7 @@ public class BitbucketSCMFileSystem extends SCMFileSystem {
                     // TODO waiting for cloud support: https://bitbucket.org/site/master/issues/5814/refify-pull-requests-by-making-them-a-ref
                     if (pr.getCheckoutStrategy() == ChangeRequestCheckoutStrategy.MERGE) {
                         return null;
-                    } else {
+                    } else if (pr.getCheckoutStrategy() == ChangeRequestCheckoutStrategy.HEAD) {
                         ref = pr.getOriginName();
                     }
                 } else if (pr.getCheckoutStrategy() == ChangeRequestCheckoutStrategy.HEAD) {

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/filesystem/BitbucketSCMFileSystem.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/filesystem/BitbucketSCMFileSystem.java
@@ -32,6 +32,7 @@ import com.cloudbees.jenkins.plugins.bitbucket.PullRequestSCMHead;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketApi;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketApiFactory;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketAuthenticator;
+import com.cloudbees.jenkins.plugins.bitbucket.client.BitbucketCloudApiClient;
 import com.cloudbees.plugins.credentials.CredentialsMatchers;
 import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.common.StandardCredentials;
@@ -56,12 +57,12 @@ import jenkins.scm.api.mixin.ChangeRequestCheckoutStrategy;
 
 public class BitbucketSCMFileSystem extends SCMFileSystem {
 
-    private final SCMHead head;
+    private final String ref;
     private final BitbucketApi api;
 
-    protected BitbucketSCMFileSystem(BitbucketApi api, SCMHead head, SCMRevision rev) throws IOException {
+    protected BitbucketSCMFileSystem(BitbucketApi api, String ref, SCMRevision rev) throws IOException {
         super(rev);
-        this.head = head;
+        this.ref = ref;
         this.api = api;
     }
 
@@ -80,7 +81,7 @@ public class BitbucketSCMFileSystem extends SCMFileSystem {
     @Override
     public SCMFile getRoot() {
         SCMRevision revision = getRevision();
-        return new BitbucketSCMFile(this, api, head, revision == null ? null : revision.toString());
+        return new BitbucketSCMFile(this, api, ref, revision == null ? null : revision.toString());
     }
 
     @Extension
@@ -139,12 +140,38 @@ public class BitbucketSCMFileSystem extends SCMFileSystem {
             BitbucketAuthenticator authenticator = AuthenticationTokens.convert(BitbucketAuthenticator.authenticationContext(serverUrl), credentials);
 
             BitbucketApi apiClient = BitbucketApiFactory.newInstance(serverUrl, authenticator, owner, repository);
+            String ref = null;
 
-            if ((!(head instanceof BranchSCMHead) && !(head instanceof PullRequestSCMHead))) {
-                return null;  // not supported branch head
+            if (head instanceof BranchSCMHead) {
+                ref = head.getName();
+            }
+            if (head instanceof PullRequestSCMHead) {
+                // working on a pull request - can be either "HEAD" or "MERGE"
+                PullRequestSCMHead pr = (PullRequestSCMHead) head;
+                if (pr.getRepository() == null) { // not clear when this happens
+                    return null;
+                }
+
+                if (apiClient instanceof BitbucketCloudApiClient) {
+                    if (pr.getCheckoutStrategy() != ChangeRequestCheckoutStrategy.MERGE) {
+                        return new BitbucketSCMFileSystem(apiClient, pr.getOriginName(), rev);
+                    }
+                    return null; // TODO support merge revisions somehow for cloud
+
+                }
+                // else build the bitbucket API compatible ref spec:
+                if (pr.getCheckoutStrategy() == ChangeRequestCheckoutStrategy.HEAD) {
+                    ref = "pull-requests/" + pr.getId() + "/from";
+                } else if (pr.getCheckoutStrategy() == ChangeRequestCheckoutStrategy.MERGE) {
+                    ref = "pull-requests/" + pr.getId() + "/merge";
+                }
+            } else if (head instanceof BitbucketTagSCMHead) {
+                ref = "tags/" + head.getName();
+            } else {
+                return null;
             }
 
-            return new BitbucketSCMFileSystem(apiClient, head, rev);
+            return new BitbucketSCMFileSystem(apiClient, ref, rev);
         }
     }
 }

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/filesystem/BitbucketSCMFileSystem.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/filesystem/BitbucketSCMFileSystem.java
@@ -152,12 +152,16 @@ public class BitbucketSCMFileSystem extends SCMFileSystem {
                 }
 
                 if (apiClient instanceof BitbucketCloudApiClient) {
-                    // Bitbucket cloud does not support refs for pull requests
-                    // TODO waiting for cloud support: https://bitbucket.org/site/master/issues/5814/refify-pull-requests-by-making-them-a-ref
-                    if (pr.getCheckoutStrategy() == ChangeRequestCheckoutStrategy.MERGE) {
-                        return null;
-                    } else if (pr.getCheckoutStrategy() == ChangeRequestCheckoutStrategy.HEAD) {
+                    // support lightweight checkout for branches with same owner and repository
+                    if (pr.getCheckoutStrategy() == ChangeRequestCheckoutStrategy.HEAD &&
+                        pr.getRepoOwner().equals(src.getRepoOwner()) &&
+                        pr.getRepository().equals(src.getRepository())) {
                         ref = pr.getOriginName();
+                    } else {
+                        // Bitbucket cloud does not support refs for pull requests
+                        // Makes lightweight checkout for forks and merge strategy improbable
+                        // TODO waiting for cloud support: https://bitbucket.org/site/master/issues/5814/refify-pull-requests-by-making-them-a-ref
+                        return null;
                     }
                 } else if (pr.getCheckoutStrategy() == ChangeRequestCheckoutStrategy.HEAD) {
                     ref = "pull-requests/" + pr.getId() + "/from";

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/BitbucketServerAPIClient.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/BitbucketServerAPIClient.java
@@ -147,7 +147,7 @@ public class BitbucketServerAPIClient implements BitbucketApi {
     private static final String API_PULL_REQUESTS_PATH = API_REPOSITORY_PATH + "/pull-requests{?start,limit,at,direction,state}";
     private static final String API_PULL_REQUEST_PATH = API_REPOSITORY_PATH + "/pull-requests/{id}";
     private static final String API_PULL_REQUEST_MERGE_PATH = API_REPOSITORY_PATH + "/pull-requests/{id}/merge";
-    private static final String API_BROWSE_PATH = API_REPOSITORY_PATH + "/browse{/path*}{?at}";
+    private static final String API_BROWSE_PATH = API_REPOSITORY_PATH + "/browse{/path*}?at={+at}";
     private static final String API_COMMITS_PATH = API_REPOSITORY_PATH + "/commits{/hash}";
     private static final String API_PROJECT_PATH = API_BASE_PATH + "/projects/{owner}";
     private static final String API_COMMIT_COMMENT_PATH = API_REPOSITORY_PATH + "/commits{/hash}/comments";

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/BitbucketServerAPIClient.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/BitbucketServerAPIClient.java
@@ -57,7 +57,6 @@ import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredenti
 import com.damnhandy.uri.template.UriTemplate;
 import com.damnhandy.uri.template.impl.Operator;
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.google.common.annotations.VisibleForTesting;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.ProxyConfiguration;

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/BitbucketServerAPIClient.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/BitbucketServerAPIClient.java
@@ -57,6 +57,7 @@ import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredenti
 import com.damnhandy.uri.template.UriTemplate;
 import com.damnhandy.uri.template.impl.Operator;
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.google.common.annotations.VisibleForTesting;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.ProxyConfiguration;
@@ -147,7 +148,7 @@ public class BitbucketServerAPIClient implements BitbucketApi {
     private static final String API_PULL_REQUESTS_PATH = API_REPOSITORY_PATH + "/pull-requests{?start,limit,at,direction,state}";
     private static final String API_PULL_REQUEST_PATH = API_REPOSITORY_PATH + "/pull-requests/{id}";
     private static final String API_PULL_REQUEST_MERGE_PATH = API_REPOSITORY_PATH + "/pull-requests/{id}/merge";
-    private static final String API_BROWSE_PATH = API_REPOSITORY_PATH + "/browse{/path*}?at={+at}";
+    static final String API_BROWSE_PATH = API_REPOSITORY_PATH + "/browse/{+path}{?at}";
     private static final String API_COMMITS_PATH = API_REPOSITORY_PATH + "/commits{/hash}";
     private static final String API_PROJECT_PATH = API_BASE_PATH + "/projects/{owner}";
     private static final String API_COMMIT_COMMENT_PATH = API_REPOSITORY_PATH + "/commits{/hash}/comments";

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/BitbucketServerAPIClientTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/BitbucketServerAPIClientTest.java
@@ -1,0 +1,34 @@
+package com.cloudbees.jenkins.plugins.bitbucket.server.client;
+
+import com.damnhandy.uri.template.UriTemplate;
+import org.junit.Assert;
+import org.junit.Test;
+
+import static com.cloudbees.jenkins.plugins.bitbucket.server.client.BitbucketServerAPIClient.API_BROWSE_PATH;
+
+public class BitbucketServerAPIClientTest {
+
+    @Test
+    public void repoBrowsePathFolder() {
+        String expand = UriTemplate
+            .fromTemplate(API_BROWSE_PATH)
+            .set("owner", "test")
+            .set("repo", "test")
+            .set("path", "folder/Jenkinsfile")
+            .set("at", "fix/test")
+            .expand();
+        Assert.assertEquals("/rest/api/1.0/projects/test/repos/test/browse/folder/Jenkinsfile?at=fix%2Ftest", expand);
+    }
+
+    @Test
+    public void repoBrowsePathFile() {
+        String expand = UriTemplate
+            .fromTemplate(API_BROWSE_PATH)
+            .set("owner", "test")
+            .set("repo", "test")
+            .set("path", "Jenkinsfile")
+            .expand();
+        Assert.assertEquals("/rest/api/1.0/projects/test/repos/test/browse/Jenkinsfile", expand);
+    }
+
+}


### PR DESCRIPTION
Fixing lightweight checkout for PRs for merge and head revisions. The easiest way seemed to pull more data (SCMHead) into BitbucketSCMFile to be able to distinguish between merge and head PRs in a central location. 

Validated on Atlassian Bitbucket Server (DC) v5.8.2 for Jenkinsfiles as well as arbitrary files directly in a repo as well as in subdirectories.

There's still the corner case left for lightweight checkouts on conflicted PRs - these are still checked out in full, also on Jenkins masters.