### PR TITLE
Set event for declined PRs

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/PullRequestHookProcessor.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/PullRequestHookProcessor.java
@@ -83,6 +83,8 @@ public class PullRequestHookProcessor extends HookProcessor {
                         eventType = SCMEvent.Type.CREATED;
                         break;
                     case PULL_REQUEST_DECLINED:
+                        eventType = SCMEvent.Type.REMOVED;
+                        break;
                     case PULL_REQUEST_MERGED:
                         eventType = SCMEvent.Type.REMOVED;
                         break;


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
I added event triggering for declined PRs.  
Usecase: If you create a deployment using PRs you will need to delete it not only when PR is merged, but when PR declined also. Pipeline should be trigerred also in this case. 
<!--
To mark your pull request as work in progress please create it as a draft pull request
-->

### Your checklist for this pull request

- [X] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [ ] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Did you provide a test-case? That demonstrates feature works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled the information below
Describe your pull request below
-->
