### PR TITLE
Fix Automatic Webhook Creation for BitBucket 5.x [Fixes 352]

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/HookEventType.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/HookEventType.java
@@ -100,13 +100,13 @@ public enum HookEventType {
     SERVER_PULL_REQUEST_APPROVED("pr:reviewer:approved", NativeServerPullRequestHookProcessor.class),
 
     /**
-     * @see <a href="https://confluence.atlassian.com/bitbucketserver0510/event-payload-951390742.html">Eventpayload-Modified</a>
+     * @see <a href="https://confluence.atlassian.com/bitbucketserver0510/event-payload-951390742.html#Eventpayload-Modified.1">Eventpayload: Pull Request - Modified</a>
      * @since Bitbucket Server 5.10
      */
     SERVER_PULL_REQUEST_MODIFIED("pr:modified", NativeServerPullRequestHookProcessor.class),
 
     /**
-     * @see <a href="https://confluence.atlassian.com/bitbucketserver0510/event-payload-951390742.html">Eventpayload-Modified</a>
+     * @see <a href="https://confluence.atlassian.com/bitbucketserver0510/event-payload-951390742.html#Eventpayload-ReviewersUpdated">Eventpayload: Pull Request - Reviewers Updated</a>
      * @since Bitbucket Server 5.10
      */
     SERVER_PULL_REQUEST_REVIEWER_UPDATED("pr:reviewer:updated", NativeServerPullRequestHookProcessor.class),

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/HookEventType.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/HookEventType.java
@@ -100,14 +100,14 @@ public enum HookEventType {
     SERVER_PULL_REQUEST_APPROVED("pr:reviewer:approved", NativeServerPullRequestHookProcessor.class),
 
     /**
-     * @see <a href="https://confluence.atlassian.com/bitbucketserver068/event-payload-981145451.html#Eventpayload-Modified">Eventpayload-Modified</a>
-     * @since Bitbucket Server 5.4
+     * @see <a href="https://confluence.atlassian.com/bitbucketserver0510/event-payload-951390742.html">Eventpayload-Modified</a>
+     * @since Bitbucket Server 5.10
      */
     SERVER_PULL_REQUEST_MODIFIED("pr:modified", NativeServerPullRequestHookProcessor.class),
 
     /**
-     * @see <a href="https://confluence.atlassian.com/bitbucketserver054/event-payload-939508609.html#Eventpayload-ReviewersUpdated">Eventpayload-Modified</a>
-     * @since Bitbucket Server 6.8
+     * @see <a href="https://confluence.atlassian.com/bitbucketserver0510/event-payload-951390742.html">Eventpayload-Modified</a>
+     * @since Bitbucket Server 5.10
      */
     SERVER_PULL_REQUEST_REVIEWER_UPDATED("pr:reviewer:updated", NativeServerPullRequestHookProcessor.class),
 

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/WebhookConfiguration.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/WebhookConfiguration.java
@@ -30,7 +30,6 @@ import com.cloudbees.jenkins.plugins.bitbucket.endpoints.AbstractBitbucketEndpoi
 import com.cloudbees.jenkins.plugins.bitbucket.endpoints.BitbucketCloudEndpoint;
 import com.cloudbees.jenkins.plugins.bitbucket.endpoints.BitbucketEndpointConfiguration;
 import com.cloudbees.jenkins.plugins.bitbucket.endpoints.BitbucketServerEndpoint;
-import com.cloudbees.jenkins.plugins.bitbucket.server.BitbucketServerVersion;
 import com.cloudbees.jenkins.plugins.bitbucket.server.client.repository.BitbucketServerWebhook;
 import com.cloudbees.jenkins.plugins.bitbucket.server.client.repository.NativeBitbucketServerWebhook;
 import com.damnhandy.uri.template.UriTemplate;
@@ -67,6 +66,7 @@ public class WebhookConfiguration {
             HookEventType.SERVER_PULL_REQUEST_MERGED.getKey(),
             HookEventType.SERVER_PULL_REQUEST_DECLINED.getKey(),
             HookEventType.SERVER_PULL_REQUEST_DELETED.getKey(),
+            // only on v5.10 and above
             HookEventType.SERVER_PULL_REQUEST_MODIFIED.getKey(),
             HookEventType.SERVER_PULL_REQUEST_REVIEWER_UPDATED.getKey(),
             // only on v7.x and above
@@ -74,9 +74,14 @@ public class WebhookConfiguration {
     ));
 
     /**
-     * The list of events available in Bitbucket Server v6.x.
+     * The list of events available in Bitbucket Server v5.10+.
      */
-    private static final List<String> NATIVE_SERVER_EVENTS_v6 = Collections.unmodifiableList(NATIVE_SERVER_EVENTS_v7.subList(0, 6));
+    private static final List<String> NATIVE_SERVER_EVENTS_v5_10 = Collections.unmodifiableList(NATIVE_SERVER_EVENTS_v7.subList(0, 7));
+
+    /**
+     * The list of events available in Bitbucket Server v5.9-.
+     */
+    private static final List<String> NATIVE_SERVER_EVENTS_v5_9 = Collections.unmodifiableList(NATIVE_SERVER_EVENTS_v7.subList(0, 5));
 
     /**
      * The title of the webhook.
@@ -203,9 +208,21 @@ public class WebhookConfiguration {
     private static List<String> getNativeServerEvents(String serverUrl) {
         AbstractBitbucketEndpoint endpoint = BitbucketEndpointConfiguration.get().findEndpoint(serverUrl);
         if (endpoint instanceof BitbucketServerEndpoint) {
-            if (((BitbucketServerEndpoint)endpoint).getServerVersion().equals(BitbucketServerVersion.VERSION_6)) {
-                return NATIVE_SERVER_EVENTS_v6;
-            }
+            switch (((BitbucketServerEndpoint) endpoint).getServerVersion()) {
+            case VERSION_5_9:
+				return NATIVE_SERVER_EVENTS_v5_9;
+            case VERSION_5_10:
+				return NATIVE_SERVER_EVENTS_v5_10;
+            case VERSION_6:
+				// plugin version 2.9.1 introduced VERSION_6 setting for BitBucket but it actually applies
+				// to Version 5.10+. In order to preserve backwards compatibility, rather than remove
+				// VERSION_6, it will use the same list as 5.10 until such time a need arises for it to have its
+				// own list
+				return NATIVE_SERVER_EVENTS_v5_10;
+            case VERSION_7:
+            default:
+				return NATIVE_SERVER_EVENTS_v7;
+			}
         }
 
         // Not specifically v6, use v7.

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/WebhookConfiguration.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/WebhookConfiguration.java
@@ -184,14 +184,14 @@ public class WebhookConfiguration {
         }
 
         switch (BitbucketServerEndpoint.findWebhookImplementation(serverUrl)) {
-        case NATIVE: {
-            NativeBitbucketServerWebhook hook = new NativeBitbucketServerWebhook();
-            hook.setActive(true);
-            hook.setEvents(getNativeServerEvents(serverUrl));
-            hook.setDescription(description);
-            hook.setUrl(getNativeServerWebhookUrl(serverUrl, rootUrl));
-            return hook;
-        }
+            case NATIVE: {
+                NativeBitbucketServerWebhook hook = new NativeBitbucketServerWebhook();
+                hook.setActive(true);
+                hook.setEvents(getNativeServerEvents(serverUrl));
+                hook.setDescription(description);
+                hook.setUrl(getNativeServerWebhookUrl(serverUrl, rootUrl));
+                return hook;
+            }
 
         case PLUGIN:
         default: {

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/WebhookConfiguration.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/WebhookConfiguration.java
@@ -74,14 +74,14 @@ public class WebhookConfiguration {
     ));
 
     /**
-     * The list of events available in Bitbucket Server v5.10+.
+     * The list of events available in Bitbucket Server v6.x.  Applies to v5.10+.
      */
-    private static final List<String> NATIVE_SERVER_EVENTS_v5_10 = Collections.unmodifiableList(NATIVE_SERVER_EVENTS_v7.subList(0, 7));
+    private static final List<String> NATIVE_SERVER_EVENTS_v6 = Collections.unmodifiableList(NATIVE_SERVER_EVENTS_v7.subList(0, 7));
 
     /**
      * The list of events available in Bitbucket Server v5.9-.
      */
-    private static final List<String> NATIVE_SERVER_EVENTS_v5_9 = Collections.unmodifiableList(NATIVE_SERVER_EVENTS_v7.subList(0, 5));
+    private static final List<String> NATIVE_SERVER_EVENTS_v5 = Collections.unmodifiableList(NATIVE_SERVER_EVENTS_v7.subList(0, 5));
 
     /**
      * The title of the webhook.
@@ -184,24 +184,24 @@ public class WebhookConfiguration {
         }
 
         switch (BitbucketServerEndpoint.findWebhookImplementation(serverUrl)) {
-            case NATIVE: {
-                NativeBitbucketServerWebhook hook = new NativeBitbucketServerWebhook();
-                hook.setActive(true);
-                hook.setEvents(getNativeServerEvents(serverUrl));
-                hook.setDescription(description);
-                hook.setUrl(getNativeServerWebhookUrl(serverUrl, rootUrl));
-                return hook;
-            }
+        case NATIVE: {
+            NativeBitbucketServerWebhook hook = new NativeBitbucketServerWebhook();
+            hook.setActive(true);
+            hook.setEvents(getNativeServerEvents(serverUrl));
+            hook.setDescription(description);
+            hook.setUrl(getNativeServerWebhookUrl(serverUrl, rootUrl));
+            return hook;
+        }
 
-            case PLUGIN:
-            default: {
-                BitbucketServerWebhook hook = new BitbucketServerWebhook();
-                hook.setActive(true);
-                hook.setDescription(description);
-                hook.setUrl(rootUrl + BitbucketSCMSourcePushHookReceiver.FULL_PATH);
-                hook.setCommittersToIgnore(committersToIgnore);
-                return hook;
-            }
+        case PLUGIN:
+        default: {
+            BitbucketServerWebhook hook = new BitbucketServerWebhook();
+            hook.setActive(true);
+            hook.setDescription(description);
+            hook.setUrl(rootUrl + BitbucketSCMSourcePushHookReceiver.FULL_PATH);
+            hook.setCommittersToIgnore(committersToIgnore);
+            return hook;
+        }
         }
     }
 
@@ -209,20 +209,23 @@ public class WebhookConfiguration {
         AbstractBitbucketEndpoint endpoint = BitbucketEndpointConfiguration.get().findEndpoint(serverUrl);
         if (endpoint instanceof BitbucketServerEndpoint) {
             switch (((BitbucketServerEndpoint) endpoint).getServerVersion()) {
-            case VERSION_5_9:
-				return NATIVE_SERVER_EVENTS_v5_9;
+            case VERSION_5:
+                return NATIVE_SERVER_EVENTS_v5;
             case VERSION_5_10:
-				return NATIVE_SERVER_EVENTS_v5_10;
+                return NATIVE_SERVER_EVENTS_v6;
             case VERSION_6:
-				// plugin version 2.9.1 introduced VERSION_6 setting for BitBucket but it actually applies
-				// to Version 5.10+. In order to preserve backwards compatibility, rather than remove
-				// VERSION_6, it will use the same list as 5.10 until such time a need arises for it to have its
-				// own list
-				return NATIVE_SERVER_EVENTS_v5_10;
+                // plugin version 2.9.1 introduced VERSION_6 setting for BitBucket but it
+                // actually applies
+                // to Version 5.10+. In order to preserve backwards compatibility, rather than
+                // remove
+                // VERSION_6, it will use the same list as 5.10 until such time a need arises
+                // for it to have its
+                // own list
+                return NATIVE_SERVER_EVENTS_v6;
             case VERSION_7:
             default:
-				return NATIVE_SERVER_EVENTS_v7;
-			}
+                return NATIVE_SERVER_EVENTS_v7;
+            }
         }
 
         // Not specifically v6, use v7.

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/WebhookConfiguration.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/WebhookConfiguration.java
@@ -193,15 +193,15 @@ public class WebhookConfiguration {
                 return hook;
             }
 
-        case PLUGIN:
-        default: {
-            BitbucketServerWebhook hook = new BitbucketServerWebhook();
-            hook.setActive(true);
-            hook.setDescription(description);
-            hook.setUrl(rootUrl + BitbucketSCMSourcePushHookReceiver.FULL_PATH);
-            hook.setCommittersToIgnore(committersToIgnore);
-            return hook;
-        }
+            case PLUGIN:
+            default: {
+                BitbucketServerWebhook hook = new BitbucketServerWebhook();
+                hook.setActive(true);
+                hook.setDescription(description);
+                hook.setUrl(rootUrl + BitbucketSCMSourcePushHookReceiver.FULL_PATH);
+                hook.setCommittersToIgnore(committersToIgnore);
+                return hook;
+            }
         }
     }
 

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/BitbucketServerVersion.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/BitbucketServerVersion.java
@@ -27,7 +27,9 @@ import hudson.model.ModelObject;
 
 public enum BitbucketServerVersion implements ModelObject {
     VERSION_7("Bitbucket v7.x (and later)"),
-    VERSION_6("Bitbucket v6.x (and earlier)");
+    VERSION_6("Bitbucket v6.x (and later)"),
+    VERSION_5_10("Bitbucket v5.10 (and later)"),
+    VERSION_5_9("Bitbucket v5.9 (and earlier)");
 
     private final String displayName;
 

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/BitbucketServerVersion.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/BitbucketServerVersion.java
@@ -27,9 +27,9 @@ import hudson.model.ModelObject;
 
 public enum BitbucketServerVersion implements ModelObject {
     VERSION_7("Bitbucket v7.x (and later)"),
-    VERSION_6("Bitbucket v6.x (and later)"),
-    VERSION_5_10("Bitbucket v5.10 (and later)"),
-    VERSION_5_9("Bitbucket v5.9 (and earlier)");
+    VERSION_6("Bitbucket v6.x"),
+    VERSION_5_10("Bitbucket v5.10 to v5.16"),
+    VERSION_5("Bitbucket v5.9 (and earlier)");
 
     private final String displayName;
 
@@ -43,4 +43,3 @@ public enum BitbucketServerVersion implements ModelObject {
     }
 
 }
-

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/BitbucketServerAPIClient.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/BitbucketServerAPIClient.java
@@ -1007,6 +1007,7 @@ public class BitbucketServerAPIClient implements BitbucketApi {
     private String postRequest(String path, String content) throws IOException {
         HttpPost request = new HttpPost(this.baseURL + path);
         request.setEntity(new StringEntity(content, ContentType.create("application/json", "UTF-8")));
+        LOGGER.log(Level.FINEST, content);
         return postRequest(request);
     }
 

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/endpoints/BitbucketEndpointConfigurationTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/endpoints/BitbucketEndpointConfigurationTest.java
@@ -649,7 +649,7 @@ public class BitbucketEndpointConfigurationTest {
 
         BitbucketEndpointConfiguration instance = BitbucketEndpointConfiguration.get();
 
-        assertThat(instance.getEndpoints(), hasSize(9));
+        assertThat(instance.getEndpoints(), hasSize(11));
 
         BitbucketCloudEndpoint endpoint1 = (BitbucketCloudEndpoint) instance.getEndpoints().get(0);
         assertThat(endpoint1.getDisplayName(), is(Messages.BitbucketCloudEndpoint_displayName()));
@@ -740,6 +740,26 @@ public class BitbucketEndpointConfigurationTest {
         assertThat(serverEndpoint.isCallChanges(), is(true));
         assertThat(serverEndpoint.getWebhookImplementation(), is(BitbucketServerWebhookImplementation.PLUGIN));
         assertThat(serverEndpoint.getServerVersion(), is(BitbucketServerVersion.VERSION_6));
+
+        serverEndpoint = (BitbucketServerEndpoint) instance.getEndpoints().get(9);
+        assertThat(serverEndpoint.getDisplayName(), is("Example Inc"));
+        assertThat(serverEndpoint.getServerUrl(), is("http://bitbucket.example.com:8089"));
+        assertThat(serverEndpoint.isManageHooks(), is(false));
+        assertThat(serverEndpoint.getCredentialsId(), is(nullValue()));
+        assertThat(serverEndpoint.isCallCanMerge(), is(false));
+        assertThat(serverEndpoint.isCallChanges(), is(true));
+        assertThat(serverEndpoint.getWebhookImplementation(), is(BitbucketServerWebhookImplementation.PLUGIN));
+        assertThat(serverEndpoint.getServerVersion(), is(BitbucketServerVersion.VERSION_5_10));
+        
+        serverEndpoint = (BitbucketServerEndpoint) instance.getEndpoints().get(10);
+        assertThat(serverEndpoint.getDisplayName(), is("Example Inc"));
+        assertThat(serverEndpoint.getServerUrl(), is("http://bitbucket.example.com:8090"));
+        assertThat(serverEndpoint.isManageHooks(), is(false));
+        assertThat(serverEndpoint.getCredentialsId(), is(nullValue()));
+        assertThat(serverEndpoint.isCallCanMerge(), is(false));
+        assertThat(serverEndpoint.isCallChanges(), is(true));
+        assertThat(serverEndpoint.getWebhookImplementation(), is(BitbucketServerWebhookImplementation.PLUGIN));
+        assertThat(serverEndpoint.getServerVersion(), is(BitbucketServerVersion.VERSION_5_9));
 
     }
 }

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/endpoints/BitbucketEndpointConfigurationTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/endpoints/BitbucketEndpointConfigurationTest.java
@@ -750,7 +750,7 @@ public class BitbucketEndpointConfigurationTest {
         assertThat(serverEndpoint.isCallChanges(), is(true));
         assertThat(serverEndpoint.getWebhookImplementation(), is(BitbucketServerWebhookImplementation.PLUGIN));
         assertThat(serverEndpoint.getServerVersion(), is(BitbucketServerVersion.VERSION_5_10));
-        
+
         serverEndpoint = (BitbucketServerEndpoint) instance.getEndpoints().get(10);
         assertThat(serverEndpoint.getDisplayName(), is("Example Inc"));
         assertThat(serverEndpoint.getServerUrl(), is("http://bitbucket.example.com:8090"));
@@ -759,7 +759,7 @@ public class BitbucketEndpointConfigurationTest {
         assertThat(serverEndpoint.isCallCanMerge(), is(false));
         assertThat(serverEndpoint.isCallChanges(), is(true));
         assertThat(serverEndpoint.getWebhookImplementation(), is(BitbucketServerWebhookImplementation.PLUGIN));
-        assertThat(serverEndpoint.getServerVersion(), is(BitbucketServerVersion.VERSION_5_9));
+        assertThat(serverEndpoint.getServerVersion(), is(BitbucketServerVersion.VERSION_5));
 
     }
 }

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/WebhookConfigurationTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/WebhookConfigurationTest.java
@@ -1,0 +1,81 @@
+package com.cloudbees.jenkins.plugins.bitbucket.hooks;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.Before;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.mockito.Mockito;
+import com.cloudbees.jenkins.plugins.bitbucket.BitbucketSCMSource;
+import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketWebHook;
+import io.jenkins.plugins.casc.ConfigurationAsCode;
+import io.jenkins.plugins.casc.ConfiguratorException;
+
+public class WebhookConfigurationTest {
+
+    @ClassRule
+    public static JenkinsRule j = new JenkinsRule();
+    
+    @Before
+    public void config() throws ConfiguratorException {
+    	ConfigurationAsCode.get().configure(getClass().getResource(getClass().getSimpleName() + "/configuration-as-code.yml").toString());
+    }
+	
+    @Test
+    public void given_instanceWithServerVersion6_when_getHooks_SERVER_PR_RVWR_UPDATE_EVENT_exists() {
+    	WebhookConfiguration whc = new WebhookConfiguration();
+    	BitbucketSCMSource owner = Mockito.mock(BitbucketSCMSource.class);
+    	final String server = "http://bitbucket.example.com:8088";
+		when(owner.getServerUrl()).thenReturn(server);
+    	when(owner.getEndpointJenkinsRootUrl()).thenReturn(server);
+    	BitbucketWebHook hook = whc.getHook(owner);
+    	assertTrue(hook.getEvents().contains(HookEventType.SERVER_PULL_REQUEST_REVIEWER_UPDATED.getKey()));
+    }
+
+    @Test
+    public void given_instanceWithServerVersion510_when_getHooks_SERVER_PR_RVWR_UPDATE_EVENT_exists() {
+    	WebhookConfiguration whc = new WebhookConfiguration();
+    	BitbucketSCMSource owner = Mockito.mock(BitbucketSCMSource.class);
+    	final String server = "http://bitbucket.example.com:8089";
+		when(owner.getServerUrl()).thenReturn(server);
+    	when(owner.getEndpointJenkinsRootUrl()).thenReturn(server);
+    	BitbucketWebHook hook = whc.getHook(owner);
+    	assertTrue(hook.getEvents().contains(HookEventType.SERVER_PULL_REQUEST_REVIEWER_UPDATED.getKey()));
+    }
+    
+    @Test
+    public void given_instanceWithServerVersion59_when_getHooks_SERVER_PR_RVWR_UPDATE_EVENT_not_exists() {
+    	WebhookConfiguration whc = new WebhookConfiguration();
+    	BitbucketSCMSource owner = Mockito.mock(BitbucketSCMSource.class);
+    	final String server = "http://bitbucket.example.com:8090";
+		when(owner.getServerUrl()).thenReturn(server);
+    	when(owner.getEndpointJenkinsRootUrl()).thenReturn(server);
+    	BitbucketWebHook hook = whc.getHook(owner);
+    	assertFalse(hook.getEvents().contains(HookEventType.SERVER_PULL_REQUEST_REVIEWER_UPDATED.getKey()));
+    }
+
+    @Test
+    public void given_instanceWithServerVersion59_when_getHooks_SERVER_PR_MOD_EVENT_not_exists() {
+    	WebhookConfiguration whc = new WebhookConfiguration();
+    	BitbucketSCMSource owner = Mockito.mock(BitbucketSCMSource.class);
+    	final String server = "http://bitbucket.example.com:8090";
+    	when(owner.getServerUrl()).thenReturn(server);
+    	when(owner.getEndpointJenkinsRootUrl()).thenReturn(server);
+    	BitbucketWebHook hook = whc.getHook(owner);
+    	assertFalse(hook.getEvents().contains(HookEventType.SERVER_PULL_REQUEST_MODIFIED.getKey()));
+    }
+    
+    @Test
+    public void given_instanceWithServerVersion7_when_getHooks_SERVER_PR_FROM_REF_UPDATED_EVENT_exists() {
+    	WebhookConfiguration whc = new WebhookConfiguration();
+    	BitbucketSCMSource owner = Mockito.mock(BitbucketSCMSource.class);
+    	final String server = "http://bitbucket.example.com:8087";
+		when(owner.getServerUrl()).thenReturn(server);
+    	when(owner.getEndpointJenkinsRootUrl()).thenReturn(server);
+    	BitbucketWebHook hook = whc.getHook(owner);
+    	assertTrue(hook.getEvents().contains(HookEventType.SERVER_PULL_REQUEST_FROM_REF_UPDATED.getKey()));
+    }
+    
+}

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/WebhookConfigurationTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/WebhookConfigurationTest.java
@@ -1,81 +1,83 @@
 package com.cloudbees.jenkins.plugins.bitbucket.hooks;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.when;
-import org.junit.ClassRule;
-import org.junit.Test;
-import org.junit.Before;
-import org.jvnet.hudson.test.JenkinsRule;
-import org.mockito.Mockito;
 import com.cloudbees.jenkins.plugins.bitbucket.BitbucketSCMSource;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketWebHook;
 import io.jenkins.plugins.casc.ConfigurationAsCode;
 import io.jenkins.plugins.casc.ConfiguratorException;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.mockito.Mockito;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
 
 public class WebhookConfigurationTest {
 
     @ClassRule
     public static JenkinsRule j = new JenkinsRule();
-    
+
     @Before
     public void config() throws ConfiguratorException {
-    	ConfigurationAsCode.get().configure(getClass().getResource(getClass().getSimpleName() + "/configuration-as-code.yml").toString());
+        ConfigurationAsCode.get().configure(
+                getClass().getResource(getClass().getSimpleName() + "/configuration-as-code.yml").toString());
     }
-	
+
     @Test
     public void given_instanceWithServerVersion6_when_getHooks_SERVER_PR_RVWR_UPDATE_EVENT_exists() {
-    	WebhookConfiguration whc = new WebhookConfiguration();
-    	BitbucketSCMSource owner = Mockito.mock(BitbucketSCMSource.class);
-    	final String server = "http://bitbucket.example.com:8088";
-		when(owner.getServerUrl()).thenReturn(server);
-    	when(owner.getEndpointJenkinsRootUrl()).thenReturn(server);
-    	BitbucketWebHook hook = whc.getHook(owner);
-    	assertTrue(hook.getEvents().contains(HookEventType.SERVER_PULL_REQUEST_REVIEWER_UPDATED.getKey()));
+        WebhookConfiguration whc = new WebhookConfiguration();
+        BitbucketSCMSource owner = Mockito.mock(BitbucketSCMSource.class);
+        final String server = "http://bitbucket.example.com:8088";
+        when(owner.getServerUrl()).thenReturn(server);
+        when(owner.getEndpointJenkinsRootUrl()).thenReturn(server);
+        BitbucketWebHook hook = whc.getHook(owner);
+        assertTrue(hook.getEvents().contains(HookEventType.SERVER_PULL_REQUEST_REVIEWER_UPDATED.getKey()));
     }
 
     @Test
     public void given_instanceWithServerVersion510_when_getHooks_SERVER_PR_RVWR_UPDATE_EVENT_exists() {
-    	WebhookConfiguration whc = new WebhookConfiguration();
-    	BitbucketSCMSource owner = Mockito.mock(BitbucketSCMSource.class);
-    	final String server = "http://bitbucket.example.com:8089";
-		when(owner.getServerUrl()).thenReturn(server);
-    	when(owner.getEndpointJenkinsRootUrl()).thenReturn(server);
-    	BitbucketWebHook hook = whc.getHook(owner);
-    	assertTrue(hook.getEvents().contains(HookEventType.SERVER_PULL_REQUEST_REVIEWER_UPDATED.getKey()));
+        WebhookConfiguration whc = new WebhookConfiguration();
+        BitbucketSCMSource owner = Mockito.mock(BitbucketSCMSource.class);
+        final String server = "http://bitbucket.example.com:8089";
+        when(owner.getServerUrl()).thenReturn(server);
+        when(owner.getEndpointJenkinsRootUrl()).thenReturn(server);
+        BitbucketWebHook hook = whc.getHook(owner);
+        assertTrue(hook.getEvents().contains(HookEventType.SERVER_PULL_REQUEST_REVIEWER_UPDATED.getKey()));
     }
-    
+
     @Test
     public void given_instanceWithServerVersion59_when_getHooks_SERVER_PR_RVWR_UPDATE_EVENT_not_exists() {
-    	WebhookConfiguration whc = new WebhookConfiguration();
-    	BitbucketSCMSource owner = Mockito.mock(BitbucketSCMSource.class);
-    	final String server = "http://bitbucket.example.com:8090";
-		when(owner.getServerUrl()).thenReturn(server);
-    	when(owner.getEndpointJenkinsRootUrl()).thenReturn(server);
-    	BitbucketWebHook hook = whc.getHook(owner);
-    	assertFalse(hook.getEvents().contains(HookEventType.SERVER_PULL_REQUEST_REVIEWER_UPDATED.getKey()));
+        WebhookConfiguration whc = new WebhookConfiguration();
+        BitbucketSCMSource owner = Mockito.mock(BitbucketSCMSource.class);
+        final String server = "http://bitbucket.example.com:8090";
+        when(owner.getServerUrl()).thenReturn(server);
+        when(owner.getEndpointJenkinsRootUrl()).thenReturn(server);
+        BitbucketWebHook hook = whc.getHook(owner);
+        assertFalse(hook.getEvents().contains(HookEventType.SERVER_PULL_REQUEST_REVIEWER_UPDATED.getKey()));
     }
 
     @Test
     public void given_instanceWithServerVersion59_when_getHooks_SERVER_PR_MOD_EVENT_not_exists() {
-    	WebhookConfiguration whc = new WebhookConfiguration();
-    	BitbucketSCMSource owner = Mockito.mock(BitbucketSCMSource.class);
-    	final String server = "http://bitbucket.example.com:8090";
-    	when(owner.getServerUrl()).thenReturn(server);
-    	when(owner.getEndpointJenkinsRootUrl()).thenReturn(server);
-    	BitbucketWebHook hook = whc.getHook(owner);
-    	assertFalse(hook.getEvents().contains(HookEventType.SERVER_PULL_REQUEST_MODIFIED.getKey()));
+        WebhookConfiguration whc = new WebhookConfiguration();
+        BitbucketSCMSource owner = Mockito.mock(BitbucketSCMSource.class);
+        final String server = "http://bitbucket.example.com:8090";
+        when(owner.getServerUrl()).thenReturn(server);
+        when(owner.getEndpointJenkinsRootUrl()).thenReturn(server);
+        BitbucketWebHook hook = whc.getHook(owner);
+        assertFalse(hook.getEvents().contains(HookEventType.SERVER_PULL_REQUEST_MODIFIED.getKey()));
     }
-    
+
     @Test
     public void given_instanceWithServerVersion7_when_getHooks_SERVER_PR_FROM_REF_UPDATED_EVENT_exists() {
-    	WebhookConfiguration whc = new WebhookConfiguration();
-    	BitbucketSCMSource owner = Mockito.mock(BitbucketSCMSource.class);
-    	final String server = "http://bitbucket.example.com:8087";
-		when(owner.getServerUrl()).thenReturn(server);
-    	when(owner.getEndpointJenkinsRootUrl()).thenReturn(server);
-    	BitbucketWebHook hook = whc.getHook(owner);
-    	assertTrue(hook.getEvents().contains(HookEventType.SERVER_PULL_REQUEST_FROM_REF_UPDATED.getKey()));
+        WebhookConfiguration whc = new WebhookConfiguration();
+        BitbucketSCMSource owner = Mockito.mock(BitbucketSCMSource.class);
+        final String server = "http://bitbucket.example.com:8087";
+        when(owner.getServerUrl()).thenReturn(server);
+        when(owner.getEndpointJenkinsRootUrl()).thenReturn(server);
+        BitbucketWebHook hook = whc.getHook(owner);
+        assertTrue(hook.getEvents().contains(HookEventType.SERVER_PULL_REQUEST_FROM_REF_UPDATED.getKey()));
     }
-    
+
 }

--- a/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/endpoints/BitbucketEndpointConfigurationTest/configuration-as-code.yml
+++ b/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/endpoints/BitbucketEndpointConfigurationTest/configuration-as-code.yml
@@ -69,5 +69,4 @@ unclassified:
         serverUrl: "http://bitbucket.example.com:8090"
         callCanMerge: false
         callChanges: true
-        serverVersion: VERSION_5_9
-
+        serverVersion: VERSION_5

--- a/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/endpoints/BitbucketEndpointConfigurationTest/configuration-as-code.yml
+++ b/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/endpoints/BitbucketEndpointConfigurationTest/configuration-as-code.yml
@@ -58,4 +58,16 @@ unclassified:
         callCanMerge: false
         callChanges: true
         serverVersion: VERSION_6
+    - bitbucketServerEndpoint:
+        displayName: "Example Inc"
+        serverUrl: "http://bitbucket.example.com:8089"
+        callCanMerge: false
+        callChanges: true
+        serverVersion: VERSION_5_10
+    - bitbucketServerEndpoint:
+        displayName: "Example Inc"
+        serverUrl: "http://bitbucket.example.com:8090"
+        callCanMerge: false
+        callChanges: true
+        serverVersion: VERSION_5_9
 

--- a/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/hooks/WebhookConfigurationTest/configuration-as-code.yml
+++ b/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/hooks/WebhookConfigurationTest/configuration-as-code.yml
@@ -28,6 +28,5 @@ unclassified:
         serverUrl: "http://bitbucket.example.com:8090"
         callCanMerge: false
         callChanges: true
-        serverVersion: VERSION_5_9
+        serverVersion: VERSION_5
         webhookImplementation: NATIVE        
-

--- a/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/hooks/WebhookConfigurationTest/configuration-as-code.yml
+++ b/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/hooks/WebhookConfigurationTest/configuration-as-code.yml
@@ -1,0 +1,33 @@
+---
+unclassified:
+  bitbucketendpointconfiguration:
+    endpoints:
+    - bitbucketServerEndpoint:
+        displayName: "Example Inc"
+        serverUrl: "http://bitbucket.example.com:8087"
+        callCanMerge: false
+        callChanges: false
+        serverVersion: VERSION_7
+        webhookImplementation: NATIVE        
+    - bitbucketServerEndpoint:
+        displayName: "Example Inc"
+        serverUrl: "http://bitbucket.example.com:8088"
+        callCanMerge: false
+        callChanges: true
+        serverVersion: VERSION_6
+        webhookImplementation: NATIVE        
+    - bitbucketServerEndpoint:
+        displayName: "Example Inc"
+        serverUrl: "http://bitbucket.example.com:8089"
+        callCanMerge: false
+        callChanges: true
+        serverVersion: VERSION_5_10
+        webhookImplementation: NATIVE        
+    - bitbucketServerEndpoint:
+        displayName: "Example Inc"
+        serverUrl: "http://bitbucket.example.com:8090"
+        callCanMerge: false
+        callChanges: true
+        serverVersion: VERSION_5_9
+        webhookImplementation: NATIVE        
+


### PR DESCRIPTION
Reorganize hook events for different BitBucket versions and introduce settings for versions 7, 6, 5.10 and earlier than 5.10

Version 2.80 accidentally added some default hook events that are only available on version 5.10+

Tested against BB v5.4

Fixes #352 

### Your checklist for this pull request

- [X] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Did you provide a test-case? That demonstrates feature works or fixes the issue.