### PR TITLE
[JENKINS-64125] Allow BitbucketServerEndpoint to be used as single BitbucketEndpoint

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource.java
@@ -1206,6 +1206,7 @@ public class BitbucketSCMSource extends SCMSource {
             }
             if (context != null && !context.hasPermission(CredentialsProvider.USE_ITEM)) {
                 return new ListBoxModel(); // not permitted to try connecting with these credentials
+            }
 
             //JENKINS-64125 in case the serverUrl is NOT selectable because there is only one server configured, we need to check
             // if the BitBucketEndpoint configured is "server type" in order to use this URL instead of the cloud one.

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource.java
@@ -1200,8 +1200,7 @@ public class BitbucketSCMSource extends SCMSource {
             if (repoOwner == null) {
                 return new ListBoxModel();
             }
-            if (context == null && !Jenkins.get().hasPermission(Jenkins.ADMINISTER) ||
-                    context != null && !context.hasPermission(Item.EXTENDED_READ)) {
+            if (context == null && !Jenkins.get().hasPermission(Jenkins.ADMINISTER) || context != null && !context.hasPermission(Item.EXTENDED_READ)) {
                 return new ListBoxModel(); // not supposed to be seeing this form
             }
             if (context != null && !context.hasPermission(CredentialsProvider.USE_ITEM)) {

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource.java
@@ -1200,7 +1200,8 @@ public class BitbucketSCMSource extends SCMSource {
             if (repoOwner == null) {
                 return new ListBoxModel();
             }
-            if (context == null && !Jenkins.get().hasPermission(Jenkins.ADMINISTER) || context != null && !context.hasPermission(Item.EXTENDED_READ)) {
+            if (context == null && !Jenkins.get().hasPermission(Jenkins.ADMINISTER) ||
+                    context != null && !context.hasPermission(Item.EXTENDED_READ)) {
                 return new ListBoxModel(); // not supposed to be seeing this form
             }
             if (context != null && !context.hasPermission(CredentialsProvider.USE_ITEM)) {


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-64125

If under Manage Jenkins -> Configure System -> Bitbucket we ONLY configure a SINGLE BitBucket Server - and we remove the BitBucket Cloud configuration which is by default, thus there is ONLY one server in the list. Then, if we create a multibranch job the dropdown menu which displays ALL the servers does not pop up because there is a single server to be used. However, in the source code we are assuming that in this case, we will be always reaching https://bitbucket.org instead of the serverUrl we configured under Manage Jenkins -> Configure System -> Bitbucket

<!--
To mark your pull request as work in progress please create it as a draft pull request
-->

### Your checklist for this pull request

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Did you provide a test-case? That demonstrates feature works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled the information below
Describe your pull request below
-->
