### PR TITLE
JENKINS-63401 Harden looking up credentials

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/credentials/BitbucketOAuthCredentialMatcher.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/credentials/BitbucketOAuthCredentialMatcher.java
@@ -4,12 +4,15 @@ import com.cloudbees.plugins.credentials.Credentials;
 import com.cloudbees.plugins.credentials.CredentialsMatcher;
 import com.cloudbees.plugins.credentials.common.UsernamePasswordCredentials;
 import hudson.util.Secret;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 public class BitbucketOAuthCredentialMatcher implements CredentialsMatcher, CredentialsMatcher.CQL {
-    private static int keyLenght = 18;
-    private static int secretLenght = 32;
+    private static int keyLength = 18;
+    private static int secretLength = 32;
 
     private static final long serialVersionUID = 6458784517693211197L;
+    private static final Logger LOGGER = Logger.getLogger(BitbucketOAuthCredentialMatcher.class.getName());
 
     /**
      * {@inheritDoc}
@@ -19,13 +22,18 @@ public class BitbucketOAuthCredentialMatcher implements CredentialsMatcher, Cred
         if (!(item instanceof UsernamePasswordCredentials))
             return false;
 
-        UsernamePasswordCredentials usernamePasswordCredential = ((UsernamePasswordCredentials) item);
-        String username = usernamePasswordCredential.getUsername();
-        boolean isEMail = username.contains(".") && username.contains("@");
-        boolean validSecretLenght = Secret.toString(usernamePasswordCredential.getPassword()).length() == secretLenght;
-        boolean validKeyLenght = username.length() == keyLenght;
+        try {
+            UsernamePasswordCredentials usernamePasswordCredential = ((UsernamePasswordCredentials) item);
+            String username = usernamePasswordCredential.getUsername();
+            boolean isEMail = username.contains(".") && username.contains("@");
+            boolean validSecretLength = Secret.toString(usernamePasswordCredential.getPassword()).length() == secretLength;
+            boolean validKeyLength = username.length() == keyLength;
 
-        return !isEMail && validKeyLenght && validSecretLenght;
+            return !isEMail && validKeyLength && validSecretLength;
+        } catch (RuntimeException e) {
+            LOGGER.log(Level.FINE, "Caught exception validating credential", e);
+            return false;
+        }
     }
 
     /**
@@ -35,7 +43,7 @@ public class BitbucketOAuthCredentialMatcher implements CredentialsMatcher, Cred
     public String describe() {
         return String.format(
                 "(username.lenght == %d && password.lenght == %d && !(username CONTAINS \".\" && username CONTAINS \"@\")",
-                keyLenght, secretLenght);
+                keyLength, secretLength);
     }
 
 

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/api/credentials/BitbucketOAuthCredentialMatcherTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/api/credentials/BitbucketOAuthCredentialMatcherTest.java
@@ -1,0 +1,50 @@
+package com.cloudbees.jenkins.plugins.bitbucket.api.credentials;
+
+import com.cloudbees.plugins.credentials.CredentialsDescriptor;
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.cloudbees.plugins.credentials.common.UsernamePasswordCredentials;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.util.Secret;
+import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
+
+import static org.junit.Assert.assertFalse;
+
+public class BitbucketOAuthCredentialMatcherTest {
+
+    /**
+     * Some plugins do remote work when getPassword is called and aren't expecting to just be randomly looked up
+     * One example is GitHubAppCredentials
+     */
+    @Test
+    @Issue("JENKINS-63401")
+    public void matches_returns_false_when_exception_getting_password() {
+        assertFalse(new BitbucketOAuthCredentialMatcher().matches(new ExceptionalCredentials()));
+    }
+
+    private static class ExceptionalCredentials implements UsernamePasswordCredentials {
+
+        @NonNull
+        @Override
+        public Secret getPassword() {
+            throw new IllegalArgumentException("Failed authentication");
+        }
+
+        @NonNull
+        @Override
+        public String getUsername() {
+            return "dummy-username";
+        }
+
+        @Override
+        public CredentialsScope getScope() {
+            return null;
+        }
+
+        @NonNull
+        @Override
+        public CredentialsDescriptor getDescriptor() {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
https://issues.jenkins-ci.org/browse/JENKINS-63401

The current behaviour can break anyone using GitHub apps from changing the rate limit strategy.
TBH it's probably a bug in core too as returning a 500 from a doFill method probably shouldn't cause the JavaScript to break...

But an easy fix here
<!--
To mark your pull request as work in progress please create it as a draft pull request
-->

cc @jetersen @bitwiseman 

### Your checklist for this pull request

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Did you provide a test-case? That demonstrates feature works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled the information below
Describe your pull request below
-->
