### PR TITLE
5 second ConnectionKeepAliveStrategy

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/BitbucketCloudApiClient.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/BitbucketCloudApiClient.java
@@ -190,7 +190,7 @@ public class BitbucketCloudApiClient implements BitbucketApi {
         // Create Http client
         HttpClientBuilder httpClientBuilder = HttpClientBuilder.create();
 
-        httpClientBuilder.setKeepAliveStrategy((__, ___) -> {return MILLISECONDS.convert(5, SECONDS);});
+        httpClientBuilder.setKeepAliveStrategy((__, ___) -> MILLISECONDS.convert(5, SECONDS));
         httpClientBuilder.setConnectionManager(connectionManager);
         httpClientBuilder.setConnectionManagerShared(true);
 

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/BitbucketCloudApiClient.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/BitbucketCloudApiClient.java
@@ -110,7 +110,9 @@ import org.apache.http.message.BasicNameValuePair;
 import org.apache.http.util.EntityUtils;
 
 import static java.util.concurrent.TimeUnit.HOURS;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.SECONDS;
 
 public class BitbucketCloudApiClient implements BitbucketApi {
 
@@ -187,6 +189,8 @@ public class BitbucketCloudApiClient implements BitbucketApi {
 
         // Create Http client
         HttpClientBuilder httpClientBuilder = HttpClientBuilder.create();
+
+        httpClientBuilder.setKeepAliveStrategy((__, ___) -> {return MILLISECONDS.convert(5, SECONDS);});
         httpClientBuilder.setConnectionManager(connectionManager);
         httpClientBuilder.setConnectionManagerShared(true);
 


### PR DESCRIPTION
### Your checklist for this pull request

- [X] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!

- [X] Please describe what you did

- [X] Link to relevant GitHub issues or pull requests

- [ ] Link to relevant [Jenkins JIRA issues](https://issues.jenkins-ci.org)

- [ ] Did you provide a test-case? That demonstrates feature works or fixes the issue.

No. I don't see any good way to test this. Would need a simulation of the external systems involved... a NAT box that doesn't RST severed connections?

<!--
Put an `x` into the [ ] to show you have filled the information below
Describe your pull request below
-->

### Description

The default behaviour of `PoolingHttpClientConnectionManager` is to inspect the server-provided `Keep-Alive` header and use it as the basis for auto configuring the `ConnectionKeepAliveStrategy`, and in the absence of such a header assumes the connection can be kept alive indefinitely.
    
api.bitbucket.org does not produce a `Keep-Alive` header.

This is a simple patch to hardcode a more aggressive 5-second ConnectionKeepAliveStrategy.

Fixes #217