### PR TITLE
[JENKINS-45504] - Add @Symbol annotations to traits

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BranchDiscoveryTrait.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BranchDiscoveryTrait.java
@@ -41,6 +41,7 @@ import jenkins.scm.api.trait.SCMSourceRequest;
 import jenkins.scm.api.trait.SCMSourceTrait;
 import jenkins.scm.api.trait.SCMSourceTraitDescriptor;
 import jenkins.scm.impl.trait.Discovery;
+import org.jenkinsci.Symbol;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -149,6 +150,7 @@ public class BranchDiscoveryTrait extends SCMSourceTrait {
     /**
      * Our descriptor.
      */
+    @Symbol("bitbucketBranchDiscovery")
     @Extension
     @Discovery
     public static class DescriptorImpl extends SCMSourceTraitDescriptor {

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/ForkPullRequestDiscoveryTrait.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/ForkPullRequestDiscoveryTrait.java
@@ -44,6 +44,7 @@ import jenkins.scm.api.trait.SCMSourceTrait;
 import jenkins.scm.api.trait.SCMSourceTraitDescriptor;
 import jenkins.scm.impl.ChangeRequestSCMHeadCategory;
 import jenkins.scm.impl.trait.Discovery;
+import org.jenkinsci.Symbol;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -156,6 +157,7 @@ public class ForkPullRequestDiscoveryTrait extends SCMSourceTrait {
     /**
      * Our descriptor.
      */
+    @Symbol("bitbucketForkDiscovery")
     @Extension
     @Discovery
     public static class DescriptorImpl extends SCMSourceTraitDescriptor {
@@ -252,6 +254,7 @@ public class ForkPullRequestDiscoveryTrait extends SCMSourceTrait {
         /**
          * Our descriptor.
          */
+        @Symbol("bitbucketTrustNobody")
         @Extension
         public static class DescriptorImpl extends SCMHeadAuthorityDescriptor {
 
@@ -301,6 +304,7 @@ public class ForkPullRequestDiscoveryTrait extends SCMSourceTrait {
         /**
          * Our descriptor.
          */
+        @Symbol({"bitbucketTrustTeam", "bitbucketTrustProject"})
         @Extension
         public static class DescriptorImpl extends SCMHeadAuthorityDescriptor {
 
@@ -345,6 +349,7 @@ public class ForkPullRequestDiscoveryTrait extends SCMSourceTrait {
         /**
          * Our descriptor.
          */
+        @Symbol("bitbucketTrustEveryone")
         @Extension
         public static class DescriptorImpl extends SCMHeadAuthorityDescriptor {
 

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/OriginPullRequestDiscoveryTrait.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/OriginPullRequestDiscoveryTrait.java
@@ -42,6 +42,7 @@ import jenkins.scm.api.trait.SCMSourceTrait;
 import jenkins.scm.api.trait.SCMSourceTraitDescriptor;
 import jenkins.scm.impl.ChangeRequestSCMHeadCategory;
 import jenkins.scm.impl.trait.Discovery;
+import org.jenkinsci.Symbol;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -128,6 +129,7 @@ public class OriginPullRequestDiscoveryTrait extends SCMSourceTrait {
     /**
      * Our descriptor.
      */
+    @Symbol("bitbucketPullRequestDiscovery")
     @Extension
     @Discovery
     public static class DescriptorImpl extends SCMSourceTraitDescriptor {

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/PublicRepoPullRequestFilterTrait.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/PublicRepoPullRequestFilterTrait.java
@@ -31,6 +31,7 @@ import jenkins.scm.api.trait.SCMSourceContext;
 import jenkins.scm.api.trait.SCMSourceTrait;
 import jenkins.scm.api.trait.SCMSourceTraitDescriptor;
 import jenkins.scm.impl.trait.Discovery;
+import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 /**
@@ -57,6 +58,7 @@ public class PublicRepoPullRequestFilterTrait extends SCMSourceTrait {
     /**
      * Our descriptor.
      */
+    @Symbol("bitbucketPublicRepoPullRequestFilter")
     @Extension
     @Discovery
     public static class DescriptorImpl extends SCMSourceTraitDescriptor {

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/SSHCheckoutTrait.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/SSHCheckoutTrait.java
@@ -52,6 +52,7 @@ import jenkins.scm.api.trait.SCMSourceContext;
 import jenkins.scm.api.trait.SCMSourceTrait;
 import jenkins.scm.api.trait.SCMSourceTraitDescriptor;
 import org.apache.commons.lang.StringUtils;
+import org.jenkinsci.Symbol;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.AncestorInPath;
@@ -117,6 +118,7 @@ public class SSHCheckoutTrait extends SCMSourceTrait {
     /**
      * Our descriptor.
      */
+    @Symbol("bitbucketSshCheckout")
     @Extension
     public static class DescriptorImpl extends SCMSourceTraitDescriptor {
 

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/TagDiscoveryTrait.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/TagDiscoveryTrait.java
@@ -37,6 +37,7 @@ import jenkins.scm.api.trait.SCMSourceTrait;
 import jenkins.scm.api.trait.SCMSourceTraitDescriptor;
 import jenkins.scm.impl.TagSCMHeadCategory;
 import jenkins.scm.impl.trait.Discovery;
+import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 /**
@@ -78,6 +79,7 @@ public class TagDiscoveryTrait extends SCMSourceTrait {
     /**
      * Our descriptor.
      */
+    @Symbol("bitbucketTagDiscovery")
     @Extension
     @Discovery
     public static class DescriptorImpl extends SCMSourceTraitDescriptor {

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/WebhookConfigurationTrait.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/WebhookConfigurationTrait.java
@@ -30,6 +30,7 @@ import jenkins.scm.api.SCMSource;
 import jenkins.scm.api.trait.SCMSourceContext;
 import jenkins.scm.api.trait.SCMSourceTrait;
 import jenkins.scm.api.trait.SCMSourceTraitDescriptor;
+import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 /**
@@ -84,6 +85,7 @@ public class WebhookConfigurationTrait extends SCMSourceTrait {
     /**
      * Our constructor.
      */
+    @Symbol("bitbucketWebhookConfiguration")
     @Extension
     public static class DescriptorImpl extends SCMSourceTraitDescriptor {
 

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/WebhookRegistrationTrait.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/WebhookRegistrationTrait.java
@@ -31,6 +31,7 @@ import jenkins.scm.api.SCMSource;
 import jenkins.scm.api.trait.SCMSourceContext;
 import jenkins.scm.api.trait.SCMSourceTrait;
 import jenkins.scm.api.trait.SCMSourceTraitDescriptor;
+import org.jenkinsci.Symbol;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -89,6 +90,7 @@ public class WebhookRegistrationTrait extends SCMSourceTrait {
     /**
      * Our constructor.
      */
+    @Symbol("bitbucketWebhookRegistration")
     @Extension
     public static class DescriptorImpl extends SCMSourceTraitDescriptor {
 


### PR DESCRIPTION
Now all traits consistently have a `@Symbol` annotation.

This improves configuration with JobDSL. Otherwise there is a clash e.g. with the github-branch-source-plugin.

Also see https://github.com/jenkinsci/github-branch-source-plugin/pull/258.