### PR TITLE
Shorten a bit test names to avoid Linux encryption issues

### DIFF
--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/SSHCheckoutTraitTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/SSHCheckoutTraitTest.java
@@ -26,13 +26,13 @@ public class SSHCheckoutTraitTest {
     public static JenkinsRule j = new JenkinsRule();
 
     @Test
-    public void given__legacyConfig__when__creatingTrait__then__convertedToModern() throws Exception {
+    public void given_legacyConfig_when_creatingTrait_then_convertedToModern() throws Exception {
         assertThat(new SSHCheckoutTrait(BitbucketSCMSource.DescriptorImpl.ANONYMOUS).getCredentialsId(),
                 is(nullValue()));
     }
 
     @Test
-    public void given__sshCheckoutWithCredentials__when__decoratingGit__then__credentialsApplied() throws Exception {
+    public void given_sshCheckoutWithCredentials_when_decoratingGit_then_credentialsApplied() throws Exception {
         SSHCheckoutTrait instance = new SSHCheckoutTrait("keyId");
         BitbucketGitSCMBuilder probe =
                 new BitbucketGitSCMBuilder(new BitbucketSCMSource("example", "does-not-exist"),
@@ -43,7 +43,7 @@ public class SSHCheckoutTraitTest {
     }
 
     @Test
-    public void given__sshCheckoutWithAgentKey__when__decoratingGit__then__useAgentKeyApplied() throws Exception {
+    public void given_sshCheckoutWithAgentKey_when_decoratingGit_then_useAgentKeyApplied() throws Exception {
         SSHCheckoutTrait instance = new SSHCheckoutTrait(null);
         BitbucketGitSCMBuilder probe =
                 new BitbucketGitSCMBuilder(new BitbucketSCMSource( "example", "does-not-exist"),
@@ -54,7 +54,7 @@ public class SSHCheckoutTraitTest {
     }
 
     @Test
-    public void given__sshCheckoutWithCredentials__when__decoratingHg__then__credentialsApplied() throws Exception {
+    public void given_sshCheckoutWithCredentials_when_decoratingHg_then_credentialsApplied() throws Exception {
         SSHCheckoutTrait instance = new SSHCheckoutTrait("keyId");
         BitbucketHgSCMBuilder probe =
                 new BitbucketHgSCMBuilder(new BitbucketSCMSource( "example", "does-not-exist"),
@@ -65,7 +65,7 @@ public class SSHCheckoutTraitTest {
     }
 
     @Test
-    public void given__sshCheckoutWithAgentKey__when__decoratingHg__then__useAgentKeyApplied() throws Exception {
+    public void given_sshCheckoutWithAgentKey_when_decoratingHg_then_useAgentKeyApplied() throws Exception {
         SSHCheckoutTrait instance = new SSHCheckoutTrait(null);
         BitbucketHgSCMBuilder probe =
                 new BitbucketHgSCMBuilder(new BitbucketSCMSource( "example", "does-not-exist"),
@@ -76,7 +76,7 @@ public class SSHCheckoutTraitTest {
     }
 
     @Test
-    public void given__descriptor__when__displayingCredentials__then__contractEnforced() throws Exception {
+    public void given_descriptor_when_displayingCredentials_then_contractEnforced() throws Exception {
         final SSHCheckoutTrait.DescriptorImpl d = j.jenkins.getDescriptorByType(SSHCheckoutTrait.DescriptorImpl.class);
         final MockFolder dummy = j.createFolder("dummy");
         SecurityRealm realm = j.jenkins.getSecurityRealm();


### PR DESCRIPTION
This change is a bit weird, I know.
In some cases, the file-length maximum length on Linux can be 143 chars depending on how you encrypted your disk.
https://stackoverflow.com/questions/6571435/limit-on-file-name-length-in-bash

The problem is the following: we have a way to designate tests in our internal testing pipelines.
And `com.cloudbees.jenkins.plugins.bitbucket.SSHCheckoutTraitTest.given__sshCheckoutWithCredentials__when__decoratingHg__then__credentialsApplied.txt` is actually 144 characters-long.

So removing the double `_` is making this filename go to 139 chars, which is below the max 143.

I understand this change may look special, but I think it's still reasonable as we keep the code readability while addressing a problem.

Thanks for considering it! :-)

<!-- Please describe your pull request here. -->

<!--
To mark your pull request as work in progress please create it as a draft pull request
-->

### Your checklist for this pull request

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- ~[ ] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)~
- ~[ ] Link to relevant pull requests, esp. upstream and downstream changes~
- ~[ ] Did you provide a test-case? That demonstrates feature works or fixes the issue.~

<!--
Put an `x` into the [ ] to show you have filled the information below
Describe your pull request below
-->
