### PR TITLE
Added condition for 403 HTTP Status

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/BitbucketCloudApiClient.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/BitbucketCloudApiClient.java
@@ -422,6 +422,10 @@ public class BitbucketCloudApiClient implements BitbucketApi {
             return true;
         } else if (HttpStatus.SC_NOT_FOUND == status) {
             return false;
+        } else if (HttpStatus.SC_FORBIDDEN == status) {
+            // Needs to skip over the branch if there are permissions issues but let you know in the logs
+            LOGGER.log(Level.FINE, "You currently do not have permissions to pull from repo: {0} at branch {1}", new Object[]{repositoryName, branchOrHash.toString()});
+            return false;
         } else {
             throw new IOException("Communication error for url: " + path + " status code: " + status);
         }

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/BitbucketCloudApiClient.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/BitbucketCloudApiClient.java
@@ -424,7 +424,7 @@ public class BitbucketCloudApiClient implements BitbucketApi {
             return false;
         } else if (HttpStatus.SC_FORBIDDEN == status) {
             // Needs to skip over the branch if there are permissions issues but let you know in the logs
-            LOGGER.log(Level.FINE, "You currently do not have permissions to pull from repo: {0} at branch {1}", new Object[]{repositoryName, branchOrHash.toString()});
+            LOGGER.log(Level.FINE, "You currently do not have permissions to pull from repo: {0} at branch {1}", new Object[]{repositoryName, branchOrHash});
             return false;
         } else {
             throw new IOException("Communication error for url: " + path + " status code: " + status);


### PR DESCRIPTION
Added a condition for Issue 273 so that permisisons issues dont break your branch indexing completely

The goal is to fix https://github.com/jenkinsci/bitbucket-branch-source-plugin/issues/273#issue-553545339 where the branch indexing was broken when the user didnt have access to a specific branch. Also it helps if there is any situation where a auth failure happens with something like API limits

### Your checklist for this pull request

- [ ✅] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [  ✅] Ensure that the pull request title represents the desired changelog entry
- [ ✅ ] Please describe what you did
- [ ✅ ] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [ ❌ ] Did you provide a test-case? That demonstrates feature works or fixes the issue. - Currently there is no implementation for HTTP status checks in the test code which means a large wiremock implementation needs to be done (most likely) and that is going to require much more time investment. I would like to do it later though.