### PR TITLE
fixed #335: Unable to create new multibranch pipeline project (Error while loading repositories from cache)

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource.java
@@ -1206,7 +1206,14 @@ public class BitbucketSCMSource extends SCMSource {
             if (context != null && !context.hasPermission(CredentialsProvider.USE_ITEM)) {
                 return new ListBoxModel(); // not permitted to try connecting with these credentials
             }
-            serverUrl = StringUtils.defaultIfBlank(serverUrl, BitbucketCloudEndpoint.SERVER_URL);
+
+            String serverUrlFallback = BitbucketCloudEndpoint.SERVER_URL;
+            // if at least one bitbucket server is configured use it instead of bitbucket cloud
+            if(BitbucketEndpointConfiguration.get().getEndpointItems().size() > 0){
+               serverUrlFallback =  BitbucketEndpointConfiguration.get().getEndpointItems().get(0).value;
+            }
+
+            serverUrl = StringUtils.defaultIfBlank(serverUrl, serverUrlFallback);
             ListBoxModel result = new ListBoxModel();
             StandardCredentials credentials = BitbucketCredentials.lookupCredentials(
                     serverUrl,


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
Fixes issue #335

### Your checklist for this pull request

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Did you provide a test-case? That demonstrates feature works or fixes the issue. (Manual testprotocol at end of comment)

<!--
Put an `x` into the [ ] to show you have filled the information below
Describe your pull request below
-->
Added a fallback to the first configured Bitbucket Server (if <0 present), before falling back to Bitbucket Cloud, as proposed in #335  by [rbywater](https://github.com/jenkinsci/bitbucket-branch-source-plugin/issues/335#issuecomment-709678249).

The implementation differs from his proposal as I calculate the default value for serverUrl in a variable before calling `serverUrl = StringUtils.defaultIfBlank(serverUrl, serverUrlFallback);` for better readability.

Tested on our infrastructure (Jenkins 2.263 and on premise Bitbucket Server 7.6.0). 

**Testprotocol**
- recreate error described in #335 with plugin version 2.9.4. 
- installing new build with proposed change (+restart jenkins)
- Test configuring branch source with 1 bitbucket server in global config -> repository dropdown filled as expected. 
- Test configuring branch source with 2 bitbucket server in global config 
- checking jenkins log and Scan Multibranch Pipeline Log -> no errors, warnings or exceptions

