### PR TITLE
Fix CHANGE_AUTHOR and CHANGE_AUTHOR_DISPLAY_NAME

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource.java
@@ -641,8 +641,7 @@ public class BitbucketSCMSource extends SCMSource {
             getPullRequestTitleCache()
                     .put(pull.getId(), StringUtils.defaultString(pull.getTitle()));
             getPullRequestContributorCache().put(pull.getId(),
-                    // TODO get more details on the author
-                    new ContributorMetadataAction(pull.getAuthorLogin(), null, pull.getAuthorEmail()));
+                    new ContributorMetadataAction(pull.getAuthorIdentifier(), pull.getAuthorLogin(), pull.getAuthorEmail()));
             try {
                 // We store resolved hashes here so to avoid resolving the commits multiple times
                 for (final ChangeRequestCheckoutStrategy strategy : strategies.get(fork)) {

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/BitbucketPullRequest.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/BitbucketPullRequest.java
@@ -64,7 +64,6 @@ public interface BitbucketPullRequest {
 
     /**
      * Username or account identifier of the author.
-     * @return
      */
     String getAuthorIdentifier();
 

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/BitbucketPullRequest.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/BitbucketPullRequest.java
@@ -52,10 +52,20 @@ public interface BitbucketPullRequest {
 
     String getLink();
 
+    /**
+     * Despite the name, this is a <em>display name</em> or <em>nickname</em> for the author, not a stable <em>username</em> for login.
+     */
     String getAuthorLogin();
 
+    /**
+     * Not set in Cloud.
+     */
     String getAuthorEmail();
 
+    /**
+     * Username or account identifier of the author.
+     * @return
+     */
     String getAuthorIdentifier();
 
     List<BitbucketReviewer> getReviewers();

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/events/BitbucketCloudPullRequestEvent.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/events/BitbucketCloudPullRequestEvent.java
@@ -70,15 +70,15 @@ public class BitbucketCloudPullRequestEvent implements BitbucketPullRequestEvent
                     this.pullRequest.getSource().getRepository().setScm(repository.getScm());
                 }
                 if (this.pullRequest.getSource().getRepository().getOwner() == null) {
-                    if (this.pullRequest.getSource().getRepository().getOwnerName().equals(this.pullRequest.getAuthorLogin())) {
+                    if (!this.pullRequest.getSource().getRepository().getOwnerName().equals(repository.getOwnerName())) { // i.e., a fork
                         BitbucketCloudRepositoryOwner owner = new BitbucketCloudRepositoryOwner();
-                        owner.setUsername(this.pullRequest.getAuthorLogin());
+                        owner.setUsername(this.pullRequest.getSource().getRepository().getOwnerName());
                         owner.setDisplayName(this.pullRequest.getAuthorLogin());
                         if (repository.isPrivate()) {
                             this.pullRequest.getSource().getRepository().setPrivate(repository.isPrivate());
                         }
                         this.pullRequest.getSource().getRepository().setOwner(owner);
-                    } else if (this.pullRequest.getSource().getRepository().getOwnerName().equals(repository.getOwnerName())) {
+                    } else { // origin branch
                         this.pullRequest.getSource().getRepository().setOwner(repository.getOwner());
                         this.pullRequest.getSource().getRepository().setPrivate(repository.isPrivate());
                     }

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/events/BitbucketCloudPullRequestEvent.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/events/BitbucketCloudPullRequestEvent.java
@@ -73,7 +73,7 @@ public class BitbucketCloudPullRequestEvent implements BitbucketPullRequestEvent
                     if (this.pullRequest.getSource().getRepository().getOwnerName().equals(this.pullRequest.getAuthorLogin())) {
                         BitbucketCloudRepositoryOwner owner = new BitbucketCloudRepositoryOwner();
                         owner.setUsername(this.pullRequest.getAuthorLogin());
-                        owner.setDisplayName(this.pullRequest.getAuthorDisplayName());
+                        owner.setDisplayName(this.pullRequest.getAuthorLogin());
                         if (repository.isPrivate()) {
                             this.pullRequest.getSource().getRepository().setPrivate(repository.isPrivate());
                         }

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/pullrequest/BitbucketPullRequestValue.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/pullrequest/BitbucketPullRequestValue.java
@@ -81,7 +81,7 @@ public class BitbucketPullRequestValue implements BitbucketPullRequest {
 
     @Override
     public String getAuthorLogin() {
-        return author.username;
+        return author.displayName;
     }
 
     @Override
@@ -105,10 +105,6 @@ public class BitbucketPullRequestValue implements BitbucketPullRequest {
 
     public void setAuthor(Author author) {
         this.author = author;
-    }
-
-    public String getAuthorDisplayName() {
-        return author.displayName;
     }
 
     @Override
@@ -155,27 +151,15 @@ public class BitbucketPullRequestValue implements BitbucketPullRequest {
     public static class Author {
         @JsonProperty("account_id")
         private String identifier;
-        private String username;
-        @JsonProperty("display_name")
+        @JsonProperty("nickname")
         private String displayName;
         public Author() {}
-        public Author(String username) {
-            this.username = username;
-        }
-
-        public String getUsername() {
-            return username;
-        }
-
-        public void setUsername(String username) {
-            this.username = username;
-        }
 
         public String getIdentifier() {
             return identifier;
         }
 
-        public void setIndentifier(String identifier) {
+        public void setIdentifier(String identifier) {
             this.identifier = identifier;
         }
 

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketClientMockUtils.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketClientMockUtils.java
@@ -200,7 +200,7 @@ public class BitbucketClientMockUtils {
         pr.setDestination(new BitbucketPullRequestValueDestination(repository, branch, commit));
 
         pr.setId("23");
-        pr.setAuthor(new BitbucketPullRequestValue.Author("amuniz"));
+        pr.setAuthor(new BitbucketPullRequestValue.Author());
         pr.setLinks(new BitbucketPullRequestValue.Links("https://bitbucket.org/amuniz/test-repos/pull-requests/23"));
         return pr;
     }

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/client/events/BitbucketCloudPullRequestEventTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/client/events/BitbucketCloudPullRequestEventTest.java
@@ -69,7 +69,8 @@ public class BitbucketCloudPullRequestEventTest {
 
         assertThat(event.getPullRequest(), notNullValue());
         assertThat(event.getPullRequest().getTitle(), is("README.md edited online with Bitbucket"));
-        assertThat(event.getPullRequest().getAuthorLogin(), is("stephenc"));
+        assertThat(event.getPullRequest().getAuthorIdentifier(), is("123456:dead-beef"));
+        assertThat(event.getPullRequest().getAuthorLogin(), is("Stephen Connolly"));
         assertThat(event.getPullRequest().getLink(),
                 is("https://bitbucket.org/cloudbeers/temp/pull-requests/1"));
 
@@ -134,7 +135,8 @@ public class BitbucketCloudPullRequestEventTest {
 
         assertThat(event.getPullRequest(), notNullValue());
         assertThat(event.getPullRequest().getTitle(), is("Forking for PR"));
-        assertThat(event.getPullRequest().getAuthorLogin(), is("stephenc"));
+        assertThat(event.getPullRequest().getAuthorIdentifier(), is("123456:dead-beef"));
+        assertThat(event.getPullRequest().getAuthorLogin(), is("Stephen Connolly"));
         assertThat(event.getPullRequest().getLink(),
                 is("https://bitbucket.org/cloudbeers/temp/pull-requests/3"));
 
@@ -198,7 +200,8 @@ public class BitbucketCloudPullRequestEventTest {
 
         assertThat(event.getPullRequest(), notNullValue());
         assertThat(event.getPullRequest().getTitle(), is("Forking for PR"));
-        assertThat(event.getPullRequest().getAuthorLogin(), is("stephenc"));
+        assertThat(event.getPullRequest().getAuthorIdentifier(), is("123456:dead-beef"));
+        assertThat(event.getPullRequest().getAuthorLogin(), is("Stephen Connolly"));
         assertThat(event.getPullRequest().getLink(),
                 is("https://bitbucket.org/cloudbeers/temp/pull-requests/3"));
 
@@ -262,7 +265,8 @@ public class BitbucketCloudPullRequestEventTest {
 
         assertThat(event.getPullRequest(), notNullValue());
         assertThat(event.getPullRequest().getTitle(), is("Forking for PR"));
-        assertThat(event.getPullRequest().getAuthorLogin(), is("stephenc"));
+        assertThat(event.getPullRequest().getAuthorIdentifier(), is("123456:dead-beef"));
+        assertThat(event.getPullRequest().getAuthorLogin(), is("Stephen Connolly"));
         assertThat(event.getPullRequest().getLink(),
                 is("https://bitbucket.org/cloudbeers/temp/pull-requests/3"));
 
@@ -326,7 +330,8 @@ public class BitbucketCloudPullRequestEventTest {
 
         assertThat(event.getPullRequest(), notNullValue());
         assertThat(event.getPullRequest().getTitle(), is("Forking for PR"));
-        assertThat(event.getPullRequest().getAuthorLogin(), is("stephenc"));
+        assertThat(event.getPullRequest().getAuthorIdentifier(), is("123456:dead-beef"));
+        assertThat(event.getPullRequest().getAuthorLogin(), is("Stephen Connolly"));
         assertThat(event.getPullRequest().getLink(),
                 is("https://bitbucket.org/cloudbeers/temp/pull-requests/3"));
 
@@ -390,7 +395,8 @@ public class BitbucketCloudPullRequestEventTest {
 
         assertThat(event.getPullRequest(), notNullValue());
         assertThat(event.getPullRequest().getTitle(), is("Forking for PR"));
-        assertThat(event.getPullRequest().getAuthorLogin(), is("stephenc"));
+        assertThat(event.getPullRequest().getAuthorIdentifier(), is("123456:dead-beef"));
+        assertThat(event.getPullRequest().getAuthorLogin(), is("Stephen Connolly"));
         assertThat(event.getPullRequest().getLink(),
                 is("https://bitbucket.org/cloudbeers/temp/pull-requests/3"));
 
@@ -455,7 +461,8 @@ public class BitbucketCloudPullRequestEventTest {
 
         assertThat(event.getPullRequest(), notNullValue());
         assertThat(event.getPullRequest().getTitle(), is("README.md edited online with Bitbucket"));
-        assertThat(event.getPullRequest().getAuthorLogin(), is("stephenc"));
+        assertThat(event.getPullRequest().getAuthorIdentifier(), is("123456:dead-beef"));
+        assertThat(event.getPullRequest().getAuthorLogin(), is("Stephen Connolly"));
         assertThat(event.getPullRequest().getLink(),
                 is("https://bitbucket.org/cloudbeers/temp/pull-requests/2"));
 

--- a/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/client/events/BitbucketCloudPullRequestEventTest/createPayloadFork.json
+++ b/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/client/events/BitbucketCloudPullRequestEventTest/createPayloadFork.json
@@ -106,8 +106,9 @@
     "reason": "",
     "updated_on": "2017-03-06T11:52:20.120024+00:00",
     "author": {
-      "username": "stephenc",
-      "display_name": "Stephen Connolly",
+      "account_id": "123456:dead-beef",
+      "nickname": "Stephen Connolly",
+      "display_name": "Stephen Q. Connolly",
       "type": "user",
       "uuid": "{f70f195e-ade1-4961-9f89-547541377b80}",
       "links": {

--- a/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/client/events/BitbucketCloudPullRequestEventTest/createPayloadOrigin.json
+++ b/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/client/events/BitbucketCloudPullRequestEventTest/createPayloadOrigin.json
@@ -35,8 +35,9 @@
       }
     },
     "author": {
-      "username": "stephenc",
-      "display_name": "Stephen Connolly",
+      "account_id": "123456:dead-beef",
+      "nickname": "Stephen Connolly",
+      "display_name": "Stephen Q. Connolly",
       "type": "user",
       "uuid": "{f70f195e-ade1-4961-9f89-547541377b80}",
       "links": {

--- a/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/client/events/BitbucketCloudPullRequestEventTest/fulfilledPayload.json
+++ b/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/client/events/BitbucketCloudPullRequestEventTest/fulfilledPayload.json
@@ -129,8 +129,9 @@
     "reason": "",
     "updated_on": "2017-03-06T10:41:59.551194+00:00",
     "author": {
-      "username": "stephenc",
-      "display_name": "Stephen Connolly",
+      "account_id": "123456:dead-beef",
+      "nickname": "Stephen Connolly",
+      "display_name": "Stephen Q. Connolly",
       "type": "user",
       "uuid": "{f70f195e-ade1-4961-9f89-547541377b80}",
       "links": {

--- a/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/client/events/BitbucketCloudPullRequestEventTest/rejectedPayload.json
+++ b/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/client/events/BitbucketCloudPullRequestEventTest/rejectedPayload.json
@@ -122,8 +122,9 @@
     "reason": "",
     "updated_on": "2017-03-06T12:05:11.484201+00:00",
     "author": {
-      "username": "stephenc",
-      "display_name": "Stephen Connolly",
+      "account_id": "123456:dead-beef",
+      "nickname": "Stephen Connolly",
+      "display_name": "Stephen Q. Connolly",
       "type": "user",
       "uuid": "{f70f195e-ade1-4961-9f89-547541377b80}",
       "links": {

--- a/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/client/events/BitbucketCloudPullRequestEventTest/updatePayload_newCommit.json
+++ b/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/client/events/BitbucketCloudPullRequestEventTest/updatePayload_newCommit.json
@@ -35,8 +35,9 @@
       }
     },
     "author": {
-      "username": "stephenc",
-      "display_name": "Stephen Connolly",
+      "account_id": "123456:dead-beef",
+      "nickname": "Stephen Connolly",
+      "display_name": "Stephen Q. Connolly",
       "type": "user",
       "uuid": "{f70f195e-ade1-4961-9f89-547541377b80}",
       "links": {

--- a/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/client/events/BitbucketCloudPullRequestEventTest/updatePayload_newDestination.json
+++ b/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/client/events/BitbucketCloudPullRequestEventTest/updatePayload_newDestination.json
@@ -106,8 +106,9 @@
     "reason": "",
     "updated_on": "2017-03-06T11:59:39.916949+00:00",
     "author": {
-      "username": "stephenc",
-      "display_name": "Stephen Connolly",
+      "account_id": "123456:dead-beef",
+      "nickname": "Stephen Connolly",
+      "display_name": "Stephen Q. Connolly",
       "type": "user",
       "uuid": "{f70f195e-ade1-4961-9f89-547541377b80}",
       "links": {

--- a/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/client/events/BitbucketCloudPullRequestEventTest/updatePayload_newDestinationCommit.json
+++ b/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/client/events/BitbucketCloudPullRequestEventTest/updatePayload_newDestinationCommit.json
@@ -106,8 +106,9 @@
     "reason": "",
     "updated_on": "2017-03-06T12:02:59.640844+00:00",
     "author": {
-      "username": "stephenc",
-      "display_name": "Stephen Connolly",
+      "account_id": "123456:dead-beef",
+      "nickname": "Stephen Connolly",
+      "display_name": "Stephen Q. Connolly",
       "type": "user",
       "uuid": "{f70f195e-ade1-4961-9f89-547541377b80}",
       "links": {


### PR DESCRIPTION
Fixes #195, which is not a plugin regression, but a [cloud API regression](https://developer.atlassian.com/cloud/bitbucket/bitbucket-api-changes-gdpr/) to satisfy GDPR. There is apparently no way to set `CHANGE_AUTHOR` to the previous value. (`CHANGE_FORK`, or its first component if `/`-separated, is probably the same thing, though this is not necessarily the _author_.) Nor is `CHANGE_AUTHOR_EMAIL` possible.

Also, for Server, the display name was mistakenly being bound to the variable intended for the (code) username.

Example variables with BB Cloud, before:

```
(no variables starting with CHANGE_AUTHOR)
```

after:

```
CHANGE_AUTHOR=123456:some-long-uuid
CHANGE_AUTHOR_DISPLAY_NAME=Jesse Glick
```

With BB Server 7, before:

```
CHANGE_AUTHOR=Test User
CHANGE_AUTHOR_EMAIL=testuser@nowhere.net
```

and after:

```
CHANGE_AUTHOR=test-user
CHANGE_AUTHOR_DISPLAY_NAME=Test User
CHANGE_AUTHOR_EMAIL=testuser@nowhere.net
```