### PR TITLE
fix Job DSL by adding a DataboundSetter it can understand

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMNavigator.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMNavigator.java
@@ -213,8 +213,8 @@ public class BitbucketSCMNavigator extends SCMNavigator {
 
     @Override
     @NonNull
-    public List<SCMTrait<? extends SCMTrait<?>>> getTraits() {
-        return Collections.<SCMTrait<? extends SCMTrait<?>>>unmodifiableList(traits);
+    public List<SCMTrait<?>> getTraits() {
+        return Collections.<SCMTrait<?>>unmodifiableList(traits);
     }
 
     @DataBoundSetter
@@ -223,9 +223,10 @@ public class BitbucketSCMNavigator extends SCMNavigator {
     }
 
     @DataBoundSetter
-    public void setTraits(@CheckForNull List<SCMTrait<? extends SCMTrait<?>>> traits) {
+    public void setTraits(@CheckForNull List<SCMTrait<?>> traits) {
         // the reduced generics in the method signature are a workaround for JENKINS-26535
-        this.traits = new ArrayList<>(Util.fixNull(traits));
+        //noinspection unchecked,rawtypes
+        this.traits = new ArrayList<>((List)/*defensive*/Util.fixNull(traits));
     }
 
     public String getServerUrl() {
@@ -642,8 +643,9 @@ public class BitbucketSCMNavigator extends SCMNavigator {
         }
 
         @Override
-        public List<SCMTrait<? extends SCMTrait<?>>> getTraitsDefaults() {
-            return Arrays.<SCMTrait<? extends SCMTrait<?>>>asList(
+        @NonNull
+        public List<SCMTrait<?>> getTraitsDefaults() {
+            return Arrays.<SCMTrait<?>>asList(
                     new BranchDiscoveryTrait(true, false),
                     new OriginPullRequestDiscoveryTrait(EnumSet.of(ChangeRequestCheckoutStrategy.MERGE)),
                     new ForkPullRequestDiscoveryTrait(EnumSet.of(ChangeRequestCheckoutStrategy.MERGE),

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMNavigator.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMNavigator.java
@@ -223,7 +223,7 @@ public class BitbucketSCMNavigator extends SCMNavigator {
     }
 
     @DataBoundSetter
-    public void setTraits(@CheckForNull List<SCMTrait<?>> traits) {
+    public void setTraits(@CheckForNull List<SCMTrait<? extends SCMTrait<?>>> traits) {
         // the reduced generics in the method signature are a workaround for JENKINS-26535
         //noinspection unchecked,rawtypes
         this.traits = new ArrayList<>((List)/*defensive*/Util.fixNull(traits));

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMNavigator.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMNavigator.java
@@ -251,7 +251,6 @@ public class BitbucketSCMNavigator extends SCMNavigator {
     @Override
     public void setTraits(@CheckForNull List<SCMTrait<? extends SCMTrait<?>>> traits) {
         this.traits = traits != null ? new ArrayList<>(traits) : new ArrayList<SCMTrait<? extends SCMTrait<?>>>();
-
     }
 
     public String getServerUrl() {

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMNavigator.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMNavigator.java
@@ -222,12 +222,36 @@ public class BitbucketSCMNavigator extends SCMNavigator {
         this.credentialsId = Util.fixEmpty(credentialsId);
     }
 
+    /**
+     * Sets the behavioural traits that are applied to this navigator and any {@link BitbucketSCMSource} instances it
+     * discovers. The new traits will take affect on the next navigation through any of the
+     * {@link #visitSources(SCMSourceObserver)} overloads or {@link #visitSource(String, SCMSourceObserver)}.
+     *
+     * @param traits the new behavioural traits.
+     */
+    @SuppressWarnings({"unchecked", "rawtypes"})
     @DataBoundSetter
-    @Override
-    public void setTraits(@CheckForNull List<SCMTrait<?>> traits) {
+    public void setTraits(@CheckForNull SCMTrait[] traits) {
         // the reduced generics in the method signature are a workaround for JENKINS-26535
-        //noinspection unchecked,rawtypes
-        this.traits = new ArrayList<>((List)/*defensive*/Util.fixNull(traits));
+        this.traits = new ArrayList<>();
+        if (traits != null) {
+            for (SCMTrait trait : traits) {
+                this.traits.add(trait);
+            }
+        }
+    }
+
+    /**
+     * Sets the behavioural traits that are applied to this navigator and any {@link BitbucketSCMSource} instances it
+     * discovers. The new traits will take affect on the next navigation through any of the
+     * {@link #visitSources(SCMSourceObserver)} overloads or {@link #visitSource(String, SCMSourceObserver)}.
+     *
+     * @param traits the new behavioural traits.
+     */
+    @Override
+    public void setTraits(@CheckForNull List<SCMTrait<? extends SCMTrait<?>>> traits) {
+        this.traits = traits != null ? new ArrayList<>(traits) : new ArrayList<SCMTrait<? extends SCMTrait<?>>>();
+
     }
 
     public String getServerUrl() {

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMNavigator.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMNavigator.java
@@ -213,8 +213,8 @@ public class BitbucketSCMNavigator extends SCMNavigator {
 
     @Override
     @NonNull
-    public List<SCMTrait<?>> getTraits() {
-        return Collections.<SCMTrait<?>>unmodifiableList(traits);
+    public List<SCMTrait<? extends SCMTrait<?>>> getTraits() {
+        return Collections.unmodifiableList(traits);
     }
 
     @DataBoundSetter
@@ -669,8 +669,8 @@ public class BitbucketSCMNavigator extends SCMNavigator {
 
         @Override
         @NonNull
-        public List<SCMTrait<?>> getTraitsDefaults() {
-            return Arrays.<SCMTrait<?>>asList(
+        public List<SCMTrait<? extends SCMTrait<?>>> getTraitsDefaults() {
+            return Arrays.asList(
                     new BranchDiscoveryTrait(true, false),
                     new OriginPullRequestDiscoveryTrait(EnumSet.of(ChangeRequestCheckoutStrategy.MERGE)),
                     new ForkPullRequestDiscoveryTrait(EnumSet.of(ChangeRequestCheckoutStrategy.MERGE),

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMNavigator.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMNavigator.java
@@ -223,7 +223,8 @@ public class BitbucketSCMNavigator extends SCMNavigator {
     }
 
     @DataBoundSetter
-    public void setTraits(@CheckForNull List<SCMTrait<? extends SCMTrait<?>>> traits) {
+    @Override
+    public void setTraits(@CheckForNull List<SCMTrait<?>> traits) {
         // the reduced generics in the method signature are a workaround for JENKINS-26535
         //noinspection unchecked,rawtypes
         this.traits = new ArrayList<>((List)/*defensive*/Util.fixNull(traits));


### PR DESCRIPTION
Reverts the changes made to traits in 2.6.0 release
as it prevents JobDSL from working with traits

fixes #258

<!--
To mark your pull request as work in progress please create it as a draft pull request
-->

### Your checklist for this pull request

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Did you provide a test-case? That demonstrates feature works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled the information below
Describe your pull request below
-->