### PR TITLE
Add payload & eventType from BitbucketSCMSourcePushHookReceiver.doNot…

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/BitbucketSCMSourcePushHookReceiver.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/BitbucketSCMSourcePushHookReceiver.java
@@ -101,6 +101,10 @@ public class BitbucketSCMSourcePushHookReceiver extends CrumbExclusion implement
             LOGGER.log(Level.FINE, "X-Bitbucket-Type header / server_url request parameter not found. Bitbucket Cloud webhook incoming.");
         }
 
+
+        type.getProcessor().putEnvVar("BITBUCKET_PAYLOAD", body);
+        type.getProcessor().putEnvVar("BITBUCKET_EVENT", eventKey);
+
         try {
             type.getProcessor().process(type, body, instanceType, origin, serverUrl);
         } catch (AbstractMethodError e) {

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/HookProcessor.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/HookProcessor.java
@@ -24,7 +24,6 @@
 package com.cloudbees.jenkins.plugins.bitbucket.hooks;
 
 import com.cloudbees.jenkins.plugins.bitbucket.BitbucketSCMSource;
-
 import hudson.EnvVars;
 import hudson.security.ACL;
 import hudson.security.ACLContext;
@@ -32,12 +31,10 @@ import hudson.slaves.EnvironmentVariablesNodeProperty;
 import hudson.slaves.NodeProperty;
 import hudson.slaves.NodePropertyDescriptor;
 import hudson.util.DescribableList;
-
 import java.io.IOException;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
 import jenkins.model.Jenkins;
 import jenkins.scm.api.SCMSource;
 import jenkins.scm.api.SCMSourceOwner;
@@ -129,13 +126,13 @@ public abstract class HookProcessor {
     protected void putEnvVar(String key, String value) throws IOException {
         Jenkins jenkins = Jenkins.getInstance();
         DescribableList<NodeProperty<?>, NodePropertyDescriptor> globalNodeProperties = jenkins.getGlobalNodeProperties();
-        List<EnvironmentVariablesNodeProperty> envVarsNodePropertyList = globalNodeProperties.getAll(hudson.slaves.EnvironmentVariablesNodeProperty.class);
+        List<EnvironmentVariablesNodeProperty> envVarsNodePropertyList = globalNodeProperties.getAll(EnvironmentVariablesNodeProperty.class);
 
         EnvironmentVariablesNodeProperty newEnvVarsNodeProperty = null;
         EnvVars envVars = null;
 
         if (envVarsNodePropertyList == null || envVarsNodePropertyList.isEmpty()) {
-            newEnvVarsNodeProperty = new hudson.slaves.EnvironmentVariablesNodeProperty();
+            newEnvVarsNodeProperty = new EnvironmentVariablesNodeProperty();
             globalNodeProperties.add(newEnvVarsNodeProperty);
             envVars = newEnvVarsNodeProperty.getEnvVars();
         } else {


### PR DESCRIPTION
…ify() method to Global Jekins ENVs

### Your checklist for this pull request

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!

- [x] Please describe what you did

- [ ] Link to relevant GitHub issues or pull requests

- [ ] Link to relevant [Jenkins JIRA issues](https://issues.jenkins-ci.org)

- [ ] Did you provide a test-case? That demonstrates feature works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled the information below
Describe your pull request below
-->

### Description
In the Pull Request we've set two global env variables which store the actual payload json received from a native BitBucket server (and the calculated eventKey) in the BitbucketSCMSourcePushHookReceiver.doNotify() method. 
With this change it will be possible to build a custom logic in the Jenkins pipeline files based on the native payload sent by the BitBucket Server.  