### PR TITLE
Keep bitbucket credentials with proxy

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/credentials/BitbucketUsernamePasswordAuthenticator.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/credentials/BitbucketUsernamePasswordAuthenticator.java
@@ -28,6 +28,8 @@ package com.cloudbees.jenkins.plugins.bitbucket.api.credentials;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketAuthenticator;
 import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
 import hudson.util.Secret;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import org.apache.http.HttpHost;
 import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.UsernamePasswordCredentials;
@@ -42,6 +44,8 @@ import org.apache.http.impl.client.BasicCredentialsProvider;
  * Authenticator that uses a username and password (probably the default)
  */
 public class BitbucketUsernamePasswordAuthenticator extends BitbucketAuthenticator {
+
+    private static final Logger LOGGER = Logger.getLogger(BitbucketUsernamePasswordAuthenticator.class.getName());
 
     private final UsernamePasswordCredentials httpCredentials;
 
@@ -64,8 +68,9 @@ public class BitbucketUsernamePasswordAuthenticator extends BitbucketAuthenticat
     @Override
     public void configureContext(HttpClientContext context, HttpHost host) {
         CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
-        credentialsProvider.setCredentials(AuthScope.ANY, httpCredentials);
+        credentialsProvider.setCredentials(new AuthScope(host), httpCredentials);
         AuthCache authCache = new BasicAuthCache();
+        LOGGER.log(Level.SEVERE,"Add host={0} to authCache.", host);
         authCache.put(host, new BasicScheme());
         context.setCredentialsProvider(credentialsProvider);
         context.setAuthCache(authCache);

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/credentials/BitbucketUsernamePasswordAuthenticator.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/credentials/BitbucketUsernamePasswordAuthenticator.java
@@ -70,7 +70,7 @@ public class BitbucketUsernamePasswordAuthenticator extends BitbucketAuthenticat
         CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
         credentialsProvider.setCredentials(new AuthScope(host), httpCredentials);
         AuthCache authCache = new BasicAuthCache();
-        LOGGER.log(Level.SEVERE,"Add host={0} to authCache.", host);
+        LOGGER.log(Level.FINE,"Add host={0} to authCache.", host);
         authCache.put(host, new BasicScheme());
         context.setCredentialsProvider(credentialsProvider);
         context.setAuthCache(authCache);

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/BitbucketCloudApiClient.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/BitbucketCloudApiClient.java
@@ -743,18 +743,29 @@ public class BitbucketCloudApiClient implements BitbucketApi {
         if (proxy.type() != Proxy.Type.DIRECT) {
             final InetSocketAddress proxyAddress = (InetSocketAddress) proxy.address();
             LOGGER.fine("Jenkins proxy: " + proxy.address());
-            builder.setProxy(new HttpHost(proxyAddress.getHostName(), proxyAddress.getPort()));
+            HttpHost proxyHttpHost = new HttpHost(proxyAddress.getHostName(), proxyAddress.getPort());
+            builder.setProxy(proxyHttpHost);
             String username = proxyConfig.getUserName();
             String password = proxyConfig.getPassword();
             if (username != null && !"".equals(username.trim())) {
                 LOGGER.fine("Using proxy authentication (user=" + username + ")");
-                CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
-                credentialsProvider.setCredentials(AuthScope.ANY, new UsernamePasswordCredentials(username, password));
-                AuthCache authCache = new BasicAuthCache();
-                authCache.put(HttpHost.create(proxyAddress.getHostName()), new BasicScheme());
-                context = HttpClientContext.create();
-                context.setCredentialsProvider(credentialsProvider);
-                context.setAuthCache(authCache);
+                if (context == null) {
+                    // may have been already set in com.cloudbees.jenkins.plugins.bitbucket.api.credentials.BitbucketUsernamePasswordAuthenticator.configureContext(HttpClientContext, HttpHost)
+                    context = HttpClientContext.create();
+                }
+                CredentialsProvider credentialsProvider = context.getCredentialsProvider();
+                if (credentialsProvider == null) {
+                    credentialsProvider = new BasicCredentialsProvider();
+                    // may have been already set in com.cloudbees.jenkins.plugins.bitbucket.api.credentials.BitbucketUsernamePasswordAuthenticator.configureContext(HttpClientContext, HttpHost)
+                    context.setCredentialsProvider(credentialsProvider);
+                }
+                credentialsProvider.setCredentials(new AuthScope(proxyHttpHost), new UsernamePasswordCredentials(username, password));
+                AuthCache authCache = context.getAuthCache();
+                if (authCache == null) {
+                    authCache = new BasicAuthCache();
+                    context.setAuthCache(authCache);
+                }
+                authCache.put(proxyHttpHost, new BasicScheme());
             }
         }
     }


### PR DESCRIPTION
Keep previously set values in context / AuthCache
and
limit the httpCredentials to bitbucket only.