### PR TITLE
JENKINS-64183 fillCredentialsIdItems fails if Amazon ECR is installed

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/credentials/BitbucketOAuthCredentialMatcher.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/credentials/BitbucketOAuthCredentialMatcher.java
@@ -22,6 +22,10 @@ public class BitbucketOAuthCredentialMatcher implements CredentialsMatcher, Cred
         if (!(item instanceof UsernamePasswordCredentials))
             return false;
 
+        if(item.getClass().getName().equals("com.cloudbees.jenkins.plugins.amazonecr.AmazonECSRegistryCredential")) {
+            return false;
+        }
+
         try {
             UsernamePasswordCredentials usernamePasswordCredential = ((UsernamePasswordCredentials) item);
             String username = usernamePasswordCredential.getUsername();


### PR DESCRIPTION
	Do not match on instances of AmazonECSRegistryCredential

<!-- Please describe your pull request here. -->

<!--
To mark your pull request as work in progress please create it as a draft pull request
-->

### Your checklist for this pull request

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [x] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Did you provide a test-case? That demonstrates feature works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled the information below
Describe your pull request below
-->
