### PR TITLE
add support for server event `pr:from_ref_updated`.

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/HookEventType.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/HookEventType.java
@@ -112,6 +112,12 @@ public enum HookEventType {
     SERVER_PULL_REQUEST_REVIEWER_UPDATED("pr:reviewer:updated", NativeServerPullRequestHookProcessor.class),
 
     /**
+     * @see <a href="https://confluence.atlassian.com/bitbucketserver070/event-payload-996644369.html#Eventpayload-Sourcebranchupdated">Eventpayload-Sourcebranchupdated</a>
+     * @since Bitbucket Server 7.0
+     */
+    SERVER_PULL_REQUEST_FROM_REF_UPDATED("pr:from_ref_updated", NativeServerPullRequestHookProcessor.class),
+
+    /**
      * Sent when hitting the {@literal "Test connection"} button in Bitbucket Server. Apparently undocumented.
      */
     SERVER_PING("diagnostics:ping", PingHookProcessor.class);

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/NativeServerPullRequestHookProcessor.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/NativeServerPullRequestHookProcessor.java
@@ -82,6 +82,7 @@ public class NativeServerPullRequestHookProcessor extends HookProcessor {
                 break;
             case SERVER_PULL_REQUEST_MODIFIED:
             case SERVER_PULL_REQUEST_REVIEWER_UPDATED:
+            case SERVER_PULL_REQUEST_FROM_REF_UPDATED:
                 eventType = SCMEvent.Type.UPDATED;
                 break;
             default:

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/WebhookConfiguration.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/WebhookConfiguration.java
@@ -65,7 +65,8 @@ public class WebhookConfiguration {
             HookEventType.SERVER_PULL_REQUEST_DECLINED.getKey(),
             HookEventType.SERVER_PULL_REQUEST_DELETED.getKey(),
             HookEventType.SERVER_PULL_REQUEST_MODIFIED.getKey(),
-            HookEventType.SERVER_PULL_REQUEST_REVIEWER_UPDATED.getKey()
+            HookEventType.SERVER_PULL_REQUEST_REVIEWER_UPDATED.getKey(),
+            HookEventType.SERVER_PULL_REQUEST_FROM_REF_UPDATED.getKey()
     ));
 
     /**


### PR DESCRIPTION
Add support for a new event type introduced by Bitbucket Server 7 `pr:from_ref_updated`.
Behaviour should be the same as any update to pull requests as created in https://github.com/jenkinsci/bitbucket-branch-source-plugin/pull/291

fixes #308 by adding support for incoming event type `pr:from_ref_updated` and processing it the same as `pr:modified`.

### Your checklist for this pull request

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Did you provide a test-case? That demonstrates feature works or fixes the issue.
