### PR TITLE
migrate wiki content to github

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -6,7 +6,7 @@ image:https://img.shields.io/github/release/jenkinsci/bitbucket-branch-source-pl
 
 === User Guide
 
-https://docs.cloudbees.com/docs/admin-resources/latest/plugins/bitbucket[See Cloudbees excellent user guide]
+https://docs.cloudbees.com/docs/admin-resources/latest/plugins/bitbucket[See CloudBees excellent user guide]
 
 === Notes
 

--- a/README.adoc
+++ b/README.adoc
@@ -1,5 +1,13 @@
 == BitBucket Branch Source Plugin
 
+image:https://img.shields.io/jenkins/plugin/v/cloudbees-bitbucket-branch-source["Jenkins Plugin", link="https://plugins.jenkins.io/cloudbees-bitbucket-branch-source"]
+image:https://img.shields.io/jenkins/plugin/i/cloudbees-bitbucket-branch-source?color=blue["Jenkins Plugin Installs", link="https://plugins.jenkins.io/cloudbees-bitbucket-branch-source"]
+image:https://img.shields.io/github/release/jenkinsci/bitbucket-branch-source-plugin.svg?label=changelog["Changelog", link="https://github.com/jenkinsci/bitbucket-branch-source-plugin/releases/latest"]
+
+=== User Guide
+
+https://docs.cloudbees.com/docs/admin-resources/latest/plugins/bitbucket[See Cloudbees excellent user guide]
+
 === Notes
 
 * Unlike GitHub, in BitBucket, https://bitbucket.org/site/master/issues/4828/team-admins-dont-have-read-access-to-forks[team admins do not have access to forks].

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
   <packaging>hpi</packaging>
 
   <name>Bitbucket Branch Source Plugin</name>
-  <url>https://wiki.jenkins.io/display/JENKINS/Bitbucket+Branch+Source+Plugin</url>
+  <url>https://github.com/jenkinsci/bitbucket-branch-source-plugin</url>
   <description>Discover and build Bitbucket Cloud and Bitbucket Server pull requests and branches and send status
     notifications with the build result.
   </description>


### PR DESCRIPTION
I decided not to migrate the changelog 😓 
The rest of the content is outdated and Cloudbees maintain a decent user guide.
Only thing missing from the user guide is how to configure the plugin from JCasC 😄

<!--
To mark your pull request as work in progress please create it as a draft pull request
-->

### Your checklist for this pull request

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Did you provide a test-case? That demonstrates feature works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled the information below
Describe your pull request below
-->
