### PR TITLE
PRs without a valid destination branch no longer break SCM scanning.

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/BitbucketCloudApiClient.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/BitbucketCloudApiClient.java
@@ -300,6 +300,9 @@ public class BitbucketCloudApiClient implements BitbucketApi {
             pullRequests.addAll(page.getValues());
         } while (page.getNext() != null);
 
+        // PRs with missing destination branch are invalid and should be ignored.
+        pullRequests.removeIf(pr -> pr.getDestination().getBranch() == null);
+
         for (BitbucketPullRequestValue pullRequest : pullRequests) {
             setupClosureForPRBranch(pullRequest);
         }

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/pullrequest/BitbucketPullRequestValueDestination.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/pullrequest/BitbucketPullRequestValueDestination.java
@@ -43,14 +43,17 @@ public class BitbucketPullRequestValueDestination implements BitbucketPullReques
 
     @JsonCreator
     public BitbucketPullRequestValueDestination(@NonNull @JsonProperty("repository") BitbucketCloudRepository repository,
-                                                @NonNull @JsonProperty("branch") BitbucketCloudBranch branch,
+                                                @JsonProperty("branch") BitbucketCloudBranch branch,
                                                 @NonNull @JsonProperty("commit") BitbucketCloudCommit commit) {
         this.repository = repository;
         this.branch = branch;
         this.commit = commit;
 
-        // redound available the informations into impl objects
-        this.branch.setRawNode(commit.getHash());
+        // It is possible for a PR's original destination to no longer exist.
+        if(this.branch != null) {
+            // redound available the informations into impl objects
+            this.branch.setRawNode(commit.getHash());
+        }
     }
 
     @Override

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/BitbucketServerAPIClient.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/BitbucketServerAPIClient.java
@@ -328,6 +328,9 @@ public class BitbucketServerAPIClient implements BitbucketApi {
             throws IOException, InterruptedException {
         List<BitbucketServerPullRequest> pullRequests = getResources(template, BitbucketServerPullRequests.class);
 
+        // PRs with missing destination branch are invalid and should be ignored.
+        pullRequests.removeIf(pr -> pr.getDestination().getBranch() == null);
+
         // set commit closure to make commit informations available when need, in a similar way to when request branches
         for (BitbucketServerPullRequest pullRequest : pullRequests) {
             setupClosureForPRBranch(pullRequest);

--- a/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/client/payload/2.0-repositories-amuniz-test-repos-pullrequests_page_1_pagelen_50.json
+++ b/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/client/payload/2.0-repositories-amuniz-test-repos-pullrequests_page_1_pagelen_50.json
@@ -278,6 +278,144 @@
     },
     "merge_commit": null,
     "closed_by": null
+  },
+   {
+    "description": "PR with destination branch deleted",
+    "links": {
+      "decline": {
+        "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/pullrequests/3/decline"
+      },
+      "commits": {
+        "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/pullrequests/3/commits"
+      },
+      "self": {
+        "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/pullrequests/3"
+      },
+      "comments": {
+        "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/pullrequests/3/comments"
+      },
+      "merge": {
+        "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/pullrequests/3/merge"
+      },
+      "html": {
+        "href": "https://bitbucket.org/amuniz/test-repos/pull-requests/3"
+      },
+      "activity": {
+        "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/pullrequests/3/activity"
+      },
+      "diff": {
+        "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/pullrequests/3/diff"
+      },
+      "approve": {
+        "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/pullrequests/3/approve"
+      },
+      "statuses": {
+        "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/pullrequests/3/statuses"
+      }
+    },
+    "title": "Bugfix 123",
+    "close_source_branch": true,
+    "type": "pullrequest",
+    "id": 3,
+    "destination": {
+      "commit": {
+        "hash": "bf4f4ce8a3a8",
+        "type": "commit",
+        "links": {
+          "self": {
+            "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/commit/bf4f4ce8a3a8"
+          },
+          "html": {
+            "href": "https://bitbucket.org/amuniz/test-repos/commits/bf4f4ce8a3a8"
+          }
+        }
+      },
+      "repository": {
+        "links": {
+          "self": {
+            "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos"
+          },
+          "html": {
+            "href": "https://bitbucket.org/amuniz/test-repos"
+          },
+          "avatar": {
+            "href": "https://bytebucket.org/ravatar/%7B3deb8c29-778a-450c-8f69-3e50a18079df%7D?ts=default"
+          }
+        },
+        "type": "repository",
+        "name": "test-repos",
+        "full_name": "amuniz/test-repos",
+        "uuid": "{3deb8c29-778a-450c-8f69-3e50a18079df}"
+      },
+      "branch": null
+    },
+    "created_on": "2018-09-21T14:57:59.455870+00:00",
+    "summary": {
+      "raw": "PR with destination branch deleted",
+      "markup": "markdown",
+      "html": "<p>PR with destination branch deleted</p>",
+      "type": "rendered"
+    },
+    "source": {
+      "commit": {
+        "hash": "bf0e8b7962c4",
+        "type": "commit",
+        "links": {
+          "self": {
+            "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/commit/bf0e8b7962c4"
+          },
+          "html": {
+            "href": "https://bitbucket.org/amuniz/test-repos/commits/bf0e8b7962c4"
+          }
+        }
+      },
+      "repository": {
+        "links": {
+          "self": {
+            "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos"
+          },
+          "html": {
+            "href": "https://bitbucket.org/amuniz/test-repos"
+          },
+          "avatar": {
+            "href": "https://bytebucket.org/ravatar/%7B3deb8c29-778a-450c-8f69-3e50a18079df%7D?ts=default"
+          }
+        },
+        "type": "repository",
+        "name": "test-repos",
+        "full_name": "amuniz/test-repos",
+        "uuid": "{3deb8c29-778a-450c-8f69-3e50a18079df}"
+      },
+      "branch": {
+        "name": "bugfix/123"
+      }
+    },
+    "comment_count": 0,
+    "state": "OPEN",
+    "task_count": 0,
+    "reason": "",
+    "updated_on": "2018-09-21T14:57:59.488719+00:00",
+    "author": {
+      "username": "amuniz",
+      "display_name": "Nikolas Falco",
+      "account_id": "557058:ca1cd232-2017-4216-94be-99637899e18d",
+      "links": {
+        "self": {
+          "href": "https://api.bitbucket.org/2.0/users/amuniz"
+        },
+        "html": {
+          "href": "https://bitbucket.org/amuniz/"
+        },
+        "avatar": {
+          "href": "https://bitbucket.org/account/amuniz/avatar/"
+        }
+      },
+      "nickname": "amuniz",
+      "type": "user",
+      "uuid": "{644c7fc2-b15a-4445-9f89-35390694fac9}"
+    },
+    "merge_commit": null,
+    "closed_by": null
   }],
   "page": 1,
   "size": 2


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
This PR attempts to address issue #205. In that issue, Jackson cannot deserialize the pull requests JSON response because one or more PRs have a null value for the destination branch. The constructor for `BitbucketPullRequestValueDestination` would throw a NullPointerException assuming that branch was never null. The fix for deserialization is as simple as a null check in the `BitbucketPullRequestValueDestination` constructor.

Fixing deserialization introduces a new problem. Several areas of the code depend on the PR having a valid destination. Rather than adding null reference handling every time a piece of code needs the destination branch, I removed these invalid PRs from the result set before passing it off to the plugin. I don't believe this should cause any problems because these PRs were never loaded before. They would have thrown a NPE on deserialization.

<!--
To mark your pull request as work in progress please create it as a draft pull request
-->

### Your checklist for this pull request

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Did you provide a test-case? That demonstrates feature works or fixes the issue.