### PR TITLE
Retry idempotent requests.

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/BitbucketCloudApiClient.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/BitbucketCloudApiClient.java
@@ -105,6 +105,7 @@ import org.apache.http.impl.client.BasicAuthCache;
 import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.client.StandardHttpRequestRetryHandler;
 import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
 import org.apache.http.message.BasicNameValuePair;
 import org.apache.http.util.EntityUtils;
@@ -189,6 +190,7 @@ public class BitbucketCloudApiClient implements BitbucketApi {
         HttpClientBuilder httpClientBuilder = HttpClientBuilder.create();
         httpClientBuilder.setConnectionManager(connectionManager);
         httpClientBuilder.setConnectionManagerShared(true);
+        httpClientBuilder.setRetryHandler(new StandardHttpRequestRetryHandler());
 
         if (authenticator != null) {
             authenticator.configureBuilder(httpClientBuilder);


### PR DESCRIPTION
### Your checklist for this pull request

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!

- [x] Please describe what you did

- [x] Link to relevant GitHub issues or pull requests

- [ ] Link to relevant [Jenkins JIRA issues](https://issues.jenkins-ci.org)

- [ ] Did you provide a test-case? That demonstrates feature works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled the information below
Describe your pull request below
-->

### Description

Fixes #213 by configuring the Apache HttpClient to retry idempotent http requests. When creating the HttpClient, the `StandardHttpRequestRetryHandler` from the Apache HttpClient is registered as retry handler meaning every idempotent request (e.g. GET, HEAD, ...) will be automatically retried 3 times.

We believe this makes the plugin more resilient to stale connections and/or intermittent network failures.
