### PR TITLE
Fix source scanning on native bitbucket server push webhook events on non matching repos

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/NativeServerPushHookProcessor.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/NativeServerPushHookProcessor.java
@@ -129,6 +129,10 @@ public class NativeServerPushHookProcessor extends HookProcessor {
         @Override
         protected Map<SCMHead, SCMRevision> heads(BitbucketSCMSource source) {
             final Map<SCMHead, SCMRevision> result = new HashMap<>();
+            if (!eventMatchesRepo(source)) {
+                return result;
+            }
+
             addBranchesAndTags(source, result);
             try {
                 addPullRequests(source, result);
@@ -139,10 +143,6 @@ public class NativeServerPushHookProcessor extends HookProcessor {
         }
 
         private void addBranchesAndTags(BitbucketSCMSource src, Map<SCMHead, SCMRevision> result) {
-            if (!eventMatchesRepo(src)) {
-                return;
-            }
-
             for (final NativeServerRefsChangedEvent.Change change : getPayload()) {
                 String refType = change.getRef().getType();
 


### PR DESCRIPTION
Without that fix, branches/tags are not added on a non matching repo, but it was still going to add prs.

### Your checklist for this pull request

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did

