### PR TITLE
Only add FirstCheckoutCompletedInvisibleAction if this build is using BitbucketSCMSource

### DIFF
--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketBuildStatusNotificationsTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketBuildStatusNotificationsTest.java
@@ -28,8 +28,8 @@ import hudson.model.Action;
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
 import java.util.List;
-import org.junit.Test;
 import org.junit.Rule;
+import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.SingleFileSCM;
 

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketBuildStatusNotificationsTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketBuildStatusNotificationsTest.java
@@ -24,16 +24,19 @@
 
 package com.cloudbees.jenkins.plugins.bitbucket;
 
+import hudson.model.Action;
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasItem;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.not;
+import java.util.List;
 import org.junit.Test;
 import org.junit.Rule;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.SingleFileSCM;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.not;
 
 public class BitbucketBuildStatusNotificationsTest {
 

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketBuildStatusNotificationsTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketBuildStatusNotificationsTest.java
@@ -47,7 +47,7 @@ public class BitbucketBuildStatusNotificationsTest {
         FreeStyleProject p = r.createFreeStyleProject();
         p.setScm(new SingleFileSCM("file", "contents"));
         FreeStyleBuild b = r.buildAndAssertSuccess(p);
-        assertThat(b.getAllActions(), not(hasItem(instanceOf(FirstCheckoutCompletedInvisibleAction.class))));
+        assertThat((List<Action>)b.getAllActions(), not(hasItem(instanceOf(FirstCheckoutCompletedInvisibleAction.class))));
     }
 
 }

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketBuildStatusNotificationsTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketBuildStatusNotificationsTest.java
@@ -1,0 +1,53 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2020 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.cloudbees.jenkins.plugins.bitbucket;
+
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.not;
+import org.junit.Test;
+import org.junit.Rule;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.SingleFileSCM;
+
+public class BitbucketBuildStatusNotificationsTest {
+
+    @Rule
+    public JenkinsRule r = new JenkinsRule();
+
+    // TODO test of effectiveness of FirstCheckoutCompletedInvisibleAction (#130)
+
+    @Test
+    public void noInappropriateFirstCheckoutCompletedInvisibleAction() throws Exception {
+        FreeStyleProject p = r.createFreeStyleProject();
+        p.setScm(new SingleFileSCM("file", "contents"));
+        FreeStyleBuild b = r.buildAndAssertSuccess(p);
+        assertThat(b.getAllActions(), not(hasItem(instanceOf(FirstCheckoutCompletedInvisibleAction.class))));
+    }
+
+}


### PR DESCRIPTION
Experimentation with a plugin usage tool looking for `Run.actions` found that this plugin was attaching its action to every build even when Bitbucket was not in use. Corrects a regression in #130 by @michelzanini.

### Your checklist for this pull request

- [X] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [ ] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Did you provide a test-case? That demonstrates feature works or fixes the issue.
