### PR TITLE
JENKINS-47867 Add WebhookConfigurationTrait

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/WebhookConfigurationTrait.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/WebhookConfigurationTrait.java
@@ -41,7 +41,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
 public class WebhookConfigurationTrait extends SCMSourceTrait {
 
     /**
-     * The committers that should be ignored in the webhook
+     * The committers that should be ignored in the webhook. A comma separated string.
      */
     @NonNull
     private final String committersToIgnore;

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/WebhookConfigurationTrait.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/WebhookConfigurationTrait.java
@@ -1,0 +1,115 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.cloudbees.jenkins.plugins.bitbucket;
+
+import com.cloudbees.jenkins.plugins.bitbucket.endpoints.BitbucketEndpointConfiguration;
+import com.cloudbees.jenkins.plugins.bitbucket.hooks.WebhookConfiguration;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Extension;
+import jenkins.scm.api.SCMSource;
+import jenkins.scm.api.trait.SCMSourceContext;
+import jenkins.scm.api.trait.SCMSourceTrait;
+import jenkins.scm.api.trait.SCMSourceTraitDescriptor;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+/**
+ * A {@link SCMSourceTrait} for {@link BitbucketSCMSource} that sets the committersToIgnore
+ * setting in {@link WebhookConfiguration}.
+ *
+ * @since 2.4.5
+ */
+public class WebhookConfigurationTrait extends SCMSourceTrait {
+
+    /**
+     * The committers that should be ignored in the webhook
+     */
+    @NonNull
+    private final String committersToIgnore;
+
+    /**
+     * Constructor.
+     *
+     * @param committersToIgnore a string of comma separated Bitbucket usernames to ignore
+     */
+    @DataBoundConstructor
+    public WebhookConfigurationTrait(@NonNull String committersToIgnore) {
+        this.committersToIgnore = committersToIgnore;
+    }
+
+    /**
+     * @return the committers to ignore
+     */
+    public String getCommittersToIgnore() {
+        return this.committersToIgnore;
+    }
+
+    /**
+     * Gets the WebhookConfiguration to apply.
+     *
+     * @return the WebhookConfiguration to apply.
+     */
+    @NonNull
+    public final WebhookConfiguration getWebhookConfiguration() {
+        return new WebhookConfiguration(this.committersToIgnore);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected void decorateContext(SCMSourceContext<?, ?> context) {
+        ((BitbucketSCMSourceContext) context).webhookConfiguration(getWebhookConfiguration());
+    }
+
+    /**
+     * Our constructor.
+     */
+    @Extension
+    public static class DescriptorImpl extends SCMSourceTraitDescriptor {
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public String getDisplayName() {
+            return Messages.WebhookConfigurationTrait_displayName();
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public Class<? extends SCMSourceContext> getContextClass() {
+            return BitbucketSCMSourceContext.class;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public Class<? extends SCMSource> getSourceClass() {
+            return BitbucketSCMSource.class;
+        }
+    }
+}

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/WebhookConfigurationTrait.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/WebhookConfigurationTrait.java
@@ -23,7 +23,6 @@
  */
 package com.cloudbees.jenkins.plugins.bitbucket;
 
-import com.cloudbees.jenkins.plugins.bitbucket.endpoints.BitbucketEndpointConfiguration;
 import com.cloudbees.jenkins.plugins.bitbucket.hooks.WebhookConfiguration;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/WebhookConfiguration.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/WebhookConfiguration.java
@@ -84,6 +84,10 @@ public class WebhookConfiguration {
         this.committersToIgnore = committersToIgnore;
     }
 
+    public String getCommittersToIgnore() {
+        return this.committersToIgnore;
+    }
+
     boolean updateHook(BitbucketWebHook hook, BitbucketSCMSource owner) {
         if (hook instanceof BitbucketRepositoryHook) {
             if (!hook.getEvents().containsAll(CLOUD_EVENTS)) {

--- a/src/main/resources/com/cloudbees/jenkins/plugins/bitbucket/Messages.properties
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/bitbucket/Messages.properties
@@ -36,6 +36,7 @@ SSHCheckoutTrait.useAgentKey=- use build agent''s key -
 WebhookRegistrationTrait.disableHook=Disable hook management
 WebhookRegistrationTrait.displayName=Override hook management
 WebhookRegistrationTrait.useItemHook=Use item credentials for hook management
+WebhookConfigurationTrait.displayName=Set ignored committers
 PullRequestSCMHead.Pronoun=Pull Request
 BranchSCMHead.Pronoun=Branch
 BitBucketTagSCMHead.Pronoun=Tag

--- a/src/main/resources/com/cloudbees/jenkins/plugins/bitbucket/WebhookConfigurationTrait/config.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/bitbucket/WebhookConfigurationTrait/config.jelly
@@ -1,0 +1,6 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+  <f:entry title="${%Ignore committers}" field="committersToIgnore">
+    <f:textbox/>
+  </f:entry>
+</j:jelly>

--- a/src/main/resources/com/cloudbees/jenkins/plugins/bitbucket/WebhookConfigurationTrait/help.html
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/bitbucket/WebhookConfigurationTrait/help.html
@@ -1,6 +1,6 @@
 <div>
     <p>
-        Sets the value for committersToIgnore in the Bitbucket Webhook.
+        Sets the value for committersToIgnore in the Bitbucket Webhook. Value should be a comma separated string.
     </p>
     <p>
         committerToIgnore is used to prevent triggering Jenkins builds when commits by certain users

--- a/src/main/resources/com/cloudbees/jenkins/plugins/bitbucket/WebhookConfigurationTrait/help.html
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/bitbucket/WebhookConfigurationTrait/help.html
@@ -1,0 +1,9 @@
+<div>
+    <p>
+        Sets the value for committersToIgnore in the Bitbucket Webhook.
+    </p>
+    <p>
+        committerToIgnore is used to prevent triggering Jenkins builds when commits by certain users
+        are made.
+    </p>
+</div>

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/WebhookConfigurationTraitTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/WebhookConfigurationTraitTest.java
@@ -1,0 +1,41 @@
+package com.cloudbees.jenkins.plugins.bitbucket;
+
+import jenkins.scm.api.SCMHeadObserver;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import static org.junit.Assert.assertEquals;
+
+public class WebhookConfigurationTraitTest {
+    @ClassRule
+    public static JenkinsRule j = new JenkinsRule();
+
+    /**
+     * Test the default empty value
+     * @throws Exception
+     */
+    @Test
+    public void given__webhookConfigurationEmpty__when__appliedToContext__then__webhookConfigurationEmpty()
+            throws Exception {
+        BitbucketSCMSourceContext ctx = new BitbucketSCMSourceContext(null, SCMHeadObserver.none());
+        assertEquals(ctx.webhookConfiguration().getCommittersToIgnore(), null);
+        WebhookConfigurationTrait instance = new WebhookConfigurationTrait("");
+        instance.decorateContext(ctx);
+        assertEquals(ctx.webhookConfiguration().getCommittersToIgnore(), "");
+    }
+
+    /**
+     * Test a set value
+     * @throws Exception
+     */
+    @Test
+    public void given__webhookRegistrationFromItem__when__appliedToContext__then__webhookRegistrationFromItem()
+            throws Exception {
+        BitbucketSCMSourceContext ctx = new BitbucketSCMSourceContext(null, SCMHeadObserver.none());
+        assertEquals(ctx.webhookConfiguration().getCommittersToIgnore(), null);
+        WebhookConfigurationTrait instance = new WebhookConfigurationTrait("jenkins");
+        instance.decorateContext(ctx);
+        assertEquals(ctx.webhookConfiguration().getCommittersToIgnore(), "jenkins");
+    }
+}

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/WebhookConfigurationTraitTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/WebhookConfigurationTraitTest.java
@@ -16,7 +16,7 @@ public class WebhookConfigurationTraitTest {
      * @throws Exception
      */
     @Test
-    public void given__webhookConfigurationEmpty__when__appliedToContext__then__webhookConfigurationEmpty()
+    public void ignoredCommittersDefault()
             throws Exception {
         BitbucketSCMSourceContext ctx = new BitbucketSCMSourceContext(null, SCMHeadObserver.none());
         assertEquals(ctx.webhookConfiguration().getCommittersToIgnore(), null);
@@ -30,7 +30,7 @@ public class WebhookConfigurationTraitTest {
      * @throws Exception
      */
     @Test
-    public void given__webhookRegistrationFromItem__when__appliedToContext__then__webhookRegistrationFromItem()
+    public void ignoredCommittersWithValue()
             throws Exception {
         BitbucketSCMSourceContext ctx = new BitbucketSCMSourceContext(null, SCMHeadObserver.none());
         assertEquals(ctx.webhookConfiguration().getCommittersToIgnore(), null);


### PR DESCRIPTION
- Adds a trait to allow setting of the committersToIgnore value
- Adds unit tests for setting of the value
- Adds a property accessor to the WebhookConfiguration for testing
- Adds resource definitions to allow setting in the UI

### Your checklist for this pull request

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!

- [x ] Please describe what you did

- [x ] Link to relevant GitHub issues or pull requests

- [x] Link to relevant [Jenkins JIRA issues](https://issues.jenkins-ci.org)

- [x ] Did you provide a test-case? That demonstrates feature works or fixes the issue.

### Description

Add a WebhookConfigurationTrait to allow setting of the committersToIgnore value of the WebhookConfiguration class. This makes it possible to set and persist the value of field for the Bitbucket Webhook. Without this exposure there is no way to set and maintain the setting on the Webhook as the current implementation does not set it, and always overwrites what is set on the server (since it's always different).

Addresses this Jira issue:
https://issues.jenkins-ci.org/browse/JENKINS-47867

Previous PR that added some of the required plumbing:
https://github.com/jenkinsci/bitbucket-branch-source-plugin/pull/77