### PR TITLE
[JENKINS-57775][JENKINS-62780] Handle PRs from/to non existing src/dest

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/BitbucketCloudApiClient.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/BitbucketCloudApiClient.java
@@ -309,6 +309,7 @@ public class BitbucketCloudApiClient implements BitbucketApi {
         // PRs with missing destination branch are invalid and should be ignored.
         pullRequests.removeIf(pr -> pr.getSource().getRepository() == null
                 || pr.getSource().getCommit() == null
+                || pr.getDestination().getBranch() == null
                 || pr.getDestination().getCommit() == null);
 
         for (BitbucketPullRequestValue pullRequest : pullRequests) {

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/BitbucketCloudApiClient.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/BitbucketCloudApiClient.java
@@ -307,7 +307,9 @@ public class BitbucketCloudApiClient implements BitbucketApi {
         } while (page.getNext() != null);
 
         // PRs with missing destination branch are invalid and should be ignored.
-        pullRequests.removeIf(pr -> pr.getDestination().getBranch() == null);
+        pullRequests.removeIf(pr -> pr.getSource().getRepository() == null
+                || pr.getSource().getCommit() == null
+                || pr.getDestination().getCommit() == null);
 
         for (BitbucketPullRequestValue pullRequest : pullRequests) {
             setupClosureForPRBranch(pullRequest);

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/BitbucketCloudApiClient.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/BitbucketCloudApiClient.java
@@ -339,9 +339,13 @@ public class BitbucketCloudApiClient implements BitbucketApi {
 
     private void setupClosureForPRBranch(BitbucketPullRequestValue pullRequest) {
         BitbucketCloudBranch branch = pullRequest.getSource().getBranch();
-        branch.setCommitClosure(new CommitClosure(branch.getRawNode()));
+        if (branch != null) {
+            branch.setCommitClosure(new CommitClosure(branch.getRawNode()));
+        }
         branch = pullRequest.getDestination().getBranch();
-        branch.setCommitClosure(new CommitClosure(branch.getRawNode()));
+        if (branch != null) {
+            branch.setCommitClosure(new CommitClosure(branch.getRawNode()));
+        }
     }
 
     @Deprecated

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/events/BitbucketCloudPullRequestEvent.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/events/BitbucketCloudPullRequestEvent.java
@@ -23,10 +23,14 @@
  */
 package com.cloudbees.jenkins.plugins.bitbucket.client.events;
 
+import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketCommit;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketPullRequest;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketPullRequestEvent;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketRepository;
+import com.cloudbees.jenkins.plugins.bitbucket.client.branch.BitbucketCloudBranch;
 import com.cloudbees.jenkins.plugins.bitbucket.client.pullrequest.BitbucketPullRequestValue;
+import com.cloudbees.jenkins.plugins.bitbucket.client.pullrequest.BitbucketPullRequestValueDestination;
+import com.cloudbees.jenkins.plugins.bitbucket.client.pullrequest.BitbucketPullRequestValueRepository;
 import com.cloudbees.jenkins.plugins.bitbucket.client.repository.BitbucketCloudRepository;
 import com.cloudbees.jenkins.plugins.bitbucket.client.repository.BitbucketCloudRepositoryOwner;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -64,58 +68,61 @@ public class BitbucketCloudPullRequestEvent implements BitbucketPullRequestEvent
 
     private void reconstructMissingData() {
         if (this.repository != null && this.pullRequest != null) {
-            if (this.pullRequest.getSource() != null
-                    && this.pullRequest.getSource().getRepository() != null) {
-                if (this.pullRequest.getSource().getRepository().getScm() == null) {
-                    this.pullRequest.getSource().getRepository().setScm(repository.getScm());
-                }
-                if (this.pullRequest.getSource().getRepository().getOwner() == null) {
-                    if (this.pullRequest.getSource().getRepository().getOwnerName().equals(this.pullRequest.getAuthorLogin())) {
-                        BitbucketCloudRepositoryOwner owner = new BitbucketCloudRepositoryOwner();
-                        owner.setUsername(this.pullRequest.getAuthorLogin());
-                        owner.setDisplayName(this.pullRequest.getAuthorDisplayName());
-                        if (repository.isPrivate()) {
-                            this.pullRequest.getSource().getRepository().setPrivate(repository.isPrivate());
+            BitbucketPullRequestValueRepository source = this.pullRequest.getSource();
+            if (source != null) {
+                BitbucketCloudRepository sourceRepository = source.getRepository();
+                if(sourceRepository != null) {
+                    if (sourceRepository.getScm() == null) {
+                        sourceRepository.setScm(repository.getScm());
+                    }
+                    if (sourceRepository.getOwner() == null) {
+                        if (sourceRepository.getOwnerName().equals(this.pullRequest.getAuthorLogin())) {
+                            BitbucketCloudRepositoryOwner owner = new BitbucketCloudRepositoryOwner();
+                            owner.setUsername(this.pullRequest.getAuthorLogin());
+                            owner.setDisplayName(this.pullRequest.getAuthorDisplayName());
+                            if (this.repository.isPrivate()) {
+                                sourceRepository.setPrivate(this.repository.isPrivate());
+                            }
+                            sourceRepository.setOwner(owner);
+                        } else if (sourceRepository.getOwnerName().equals(this.repository.getOwnerName())) {
+                            sourceRepository.setOwner(this.repository.getOwner());
+                            sourceRepository.setPrivate(this.repository.isPrivate());
                         }
-                        this.pullRequest.getSource().getRepository().setOwner(owner);
-                    } else if (this.pullRequest.getSource().getRepository().getOwnerName().equals(repository.getOwnerName())) {
-                        this.pullRequest.getSource().getRepository().setOwner(repository.getOwner());
-                        this.pullRequest.getSource().getRepository().setPrivate(repository.isPrivate());
                     }
                 }
             }
-            if (this.pullRequest.getSource() != null
-                    && this.pullRequest.getSource().getCommit() != null
-                    && this.pullRequest.getSource().getBranch() != null
-                    && this.pullRequest.getSource().getBranch().getRawNode() == null) {
-                this.pullRequest.getSource().getBranch()
-                        .setRawNode(this.pullRequest.getSource().getCommit().getHash());
-            }
-            if (this.pullRequest.getSource() != null
-                    && this.pullRequest.getSource().getCommit() != null
-                    && this.pullRequest.getSource().getBranch() != null
-                    && this.pullRequest.getSource().getBranch().getDateMillis() == 0) {
-                this.pullRequest.getSource().getBranch()
-                        .setDateMillis(toDate(this.pullRequest.getSource().getCommit().getDate()));
-            }
-            if (this.pullRequest.getDestination() != null
-                    && this.pullRequest.getDestination().getRepository() != null) {
-                if (this.pullRequest.getDestination().getRepository().getScm() == null) {
-                    this.pullRequest.getDestination().getRepository().setScm(repository.getScm());
+            if (source != null) {
+                BitbucketCloudBranch sourceBranch = source.getBranch();
+                BitbucketCommit sourceCommit = source.getCommit();
+                if (sourceCommit != null
+                        && sourceBranch != null) {
+                    if (sourceBranch.getRawNode() == null) {
+                        sourceBranch.setRawNode(source.getCommit().getHash());
+                    }
+                    if (sourceBranch.getDateMillis() == 0) {
+                        sourceBranch.setDateMillis(toDate(sourceCommit.getDate()));
+                    }
                 }
-                if (this.pullRequest.getDestination().getRepository().getOwner() == null
-                        && this.pullRequest.getDestination().getRepository().getOwnerName()
+            }
+            BitbucketPullRequestValueDestination destination = this.pullRequest.getDestination();
+            if (destination != null
+                    && destination.getRepository() != null) {
+                if (destination.getRepository().getScm() == null) {
+                    destination.getRepository().setScm(repository.getScm());
+                }
+                if (destination.getRepository().getOwner() == null
+                        && destination.getRepository().getOwnerName()
                         .equals(repository.getOwnerName())) {
-                    this.pullRequest.getDestination().getRepository().setOwner(repository.getOwner());
-                    this.pullRequest.getDestination().getRepository().setPrivate(repository.isPrivate());
+                    destination.getRepository().setOwner(repository.getOwner());
+                    destination.getRepository().setPrivate(repository.isPrivate());
                 }
             }
-            if (this.pullRequest.getDestination() != null
-                    && this.pullRequest.getDestination().getCommit() != null
-                    && this.pullRequest.getDestination().getBranch() != null
-                    && this.pullRequest.getDestination().getBranch().getRawNode() == null) {
-                this.pullRequest.getDestination().getBranch()
-                        .setRawNode(this.pullRequest.getDestination().getCommit().getHash());
+            if (destination != null
+                    && destination.getCommit() != null
+                    && destination.getBranch() != null
+                    && destination.getBranch().getRawNode() == null) {
+                destination.getBranch()
+                        .setRawNode(destination.getCommit().getHash());
             }
         }
     }

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/pullrequest/BitbucketPullRequestValueDestination.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/pullrequest/BitbucketPullRequestValueDestination.java
@@ -45,7 +45,7 @@ public class BitbucketPullRequestValueDestination implements BitbucketPullReques
     @JsonCreator
     public BitbucketPullRequestValueDestination(@NonNull @JsonProperty("repository") BitbucketCloudRepository repository,
                                                 @JsonProperty("branch") BitbucketCloudBranch branch,
-                                                @JsonProperty("commit") BitbucketCloudCommit commit) {
+                                                @CheckForNull @JsonProperty("commit") BitbucketCloudCommit commit) {
         this.repository = repository;
         this.branch = branch;
         this.commit = commit;

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/pullrequest/BitbucketPullRequestValueDestination.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/pullrequest/BitbucketPullRequestValueDestination.java
@@ -33,6 +33,7 @@ import com.cloudbees.jenkins.plugins.bitbucket.client.repository.BitbucketCloudR
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.util.StdDateFormat;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Date;
 
@@ -44,14 +45,14 @@ public class BitbucketPullRequestValueDestination implements BitbucketPullReques
     @JsonCreator
     public BitbucketPullRequestValueDestination(@NonNull @JsonProperty("repository") BitbucketCloudRepository repository,
                                                 @JsonProperty("branch") BitbucketCloudBranch branch,
-                                                @NonNull @JsonProperty("commit") BitbucketCloudCommit commit) {
+                                                @JsonProperty("commit") BitbucketCloudCommit commit) {
         this.repository = repository;
         this.branch = branch;
         this.commit = commit;
 
         // It is possible for a PR's original destination to no longer exist.
-        if(this.branch != null) {
-            // redound available the informations into impl objects
+        if(this.branch != null && this.commit != null) {
+            // redound available the information into impl objects
             this.branch.setRawNode(commit.getHash());
         }
     }
@@ -66,6 +67,7 @@ public class BitbucketPullRequestValueDestination implements BitbucketPullReques
     }
 
     @Override
+    @CheckForNull
     public BitbucketCloudBranch getBranch() {
         return branch;
     }
@@ -75,6 +77,7 @@ public class BitbucketPullRequestValueDestination implements BitbucketPullReques
     }
 
     @Override
+    @CheckForNull
     public BitbucketCommit getCommit() {
         if (branch != null && commit != null) {
             // initialise commit value using branch closure if not already valued

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/pullrequest/BitbucketPullRequestValueDestination.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/pullrequest/BitbucketPullRequestValueDestination.java
@@ -52,7 +52,7 @@ public class BitbucketPullRequestValueDestination implements BitbucketPullReques
 
         // It is possible for a PR's original destination to no longer exist.
         if(this.branch != null && this.commit != null) {
-            // redound available the information into impl objects
+            // Make the commit information available into impl objects
             this.branch.setRawNode(commit.getHash());
         }
     }

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/pullrequest/BitbucketPullRequestValueRepository.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/pullrequest/BitbucketPullRequestValueRepository.java
@@ -49,7 +49,7 @@ public class BitbucketPullRequestValueRepository implements BitbucketPullRequest
 
         // It is possible for a PR's original source to no longer exist.
         if(branch != null && commit != null) {
-            // redound available the information into impl objects
+            // Make the commit information available into impl objects
             this.branch.setRawNode(commit.getHash());
         }
     }

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/pullrequest/BitbucketPullRequestValueRepository.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/pullrequest/BitbucketPullRequestValueRepository.java
@@ -31,7 +31,7 @@ import com.cloudbees.jenkins.plugins.bitbucket.client.repository.BitbucketCloudR
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.util.StdDateFormat;
-import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import java.util.Date;
 
 public class BitbucketPullRequestValueRepository implements BitbucketPullRequestSource {
@@ -40,18 +40,22 @@ public class BitbucketPullRequestValueRepository implements BitbucketPullRequest
     private BitbucketCloudCommit commit;
 
     @JsonCreator
-    public BitbucketPullRequestValueRepository(@NonNull @JsonProperty("repository") BitbucketCloudRepository repository,
-                                               @NonNull @JsonProperty("branch") BitbucketCloudBranch branch,
-                                               @NonNull @JsonProperty("commit") BitbucketCloudCommit commit) {
+    public BitbucketPullRequestValueRepository(@JsonProperty("repository") BitbucketCloudRepository repository,
+                                               @JsonProperty("branch") BitbucketCloudBranch branch,
+                                               @JsonProperty("commit") BitbucketCloudCommit commit) {
         this.repository = repository;
         this.branch = branch;
         this.commit = commit;
 
-        // redound available the informations into impl objects
-        this.branch.setRawNode(commit.getHash());
+        // It is possible for a PR's original source to no longer exist.
+        if(branch != null && commit != null) {
+            // redound available the information into impl objects
+            this.branch.setRawNode(commit.getHash());
+        }
     }
 
     @Override
+    @CheckForNull
     public BitbucketCloudRepository getRepository() {
         return repository;
     }
@@ -61,6 +65,7 @@ public class BitbucketPullRequestValueRepository implements BitbucketPullRequest
     }
 
     @Override
+    @CheckForNull
     public BitbucketCloudBranch getBranch() {
         return branch;
     }
@@ -70,6 +75,7 @@ public class BitbucketPullRequestValueRepository implements BitbucketPullRequest
     }
 
     @Override
+    @CheckForNull
     public BitbucketCommit getCommit() {
         if (branch != null && commit != null) {
             // initialise commit value using branch closure if not already valued

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/BitbucketServerAPIClient.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/BitbucketServerAPIClient.java
@@ -330,8 +330,8 @@ public class BitbucketServerAPIClient implements BitbucketApi {
 
         // PRs with missing destination branch are invalid and should be ignored.
         pullRequests.removeIf(pr -> pr.getSource().getRepository() == null
-                || pr.getSource().getCommit() == null
-                || pr.getDestination().getCommit() == null);
+                || pr.getSource().getBranch() == null
+                || pr.getDestination().getBranch() == null);
 
         // set commit closure to make commit informations available when need, in a similar way to when request branches
         for (BitbucketServerPullRequest pullRequest : pullRequests) {

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/BitbucketServerAPIClient.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/BitbucketServerAPIClient.java
@@ -329,7 +329,9 @@ public class BitbucketServerAPIClient implements BitbucketApi {
         List<BitbucketServerPullRequest> pullRequests = getResources(template, BitbucketServerPullRequests.class);
 
         // PRs with missing destination branch are invalid and should be ignored.
-        pullRequests.removeIf(pr -> pr.getDestination().getBranch() == null);
+        pullRequests.removeIf(pr -> pr.getSource().getRepository() == null
+                || pr.getSource().getCommit() == null
+                || pr.getDestination().getCommit() == null);
 
         // set commit closure to make commit informations available when need, in a similar way to when request branches
         for (BitbucketServerPullRequest pullRequest : pullRequests) {

--- a/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/client/payload/2.0-repositories-amuniz-test-repos-pullrequests_page_1_pagelen_50.json
+++ b/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/client/payload/2.0-repositories-amuniz-test-repos-pullrequests_page_1_pagelen_50.json
@@ -416,7 +416,248 @@
     },
     "merge_commit": null,
     "closed_by": null
-  }],
+  }, {
+      "description": "PR from deleted forked repo",
+      "links": {
+        "decline": {
+          "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/pullrequests/2/decline"
+        },
+        "commits": {
+          "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/pullrequests/2/commits"
+        },
+        "self": {
+          "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/pullrequests/2"
+        },
+        "comments": {
+          "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/pullrequests/2/comments"
+        },
+        "merge": {
+          "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/pullrequests/2/merge"
+        },
+        "html": {
+          "href": "https://bitbucket.org/amuniz/test-repos/pull-requests/3"
+        },
+        "activity": {
+          "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/pullrequests/2/activity"
+        },
+        "diff": {
+          "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/pullrequests/2/diff"
+        },
+        "approve": {
+          "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/pullrequests/2/approve"
+        },
+        "statuses": {
+          "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/pullrequests/2/statuses"
+        }
+      },
+      "title": "JENKINS-62780",
+      "close_source_branch": true,
+      "type": "pullrequest",
+      "id": 4,
+      "destination": {
+        "commit": {
+          "hash": "bf4f4ce8a3a8",
+          "type": "commit",
+          "links": {
+            "self": {
+              "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/commit/bf4f4ce8a3a8"
+            },
+            "html": {
+              "href": "https://bitbucket.org/amuniz/test-repos/commits/bf4f4ce8a3a8"
+            }
+          }
+        },
+        "repository": {
+          "links": {
+            "self": {
+              "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos"
+            },
+            "html": {
+              "href": "https://bitbucket.org/amuniz/test-repos"
+            },
+            "avatar": {
+              "href": "https://bytebucket.org/ravatar/%7B3deb8c29-778a-450c-8f69-3e50a18079df%7D?ts=default"
+            }
+          },
+          "type": "repository",
+          "name": "test-repos",
+          "full_name": "amuniz/test-repos",
+          "uuid": "{3deb8c29-778a-450c-8f69-3e50a18079df}"
+        },
+        "branch": {
+          "name": "master"
+        }
+      },
+      "created_on": "2018-11-08T13:45:13.837779+00:00",
+      "summary": {
+        "raw": "test from forked repo",
+        "markup": "markdown",
+        "html": "<p>test from forked repo</p>",
+        "type": "rendered"
+      },
+      "source": {
+        "branch": {
+          "name": "feature/BB-2"
+        },
+        "commit": null,
+        "repository": null
+      },
+      "comment_count": 0,
+      "state": "OPEN",
+      "task_count": 0,
+      "reason": "",
+      "updated_on": "2018-11-08T13:45:13.958677+00:00",
+      "author": {
+        "username": "amuniz",
+        "display_name": "Nikolas Falco",
+        "account_id": "557058:ca1cd232-2017-4216-94be-99637899e18d",
+        "links": {
+          "self": {
+            "href": "https://api.bitbucket.org/2.0/users/amuniz"
+          },
+          "html": {
+            "href": "https://bitbucket.org/amuniz/"
+          },
+          "avatar": {
+            "href": "https://bitbucket.org/account/amuniz/avatar/"
+          }
+        },
+        "nickname": "amuniz",
+        "type": "user",
+        "uuid": "{644c7fc2-b15a-4445-9f89-35390694fac9}"
+      },
+      "merge_commit": null,
+      "closed_by": null
+    },
+    {
+      "description": "PR from deleted source branch",
+      "links": {
+        "decline": {
+          "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/pullrequests/3/decline"
+        },
+        "commits": {
+          "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/pullrequests/3/commits"
+        },
+        "self": {
+          "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/pullrequests/3"
+        },
+        "comments": {
+          "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/pullrequests/3/comments"
+        },
+        "merge": {
+          "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/pullrequests/3/merge"
+        },
+        "html": {
+          "href": "https://bitbucket.org/amuniz/test-repos/pull-requests/3"
+        },
+        "activity": {
+          "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/pullrequests/3/activity"
+        },
+        "diff": {
+          "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/pullrequests/3/diff"
+        },
+        "approve": {
+          "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/pullrequests/3/approve"
+        },
+        "statuses": {
+          "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/pullrequests/3/statuses"
+        }
+      },
+      "title": "JENKINS-57775",
+      "close_source_branch": true,
+      "type": "pullrequest",
+      "id": 5,
+      "destination": {
+        "commit": null,
+        "repository": {
+          "links": {
+            "self": {
+              "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos"
+            },
+            "html": {
+              "href": "https://bitbucket.org/amuniz/test-repos"
+            },
+            "avatar": {
+              "href": "https://bytebucket.org/ravatar/%7B3deb8c29-778a-450c-8f69-3e50a18079df%7D?ts=default"
+            }
+          },
+          "type": "repository",
+          "name": "test-repos",
+          "full_name": "amuniz/test-repos",
+          "uuid": "{3deb8c29-778a-450c-8f69-3e50a18079df}"
+        },
+        "branch": {
+          "name": "master"
+        }
+      },
+      "created_on": "2018-09-21T14:57:59.455870+00:00",
+      "summary": {
+        "raw": "PR with destination branch deleted",
+        "markup": "markdown",
+        "html": "<p>PR with destination branch deleted</p>",
+        "type": "rendered"
+      },
+      "source": {
+        "commit": {
+          "hash": "bf0e8b7962c4",
+          "type": "commit",
+          "links": {
+            "self": {
+              "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/commit/bf0e8b7962c4"
+            },
+            "html": {
+              "href": "https://bitbucket.org/amuniz/test-repos/commits/bf0e8b7962c4"
+            }
+          }
+        },
+        "repository": {
+          "links": {
+            "self": {
+              "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos"
+            },
+            "html": {
+              "href": "https://bitbucket.org/amuniz/test-repos"
+            },
+            "avatar": {
+              "href": "https://bytebucket.org/ravatar/%7B3deb8c29-778a-450c-8f69-3e50a18079df%7D?ts=default"
+            }
+          },
+          "type": "repository",
+          "name": "test-repos",
+          "full_name": "amuniz/test-repos",
+          "uuid": "{3deb8c29-778a-450c-8f69-3e50a18079df}"
+        },
+        "branch": {
+          "name": "bugfix/123"
+        }
+      },
+      "comment_count": 0,
+      "state": "OPEN",
+      "task_count": 0,
+      "reason": "",
+      "updated_on": "2018-09-21T14:57:59.488719+00:00",
+      "author": {
+        "username": "amuniz",
+        "display_name": "Nikolas Falco",
+        "account_id": "557058:ca1cd232-2017-4216-94be-99637899e18d",
+        "links": {
+          "self": {
+            "href": "https://api.bitbucket.org/2.0/users/amuniz"
+          },
+          "html": {
+            "href": "https://bitbucket.org/amuniz/"
+          },
+          "avatar": {
+            "href": "https://bitbucket.org/account/amuniz/avatar/"
+          }
+        },
+        "nickname": "amuniz",
+        "type": "user",
+        "uuid": "{644c7fc2-b15a-4445-9f89-35390694fac9}"
+      },
+      "merge_commit": null,
+      "closed_by": null
+    }],
   "page": 1,
   "size": 2
 }


### PR DESCRIPTION
Fix NPEs caused by deleted source and destination branch or repository of PRs.

* [JENKINS-62780](https://issues.jenkins-ci.org/browse/JENKINS-62780)
* [JENKINS-57775](https://issues.jenkins-ci.org/browse/JENKINS-57775)
* https://github.com/jenkinsci/bitbucket-branch-source-plugin/pull/283

Tested the different scenario against Bitbucket Cloud and confirmed that:

* `source.repository` can be `null` (deleted source repository)
* `source.commit` can be `null` (deleted source repository)
* `destination.commit` can be `null` (deleted destination branch)

I haven't been able to reproduce a nullable `source.branch` or `destination.branch`.

When testing against Bitbucket Server (7.2.1), I could not reproduce such scenario:

* PR opened from deleted source branch or forked are automatically declined.
* Bitbucket Server does not let me delete a destination branch if there is an open PR against it: "You cannot delete this branch since it has at least one open pull request associated with it"

### Your checklist for this pull request

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Did you provide a test-case? That demonstrates feature works or fixes the issue.