### PR TITLE
feat: be more verbose in build status notification exception

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketBuildStatusNotifications.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketBuildStatusNotifications.java
@@ -109,7 +109,8 @@ public class BitbucketBuildStatusNotifications {
             listener.getLogger().println("Can not determine Jenkins root URL " +
                     "or Jenkins URL is not a valid URL regarding Bitbucket API. " +
                     "Commit status notifications are disabled until a root URL is " +
-                    "configured in Jenkins global configuration.");
+                    "configured in Jenkins global configuration. \n" +
+                    "IllegalStateException: " + e.getMessage());
             return;
         }
 


### PR DESCRIPTION
provide the reason why Jenkins cannot determine the Jenkins root URL

refs https://issues.jenkins-ci.org/browse/JENKINS-54297

<!-- Please describe your pull request here. -->
### Your checklist for this pull request

- [X] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Did you provide a test-case? That demonstrates feature works or fixes the issue.

