### PR TITLE
Avoid fetching all PRs

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource.java
@@ -808,8 +808,14 @@ public class BitbucketSCMSource extends SCMSource {
                         : buildBitbucketClient(h).getBranches();
                 sourceRevision = findCommit(h.getBranchName(), branches, listener);
             } else {
-                final List<? extends BitbucketPullRequest> pullRequests = bitbucket.getPullRequests();
-                sourceRevision = findPRCommit(h.getId(), pullRequests, listener);
+                BitbucketPullRequest pullRequest;
+                try {
+                    Integer prId = Integer.parseInt(h.getId());
+                    pullRequest = bitbucket.getPullRequestById(prId);
+                } catch (NumberFormatException e) {
+                    pullRequest = null;
+                }
+                sourceRevision = findPRCommit(h.getId(), pullRequest, listener);
             }
             if (sourceRevision == null) {
                 LOGGER.log(Level.WARNING, "No revision found in {0}/{1} for PR-{2} [{3}]",
@@ -868,28 +874,27 @@ public class BitbucketSCMSource extends SCMSource {
         return null;
     }
 
-    private BitbucketCommit findPRCommit(String prId, List<? extends BitbucketPullRequest> pullRequests, TaskListener listener) {
-        for (BitbucketPullRequest pr : pullRequests) {
-            if (prId.equals(pr.getId())) {
-                // if I use getCommit() the branch closure is trigger immediately
-                BitbucketBranch branch = pr.getSource().getBranch();
-                String hash = branch.getRawNode();
-                if (hash == null) {
-                    if (BitbucketCloudEndpoint.SERVER_URL.equals(getServerUrl())) {
-                        listener.getLogger().format("Cannot resolve the hash of the revision in PR-%s%n",
-                                prId);
-                    } else {
-                        listener.getLogger().format("Cannot resolve the hash of the revision in PR-%s. "
-                                        + "Perhaps you are using Bitbucket Server previous to 4.x%n",
-                                prId);
-                    }
-                    return null;
-                }
-                return new BranchHeadCommit(branch);
-            }
+    private BitbucketCommit findPRCommit(String prId, BitbucketPullRequest pullRequest, TaskListener listener) {
+        if (pullRequest == null) {
+            listener.getLogger().format("Cannot find the PR-%s%n", prId);
+            return null;
         }
-        listener.getLogger().format("Cannot find the PR-%s%n", prId);
-        return null;
+
+        // if I use getCommit() the branch closure is trigger immediately
+        BitbucketBranch branch = pullRequest.getSource().getBranch();
+        String hash = branch.getRawNode();
+        if (hash == null) {
+            if (BitbucketCloudEndpoint.SERVER_URL.equals(getServerUrl())) {
+                listener.getLogger().format("Cannot resolve the hash of the revision in PR-%s%n",
+                        prId);
+            } else {
+                listener.getLogger().format("Cannot resolve the hash of the revision in PR-%s. "
+                                + "Perhaps you are using Bitbucket Server previous to 4.x%n",
+                                prId);
+            }
+            return null;
+        }
+        return new BranchHeadCommit(branch);
     }
 
     @Override

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource.java
@@ -40,6 +40,7 @@ import com.cloudbees.jenkins.plugins.bitbucket.client.repository.UserRoleInRepos
 import com.cloudbees.jenkins.plugins.bitbucket.endpoints.AbstractBitbucketEndpoint;
 import com.cloudbees.jenkins.plugins.bitbucket.endpoints.BitbucketCloudEndpoint;
 import com.cloudbees.jenkins.plugins.bitbucket.endpoints.BitbucketEndpointConfiguration;
+import com.cloudbees.jenkins.plugins.bitbucket.hooks.HasPullRequests;
 import com.cloudbees.plugins.credentials.CredentialsNameProvider;
 import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.common.StandardCredentials;
@@ -550,6 +551,11 @@ public class BitbucketSCMSource extends SCMSource {
                     @Override
                     protected Iterable<BitbucketPullRequest> create() {
                         try {
+                            if (event instanceof HasPullRequests) {
+                                HasPullRequests hasPrEvent = (HasPullRequests) event;
+                                return hasPrEvent.getPullRequests(BitbucketSCMSource.this);
+                            }
+
                             return (Iterable<BitbucketPullRequest>) buildBitbucketClient().getPullRequests();
                         } catch (IOException | InterruptedException e) {
                             throw new BitbucketSCMSource.WrappedException(e);

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/BitbucketCloudApiClient.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/BitbucketCloudApiClient.java
@@ -298,16 +298,26 @@ public class BitbucketCloudApiClient implements BitbucketApi {
         } while (page.getNext() != null);
 
         // PRs with missing destination branch are invalid and should be ignored.
-        pullRequests.removeIf(pr -> pr.getSource().getRepository() == null
-                || pr.getSource().getCommit() == null
-                || pr.getDestination().getBranch() == null
-                || pr.getDestination().getCommit() == null);
+        pullRequests.removeIf(this::shouldIgnore);
 
         for (BitbucketPullRequestValue pullRequest : pullRequests) {
             setupClosureForPRBranch(pullRequest);
         }
 
         return pullRequests;
+    }
+
+    /**
+     * PRs with missing source / destination branch are invalid and should be ignored.
+     *
+     * @param pr a {@link BitbucketPullRequest}
+     * @return
+     */
+    private boolean shouldIgnore(BitbucketPullRequest pr) {
+        return pr.getSource().getRepository() == null
+            || pr.getSource().getCommit() == null
+            || pr.getDestination().getBranch() == null
+            || pr.getDestination().getCommit() == null;
     }
 
     /**

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/endpoints/BitbucketEndpointConfiguration.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/endpoints/BitbucketEndpointConfiguration.java
@@ -39,6 +39,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Locale;
+import java.util.Optional;
 import java.util.Set;
 import jenkins.model.GlobalConfiguration;
 import jenkins.model.Jenkins;
@@ -263,6 +264,21 @@ public class BitbucketEndpointConfiguration extends GlobalConfiguration {
             }
         }
         return null;
+    }
+
+    /**
+     * Checks to see if the supplied server URL is defined in the global configuration.
+     *
+     * @param serverUrl the server url to check.
+     * @param clazz
+     * @return the global configuration for the specified server url or {@code null} if not defined.
+     */
+    public synchronized Optional<AbstractBitbucketEndpoint> findEndpoint(@CheckForNull String serverUrl,
+                                                                         Class<? extends AbstractBitbucketEndpoint> clazz) {
+        return getEndpoints().stream()
+            .filter(clazz::isInstance)
+            .filter(endpoint -> normalizeServerUrl(serverUrl).equals(endpoint.getServerUrl()))
+            .findFirst();
     }
 
     /**

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/HasPullRequests.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/HasPullRequests.java
@@ -1,0 +1,11 @@
+package com.cloudbees.jenkins.plugins.bitbucket.hooks;
+
+
+import com.cloudbees.jenkins.plugins.bitbucket.BitbucketSCMSource;
+import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketPullRequest;
+
+public interface HasPullRequests {
+
+    Iterable<BitbucketPullRequest> getPullRequests(BitbucketSCMSource src) throws InterruptedException;
+
+}

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/NativeServerPullRequestHookProcessor.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/NativeServerPullRequestHookProcessor.java
@@ -155,6 +155,9 @@ public class NativeServerPullRequestHookProcessor extends HookProcessor {
 
         @Override
         public Iterable<BitbucketPullRequest> getPullRequests(BitbucketSCMSource src) throws InterruptedException {
+            if (Type.REMOVED.equals(getType())) {
+                return Collections.emptySet();
+            }
             return Collections.singleton(getPayload().getPullRequest());
         }
     }

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/NativeServerPullRequestHookProcessor.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/NativeServerPullRequestHookProcessor.java
@@ -93,7 +93,7 @@ public class NativeServerPullRequestHookProcessor extends HookProcessor {
         SCMHeadEvent.fireNow(new HeadEvent(serverUrl, eventType, pullRequestEvent, origin));
     }
 
-    private static final class HeadEvent extends NativeServerHeadEvent<NativeServerPullRequestEvent> {
+    private static final class HeadEvent extends NativeServerHeadEvent<NativeServerPullRequestEvent> implements HasPullRequests {
         private HeadEvent(String serverUrl, Type type, NativeServerPullRequestEvent payload, String origin) {
             super(serverUrl, type, payload, origin);
         }
@@ -151,6 +151,11 @@ public class NativeServerPullRequestHookProcessor extends HookProcessor {
             }
 
             return result;
+        }
+
+        @Override
+        public Iterable<BitbucketPullRequest> getPullRequests(BitbucketSCMSource src) throws InterruptedException {
+            return Collections.singleton(getPayload().getPullRequest());
         }
     }
 }

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/NativeServerPushHookProcessor.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/NativeServerPushHookProcessor.java
@@ -30,6 +30,7 @@ import com.cloudbees.jenkins.plugins.bitbucket.BranchSCMHead;
 import com.cloudbees.jenkins.plugins.bitbucket.JsonParser;
 import com.cloudbees.jenkins.plugins.bitbucket.PullRequestSCMHead;
 import com.cloudbees.jenkins.plugins.bitbucket.PullRequestSCMRevision;
+import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketPullRequest;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketRepositoryType;
 import com.cloudbees.jenkins.plugins.bitbucket.server.client.BitbucketServerAPIClient;
 import com.cloudbees.jenkins.plugins.bitbucket.server.client.pullrequest.BitbucketServerPullRequest;
@@ -42,8 +43,10 @@ import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -111,7 +114,7 @@ public class NativeServerPushHookProcessor extends HookProcessor {
         }
     }
 
-    private static final class HeadEvent extends NativeServerHeadEvent<Collection<NativeServerRefsChangedEvent.Change>> {
+    private static final class HeadEvent extends NativeServerHeadEvent<Collection<NativeServerRefsChangedEvent.Change>> implements HasPullRequests {
         private final NativeServerRefsChangedEvent refsChangedEvent;
         private final Map<CacheKey, Map<String, BitbucketServerPullRequest>> cachedPullRequests = new HashMap<>();
 
@@ -271,6 +274,17 @@ public class NativeServerPushHookProcessor extends HookProcessor {
             }
 
             return pullRequests;
+        }
+
+        @Override
+        public Collection<BitbucketPullRequest> getPullRequests(BitbucketSCMSource src) throws InterruptedException {
+            List<BitbucketPullRequest> prs = new ArrayList<>();
+            for (final NativeServerRefsChangedEvent.Change change : getPayload()) {
+                Map<String, BitbucketServerPullRequest> prsForChange = getPullRequests(src, change);
+                prs.addAll(prsForChange.values());
+            }
+
+            return prs;
         }
     }
 

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/NativeServerPushHookProcessor.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/NativeServerPushHookProcessor.java
@@ -129,6 +129,10 @@ public class NativeServerPushHookProcessor extends HookProcessor {
         @Override
         protected Map<SCMHead, SCMRevision> heads(BitbucketSCMSource source) {
             final Map<SCMHead, SCMRevision> result = new HashMap<>();
+            if (!eventMatchesRepo(source)) {
+                return result;
+            }
+
             addBranchesAndTags(source, result);
             try {
                 addPullRequests(source, result);
@@ -139,10 +143,6 @@ public class NativeServerPushHookProcessor extends HookProcessor {
         }
 
         private void addBranchesAndTags(BitbucketSCMSource src, Map<SCMHead, SCMRevision> result) {
-            if (!eventMatchesRepo(src)) {
-                return;
-            }
-
             for (final NativeServerRefsChangedEvent.Change change : getPayload()) {
                 String refType = change.getRef().getType();
 

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/PullRequestHookProcessor.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/PullRequestHookProcessor.java
@@ -51,6 +51,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import jenkins.plugins.git.AbstractGitSCMSource;
 import jenkins.scm.api.SCMEvent;
+import jenkins.scm.api.SCMEvent.Type;
 import jenkins.scm.api.SCMHead;
 import jenkins.scm.api.SCMHeadEvent;
 import jenkins.scm.api.SCMHeadObserver;
@@ -91,164 +92,180 @@ public class PullRequestHookProcessor extends HookProcessor {
                         break;
                 }
                 // assume updated as a catch-all type
-                SCMHeadEvent.fireNow(new SCMHeadEvent<BitbucketPullRequestEvent>(eventType, pull, origin) {
-                    @Override
-                    public boolean isMatch(@NonNull SCMNavigator navigator) {
-                        if (!(navigator instanceof BitbucketSCMNavigator)) {
-                            return false;
-                        }
-                        BitbucketSCMNavigator bbNav = (BitbucketSCMNavigator) navigator;
-                        if (!isServerUrlMatch(bbNav.getServerUrl())) {
-                            return false;
-                        }
-                        return bbNav.getRepoOwner().equalsIgnoreCase(getPayload().getRepository().getOwnerName());
-                    }
-
-                    private boolean isServerUrlMatch(String serverUrl) {
-                        if (serverUrl == null || BitbucketCloudEndpoint.SERVER_URL.equals(serverUrl)) {
-                            // this is a Bitbucket cloud navigator
-                            if (getPayload() instanceof BitbucketServerPullRequestEvent) {
-                                return false;
-                            }
-                        } else {
-                            // this is a Bitbucket server navigator
-                            if (getPayload() instanceof BitbucketCloudPullRequestEvent) {
-                                return false;
-                            }
-                            Map<String, List<BitbucketHref>> links = getPayload().getRepository().getLinks();
-                            if (links != null && links.containsKey("self")) {
-                                boolean matches = false;
-                                for (BitbucketHref link: links.get("self")) {
-                                    try {
-                                        URI navUri = new URI(serverUrl);
-                                        URI evtUri = new URI(link.getHref());
-                                        if (navUri.getHost().equalsIgnoreCase(evtUri.getHost())) {
-                                            matches = true;
-                                            break;
-                                        }
-                                    } catch (URISyntaxException e) {
-                                        // ignore
-                                    }
-                                }
-                                return matches;
-                            }
-                        }
-                        return true;
-                    }
-
-                    @NonNull
-                    @Override
-                    public String getSourceName() {
-                        return getPayload().getRepository().getRepositoryName();
-                    }
-
-                    @NonNull
-                    @Override
-                    public Map<SCMHead, SCMRevision> heads(@NonNull SCMSource source) {
-                        if (!(source instanceof BitbucketSCMSource)) {
-                            return Collections.emptyMap();
-                        }
-                        BitbucketSCMSource src = (BitbucketSCMSource) source;
-                        if (!isServerUrlMatch(src.getServerUrl())) {
-                            return Collections.emptyMap();
-                        }
-                        if (!src.getRepoOwner().equalsIgnoreCase(getPayload().getRepository().getOwnerName())) {
-                            return Collections.emptyMap();
-                        }
-                        if (!src.getRepository().equalsIgnoreCase(getPayload().getRepository().getRepositoryName())) {
-                            return Collections.emptyMap();
-                        }
-                        BitbucketRepositoryType type =
-                                BitbucketRepositoryType.fromString(getPayload().getRepository().getScm());
-                        if (type == null) {
-                            LOGGER.log(Level.INFO, "Received event for unknown repository type: {0}",
-                                    getPayload().getRepository().getScm());
-                            return Collections.emptyMap();
-                        }
-                        BitbucketSCMSourceContext ctx = new BitbucketSCMSourceContext(null, SCMHeadObserver.none())
-                                .withTraits(src.getTraits());
-                        if (!ctx.wantPRs()) {
-                            // doesn't want PRs, let the push event handle origin branches
-                            return Collections.emptyMap();
-                        }
-                        BitbucketPullRequest pull = getPayload().getPullRequest();
-                        String pullRepoOwner = pull.getSource().getRepository().getOwnerName();
-                        String pullRepository = pull.getSource().getRepository().getRepositoryName();
-                        SCMHeadOrigin headOrigin = src.originOf(pullRepoOwner, pullRepository);
-                        Set<ChangeRequestCheckoutStrategy> strategies =
-                                headOrigin == SCMHeadOrigin.DEFAULT
-                                        ? ctx.originPRStrategies()
-                                        : ctx.forkPRStrategies();
-                        Map<SCMHead, SCMRevision> result = new HashMap<>(strategies.size());
-                        for (ChangeRequestCheckoutStrategy strategy : strategies) {
-                            String branchName = "PR-" + pull.getId();
-                            if (strategies.size() > 1) {
-                                branchName = branchName + "-" + strategy.name().toLowerCase(Locale.ENGLISH);
-                            }
-                            String originalBranchName = pull.getSource().getBranch().getName();
-                            PullRequestSCMHead head;
-                            if (instanceType == BitbucketType.CLOUD) {
-                                head = new PullRequestSCMHead(
-                                        branchName,
-                                        pullRepoOwner,
-                                        pullRepository,
-                                        type,
-                                        originalBranchName,
-                                        pull,
-                                        headOrigin,
-                                        strategy
-                                );
-                            } else {
-                                head = new PullRequestSCMHead(
-                                        branchName,
-                                        src.getRepoOwner(),
-                                        src.getRepository(),
-                                        type,
-                                        originalBranchName,
-                                        pull,
-                                        headOrigin,
-                                        strategy
-                                );
-                            }
-                            if (hookEvent == PULL_REQUEST_DECLINED || hookEvent == PULL_REQUEST_MERGED) {
-                                // special case for repo being deleted
-                                result.put(head, null);
-                            } else {
-                                String targetHash =
-                                        pull.getDestination().getCommit().getHash();
-                                String pullHash = pull.getSource().getCommit().getHash();
-                                switch (type) {
-                                    case GIT:
-                                        result.put(head, new PullRequestSCMRevision<>(
-                                                        head,
-                                                        new AbstractGitSCMSource.SCMRevisionImpl(
-                                                                head.getTarget(),
-                                                                targetHash
-                                                        ),
-                                                        new AbstractGitSCMSource.SCMRevisionImpl(
-                                                                head,
-                                                                pullHash
-                                                        )
-                                                )
-                                        );
-                                        break;
-                                    default:
-                                        LOGGER.log(Level.INFO, "Received event for unknown repository type: {0}", type);
-                                        break;
-                                }
-                            }
-                        }
-                        return result;
-                    }
-
-                    @Override
-                    public boolean isMatch(@NonNull SCM scm) {
-                        // TODO
-                        return false;
-                    }
-                });
+                SCMHeadEvent.fireNow(new HeadEvent(eventType, pull, origin, hookEvent, instanceType));
             }
         }
     }
 
+    private static final class HeadEvent extends SCMHeadEvent<BitbucketPullRequestEvent> implements HasPullRequests{
+        private final HookEventType hookEvent;
+        private final BitbucketType instanceType;
+
+        private HeadEvent(Type type, BitbucketPullRequestEvent payload, String origin, HookEventType hookEvent,
+                BitbucketType instanceType) {
+            super(type, payload, origin);
+            this.hookEvent = hookEvent;
+            this.instanceType = instanceType;
+        }
+
+        @Override
+        public boolean isMatch(@NonNull SCMNavigator navigator) {
+            if (!(navigator instanceof BitbucketSCMNavigator)) {
+                return false;
+            }
+            BitbucketSCMNavigator bbNav = (BitbucketSCMNavigator) navigator;
+            if (!isServerUrlMatch(bbNav.getServerUrl())) {
+                return false;
+            }
+            return bbNav.getRepoOwner().equalsIgnoreCase(getPayload().getRepository().getOwnerName());
+        }
+
+        private boolean isServerUrlMatch(String serverUrl) {
+            if (serverUrl == null || BitbucketCloudEndpoint.SERVER_URL.equals(serverUrl)) {
+                // this is a Bitbucket cloud navigator
+                if (getPayload() instanceof BitbucketServerPullRequestEvent) {
+                    return false;
+                }
+            } else {
+                // this is a Bitbucket server navigator
+                if (getPayload() instanceof BitbucketCloudPullRequestEvent) {
+                    return false;
+                }
+                Map<String, List<BitbucketHref>> links = getPayload().getRepository().getLinks();
+                if (links != null && links.containsKey("self")) {
+                    boolean matches = false;
+                    for (BitbucketHref link: links.get("self")) {
+                        try {
+                            URI navUri = new URI(serverUrl);
+                            URI evtUri = new URI(link.getHref());
+                            if (navUri.getHost().equalsIgnoreCase(evtUri.getHost())) {
+                                matches = true;
+                                break;
+                            }
+                        } catch (URISyntaxException e) {
+                            // ignore
+                        }
+                    }
+                    return matches;
+                }
+            }
+            return true;
+        }
+
+        @NonNull
+        @Override
+        public String getSourceName() {
+            return getPayload().getRepository().getRepositoryName();
+        }
+
+        @NonNull
+        @Override
+        public Map<SCMHead, SCMRevision> heads(@NonNull SCMSource source) {
+            if (!(source instanceof BitbucketSCMSource)) {
+                return Collections.emptyMap();
+            }
+            BitbucketSCMSource src = (BitbucketSCMSource) source;
+            if (!isServerUrlMatch(src.getServerUrl())) {
+                return Collections.emptyMap();
+            }
+            if (!src.getRepoOwner().equalsIgnoreCase(getPayload().getRepository().getOwnerName())) {
+                return Collections.emptyMap();
+            }
+            if (!src.getRepository().equalsIgnoreCase(getPayload().getRepository().getRepositoryName())) {
+                return Collections.emptyMap();
+            }
+            BitbucketRepositoryType type =
+                    BitbucketRepositoryType.fromString(getPayload().getRepository().getScm());
+            if (type == null) {
+                LOGGER.log(Level.INFO, "Received event for unknown repository type: {0}",
+                        getPayload().getRepository().getScm());
+                return Collections.emptyMap();
+            }
+            BitbucketSCMSourceContext ctx = new BitbucketSCMSourceContext(null, SCMHeadObserver.none())
+                    .withTraits(src.getTraits());
+            if (!ctx.wantPRs()) {
+                // doesn't want PRs, let the push event handle origin branches
+                return Collections.emptyMap();
+            }
+            BitbucketPullRequest pull = getPayload().getPullRequest();
+            String pullRepoOwner = pull.getSource().getRepository().getOwnerName();
+            String pullRepository = pull.getSource().getRepository().getRepositoryName();
+            SCMHeadOrigin headOrigin = src.originOf(pullRepoOwner, pullRepository);
+            Set<ChangeRequestCheckoutStrategy> strategies =
+                    headOrigin == SCMHeadOrigin.DEFAULT
+                            ? ctx.originPRStrategies()
+                            : ctx.forkPRStrategies();
+            Map<SCMHead, SCMRevision> result = new HashMap<>(strategies.size());
+            for (ChangeRequestCheckoutStrategy strategy : strategies) {
+                String branchName = "PR-" + pull.getId();
+                if (strategies.size() > 1) {
+                    branchName = branchName + "-" + strategy.name().toLowerCase(Locale.ENGLISH);
+                }
+                String originalBranchName = pull.getSource().getBranch().getName();
+                PullRequestSCMHead head;
+                if (instanceType == BitbucketType.CLOUD) {
+                    head = new PullRequestSCMHead(
+                            branchName,
+                            pullRepoOwner,
+                            pullRepository,
+                            type,
+                            originalBranchName,
+                            pull,
+                            headOrigin,
+                            strategy
+                    );
+                } else {
+                    head = new PullRequestSCMHead(
+                            branchName,
+                            src.getRepoOwner(),
+                            src.getRepository(),
+                            type,
+                            originalBranchName,
+                            pull,
+                            headOrigin,
+                            strategy
+                    );
+                }
+                if (hookEvent == PULL_REQUEST_DECLINED || hookEvent == PULL_REQUEST_MERGED) {
+                    // special case for repo being deleted
+                    result.put(head, null);
+                } else {
+                    String targetHash =
+                            pull.getDestination().getCommit().getHash();
+                    String pullHash = pull.getSource().getCommit().getHash();
+                    switch (type) {
+                        case GIT:
+                            result.put(head, new PullRequestSCMRevision<>(
+                                            head,
+                                            new AbstractGitSCMSource.SCMRevisionImpl(
+                                                    head.getTarget(),
+                                                    targetHash
+                                            ),
+                                            new AbstractGitSCMSource.SCMRevisionImpl(
+                                                    head,
+                                                    pullHash
+                                            )
+                                    )
+                            );
+                            break;
+                        default:
+                            LOGGER.log(Level.INFO, "Received event for unknown repository type: {0}", type);
+                            break;
+                    }
+                }
+            }
+            return result;
+        }
+
+        @Override
+        public boolean isMatch(@NonNull SCM scm) {
+            // TODO
+            return false;
+        }
+
+        @Override
+        public Iterable<BitbucketPullRequest> getPullRequests(BitbucketSCMSource src) throws InterruptedException {
+            return Collections.singleton(getPayload().getPullRequest());
+        }
+    }
 }

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/PullRequestHookProcessor.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/PullRequestHookProcessor.java
@@ -265,6 +265,9 @@ public class PullRequestHookProcessor extends HookProcessor {
 
         @Override
         public Iterable<BitbucketPullRequest> getPullRequests(BitbucketSCMSource src) throws InterruptedException {
+            if (hookEvent == PULL_REQUEST_DECLINED || hookEvent == PULL_REQUEST_MERGED) {
+                return Collections.emptyList();
+            }
             return Collections.singleton(getPayload().getPullRequest());
         }
     }

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/BitbucketServerAPIClient.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/BitbucketServerAPIClient.java
@@ -327,45 +327,57 @@ public class BitbucketServerAPIClient implements BitbucketApi {
     }
 
     private List<BitbucketServerPullRequest> getPullRequests(UriTemplate template)
-            throws IOException, InterruptedException {
+        throws IOException, InterruptedException {
         List<BitbucketServerPullRequest> pullRequests = getResources(template, BitbucketServerPullRequests.class);
 
-        // PRs with missing destination branch are invalid and should be ignored.
-        pullRequests.removeIf(pr -> pr.getSource().getRepository() == null
-                || pr.getSource().getBranch() == null
-                || pr.getDestination().getBranch() == null);
+        pullRequests.removeIf(this::shouldIgnore);
 
-        AbstractBitbucketEndpoint endpointConfig = BitbucketEndpointConfiguration.get().findEndpoint(baseURL);
-        final BitbucketServerEndpoint endpoint = endpointConfig instanceof BitbucketServerEndpoint ?
-            (BitbucketServerEndpoint) endpointConfig : null;
+        BitbucketServerEndpoint endpoint = (BitbucketServerEndpoint) BitbucketEndpointConfiguration.get().
+            findEndpoint(this.baseURL, BitbucketServerEndpoint.class).orElse(null);
 
         for (BitbucketServerPullRequest pullRequest : pullRequests) {
-            // set commit closure to make commit informations available when need, in a similar way to when request branches
-            setupClosureForPRBranch(pullRequest);
-
-            if (endpoint != null) {
-                // This is required for Bitbucket Server to update the refs/pull-requests/* references
-                // See https://community.atlassian.com/t5/Bitbucket-questions/Change-pull-request-refs-after-Commit-instead-of-after-Approval/qaq-p/194702#M6829
-                if (endpoint.isCallCanMerge()) {
-                    try {
-                        pullRequest.setCanMerge(getPullRequestCanMergeById(pullRequest.getId()));
-                    } catch (BitbucketRequestException e) {
-                        // see JENKINS-65718 https://docs.atlassian.com/bitbucket-server/rest/7.2.1/bitbucket-rest.html#errors-and-validation
-                        // in this case we just say cannot merge this one
-                        if(e.getHttpCode()==409){
-                            pullRequest.setCanMerge(false);
-                        } else {
-                            throw e;
-                        }
-                    }
-                }
-                if (endpoint.isCallChanges() && BitbucketServerVersion.VERSION_7.equals(endpoint.getServerVersion())) {
-                    callPullRequestChangesById(pullRequest.getId());
-                }
-            }
+            setupPullRequest(pullRequest, endpoint);
         }
 
         return pullRequests;
+    }
+
+    private void setupPullRequest(BitbucketServerPullRequest pullRequest, BitbucketServerEndpoint endpoint) throws IOException {
+        // set commit closure to make commit information available when need, in a similar way to when request branches
+        setupClosureForPRBranch(pullRequest);
+
+        if (endpoint != null) {
+            // This is required for Bitbucket Server to update the refs/pull-requests/* references
+            // See https://community.atlassian.com/t5/Bitbucket-questions/Change-pull-request-refs-after-Commit-instead-of-after-Approval/qaq-p/194702#M6829
+            if (endpoint.isCallCanMerge()) {
+                try {
+                    pullRequest.setCanMerge(getPullRequestCanMergeById(pullRequest.getId()));
+                } catch (BitbucketRequestException e) {
+                    // see JENKINS-65718 https://docs.atlassian.com/bitbucket-server/rest/7.2.1/bitbucket-rest.html#errors-and-validation
+                    // in this case we just say cannot merge this one
+                    if(e.getHttpCode()==409){
+                        pullRequest.setCanMerge(false);
+                    } else {
+                        throw e;
+                    }
+                }
+            }
+            if (endpoint.isCallChanges() && BitbucketServerVersion.VERSION_7.equals(endpoint.getServerVersion())) {
+                callPullRequestChangesById(pullRequest.getId());
+            }
+        }
+    }
+
+    /**
+     * PRs with missing source / destination branch are invalid and should be ignored.
+     *
+     * @param pullRequest a {@link BitbucketPullRequest}
+     * @return
+     */
+    private boolean shouldIgnore(BitbucketPullRequest pullRequest) {
+        return pullRequest.getSource().getRepository() == null
+            || pullRequest.getSource().getBranch() == null
+            || pullRequest.getDestination().getBranch() == null;
     }
 
     /**
@@ -441,9 +453,9 @@ public class BitbucketServerAPIClient implements BitbucketApi {
         String response = getRequest(url);
         try {
             BitbucketServerPullRequest pr = JsonParser.toJava(response, BitbucketServerPullRequest.class);
-
             setupClosureForPRBranch(pr);
-
+            setupPullRequest(pr, (BitbucketServerEndpoint) BitbucketEndpointConfiguration.get().
+                findEndpoint(this.baseURL, BitbucketServerEndpoint.class).orElse(null));
             return pr;
         } catch (IOException e) {
             throw new IOException("I/O error when accessing URL: " + url, e);

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/BitbucketServerAPIClient.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/BitbucketServerAPIClient.java
@@ -38,7 +38,6 @@ import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketWebHook;
 import com.cloudbees.jenkins.plugins.bitbucket.api.credentials.BitbucketUsernamePasswordAuthenticator;
 import com.cloudbees.jenkins.plugins.bitbucket.avatars.AvatarCacheSource.AvatarImage;
 import com.cloudbees.jenkins.plugins.bitbucket.client.repository.UserRoleInRepository;
-import com.cloudbees.jenkins.plugins.bitbucket.endpoints.AbstractBitbucketEndpoint;
 import com.cloudbees.jenkins.plugins.bitbucket.endpoints.BitbucketEndpointConfiguration;
 import com.cloudbees.jenkins.plugins.bitbucket.endpoints.BitbucketServerEndpoint;
 import com.cloudbees.jenkins.plugins.bitbucket.filesystem.BitbucketSCMFile;

--- a/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/server/payload/1.0-projects-amuniz-repos-test-repos-pull-requests-1.json
+++ b/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/server/payload/1.0-projects-amuniz-repos-test-repos-pull-requests-1.json
@@ -1,126 +1,126 @@
 {
-    "id": 1,
-    "version": 0,
-    "title": "Release/release 1",
-    "description": "* Add license\r\n* [CI] Release version 1.0.0",
-    "state": "OPEN",
-    "open": true,
-    "closed": false,
-    "createdDate": 1537885911512,
-    "updatedDate": 1537885911512,
-    "fromRef": {
-      "id": "refs/heads/release/release-1",
-      "displayId": "release/release-1",
-      "latestCommit": "bf0e8b7962c024026ad01ae09d3a11732e26c0d4",
-      "repository": {
-        "slug": "test-repos",
+  "id": 1,
+  "version": 0,
+  "title": "Release/release 1",
+  "description": "* Add license\r\n* [CI] Release version 1.0.0",
+  "state": "OPEN",
+  "open": true,
+  "closed": false,
+  "createdDate": 1537885911512,
+  "updatedDate": 1537885911512,
+  "fromRef": {
+    "id": "refs/heads/release/release-1",
+    "displayId": "release/release-1",
+    "latestCommit": "bf0e8b7962c024026ad01ae09d3a11732e26c0d4",
+    "repository": {
+      "slug": "test-repos",
+      "id": 1,
+      "name": "test-repos",
+      "scmId": "git",
+      "state": "AVAILABLE",
+      "statusMessage": "Available",
+      "forkable": true,
+      "project": {
+        "key": "AMUNIZ",
         "id": 1,
-        "name": "test-repos",
-        "scmId": "git",
-        "state": "AVAILABLE",
-        "statusMessage": "Available",
-        "forkable": true,
-        "project": {
-          "key": "AMUNIZ",
-          "id": 1,
-          "name": "prj",
-          "description": "This is a test repo",
-          "public": true,
-          "type": "NORMAL",
-          "links": {
-            "self": [{
-              "href": "http://localhost:7990/projects/AMUNIZ"
-            }]
-          }
-        },
-        "public": false,
-        "links": {
-          "clone": [{
-            "href": "ssh://git@localhost:7999/amuniz/test-repos.git",
-            "name": "ssh"
-          }, {
-            "href": "http://localhost:7990/scm/amuniz/test-repos.git",
-            "name": "http"
-          }],
-          "self": [{
-            "href": "http://localhost:7990/projects/AMUNIZ/repos/test-repos/browse"
-          }]
-        }
-      }
-    },
-    "toRef": {
-      "id": "refs/heads/master",
-      "displayId": "master",
-      "latestCommit": "bf4f4ce8a3a8d5c7dbfe7d609973a81a6c6664cf",
-      "repository": {
-        "slug": "test-repos",
-        "id": 1,
-        "name": "test-repos",
-        "scmId": "git",
-        "state": "AVAILABLE",
-        "statusMessage": "Available",
-        "forkable": true,
-        "project": {
-          "key": "AMUNIZ",
-          "id": 1,
-          "name": "prj",
-          "description": "This is a test repo",
-          "public": true,
-          "type": "NORMAL",
-          "links": {
-            "self": [{
-              "href": "http://localhost:7990/projects/AMUNIZ"
-            }]
-          }
-        },
-        "public": false,
-        "links": {
-          "clone": [{
-            "href": "ssh://git@localhost:7999/amuniz/test-repos.git",
-            "name": "ssh"
-          }, {
-            "href": "http://localhost:7990/scm/amuniz/test-repos.git",
-            "name": "http"
-          }],
-          "self": [{
-            "href": "http://localhost:7990/projects/AMUNIZ/repos/test-repos/browse"
-          }]
-        }
-      }
-    },
-    "locked": false,
-    "author": {
-      "user": {
-        "name": "amuniz",
-        "emailAddress": "amuniz@acme.com",
-        "id": 2,
-        "displayName": "Antonio Muniz",
-        "active": true,
-        "slug": "amuniz",
+        "name": "prj",
+        "description": "This is a test repo",
+        "public": true,
         "type": "NORMAL",
         "links": {
           "self": [{
-            "href": "http://localhost:7990/users/amuniz"
+            "href": "http://localhost:7990/projects/AMUNIZ"
           }]
         }
       },
-      "role": "AUTHOR",
-      "approved": false,
-      "status": "UNAPPROVED"
-    },
-    "reviewers": [],
-    "participants": [],
-    "properties": {
-      "mergeResult": {
-        "outcome": "CLEAN",
-        "current": true
-      },
-      "resolvedTaskCount": 0,
-      "openTaskCount": 0
-    },
-    "links": {
-      "self": [{
-        "href": "http://localhost:7990/projects/AMUNIZ/repos/test-repos/pull-requests/1"
-      }]
+      "public": false,
+      "links": {
+        "clone": [{
+          "href": "ssh://git@localhost:7999/amuniz/test-repos.git",
+          "name": "ssh"
+        }, {
+          "href": "http://localhost:7990/scm/amuniz/test-repos.git",
+          "name": "http"
+        }],
+        "self": [{
+          "href": "http://localhost:7990/projects/AMUNIZ/repos/test-repos/browse"
+        }]
+      }
     }
+  },
+  "toRef": {
+    "id": "refs/heads/master",
+    "displayId": "master",
+    "latestCommit": "bf4f4ce8a3a8d5c7dbfe7d609973a81a6c6664cf",
+    "repository": {
+      "slug": "test-repos",
+      "id": 1,
+      "name": "test-repos",
+      "scmId": "git",
+      "state": "AVAILABLE",
+      "statusMessage": "Available",
+      "forkable": true,
+      "project": {
+        "key": "AMUNIZ",
+        "id": 1,
+        "name": "prj",
+        "description": "This is a test repo",
+        "public": true,
+        "type": "NORMAL",
+        "links": {
+          "self": [{
+            "href": "http://localhost:7990/projects/AMUNIZ"
+          }]
+        }
+      },
+      "public": false,
+      "links": {
+        "clone": [{
+          "href": "ssh://git@localhost:7999/amuniz/test-repos.git",
+          "name": "ssh"
+        }, {
+          "href": "http://localhost:7990/scm/amuniz/test-repos.git",
+          "name": "http"
+        }],
+        "self": [{
+          "href": "http://localhost:7990/projects/AMUNIZ/repos/test-repos/browse"
+        }]
+      }
+    }
+  },
+  "locked": false,
+  "author": {
+    "user": {
+      "name": "amuniz",
+      "emailAddress": "amuniz@acme.com",
+      "id": 2,
+      "displayName": "Antonio Muniz",
+      "active": true,
+      "slug": "amuniz",
+      "type": "NORMAL",
+      "links": {
+        "self": [{
+          "href": "http://localhost:7990/users/amuniz"
+        }]
+      }
+    },
+    "role": "AUTHOR",
+    "approved": false,
+    "status": "UNAPPROVED"
+  },
+  "reviewers": [],
+  "participants": [],
+  "properties": {
+    "mergeResult": {
+      "outcome": "CLEAN",
+      "current": true
+    },
+    "resolvedTaskCount": 0,
+    "openTaskCount": 0
+  },
+  "links": {
+    "self": [{
+      "href": "http://localhost:7990/projects/AMUNIZ/repos/test-repos/pull-requests/1"
+    }]
+  }
 }

--- a/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/server/payload/1.0-projects-amuniz-repos-test-repos-pull-requests-1.json
+++ b/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/server/payload/1.0-projects-amuniz-repos-test-repos-pull-requests-1.json
@@ -1,0 +1,126 @@
+{
+    "id": 1,
+    "version": 0,
+    "title": "Release/release 1",
+    "description": "* Add license\r\n* [CI] Release version 1.0.0",
+    "state": "OPEN",
+    "open": true,
+    "closed": false,
+    "createdDate": 1537885911512,
+    "updatedDate": 1537885911512,
+    "fromRef": {
+      "id": "refs/heads/release/release-1",
+      "displayId": "release/release-1",
+      "latestCommit": "bf0e8b7962c024026ad01ae09d3a11732e26c0d4",
+      "repository": {
+        "slug": "test-repos",
+        "id": 1,
+        "name": "test-repos",
+        "scmId": "git",
+        "state": "AVAILABLE",
+        "statusMessage": "Available",
+        "forkable": true,
+        "project": {
+          "key": "AMUNIZ",
+          "id": 1,
+          "name": "prj",
+          "description": "This is a test repo",
+          "public": true,
+          "type": "NORMAL",
+          "links": {
+            "self": [{
+              "href": "http://localhost:7990/projects/AMUNIZ"
+            }]
+          }
+        },
+        "public": false,
+        "links": {
+          "clone": [{
+            "href": "ssh://git@localhost:7999/amuniz/test-repos.git",
+            "name": "ssh"
+          }, {
+            "href": "http://localhost:7990/scm/amuniz/test-repos.git",
+            "name": "http"
+          }],
+          "self": [{
+            "href": "http://localhost:7990/projects/AMUNIZ/repos/test-repos/browse"
+          }]
+        }
+      }
+    },
+    "toRef": {
+      "id": "refs/heads/master",
+      "displayId": "master",
+      "latestCommit": "bf4f4ce8a3a8d5c7dbfe7d609973a81a6c6664cf",
+      "repository": {
+        "slug": "test-repos",
+        "id": 1,
+        "name": "test-repos",
+        "scmId": "git",
+        "state": "AVAILABLE",
+        "statusMessage": "Available",
+        "forkable": true,
+        "project": {
+          "key": "AMUNIZ",
+          "id": 1,
+          "name": "prj",
+          "description": "This is a test repo",
+          "public": true,
+          "type": "NORMAL",
+          "links": {
+            "self": [{
+              "href": "http://localhost:7990/projects/AMUNIZ"
+            }]
+          }
+        },
+        "public": false,
+        "links": {
+          "clone": [{
+            "href": "ssh://git@localhost:7999/amuniz/test-repos.git",
+            "name": "ssh"
+          }, {
+            "href": "http://localhost:7990/scm/amuniz/test-repos.git",
+            "name": "http"
+          }],
+          "self": [{
+            "href": "http://localhost:7990/projects/AMUNIZ/repos/test-repos/browse"
+          }]
+        }
+      }
+    },
+    "locked": false,
+    "author": {
+      "user": {
+        "name": "amuniz",
+        "emailAddress": "amuniz@acme.com",
+        "id": 2,
+        "displayName": "Antonio Muniz",
+        "active": true,
+        "slug": "amuniz",
+        "type": "NORMAL",
+        "links": {
+          "self": [{
+            "href": "http://localhost:7990/users/amuniz"
+          }]
+        }
+      },
+      "role": "AUTHOR",
+      "approved": false,
+      "status": "UNAPPROVED"
+    },
+    "reviewers": [],
+    "participants": [],
+    "properties": {
+      "mergeResult": {
+        "outcome": "CLEAN",
+        "current": true
+      },
+      "resolvedTaskCount": 0,
+      "openTaskCount": 0
+    },
+    "links": {
+      "self": [{
+        "href": "http://localhost:7990/projects/AMUNIZ/repos/test-repos/pull-requests/1"
+      }]
+    }
+}

--- a/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/server/payload/1.0-projects-amuniz-repos-test-repos-pull-requests-2.json
+++ b/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/server/payload/1.0-projects-amuniz-repos-test-repos-pull-requests-2.json
@@ -1,0 +1,161 @@
+{
+    "id": 2,
+    "version": 0,
+    "title": "Add one message more",
+    "description": "test from forked repo",
+    "state": "OPEN",
+    "open": true,
+    "closed": false,
+    "createdDate": 1541687143031,
+    "updatedDate": 1541687143031,
+    "fromRef": {
+      "id": "refs/heads/feature/BB-2",
+      "displayId": "feature/BB-2",
+      "latestCommit": "046d9a3c1532acf4cf08fe93235c00e4d673c1d2",
+      "repository": {
+        "slug": "test-repos-fork",
+        "id": 12,
+        "name": "test-repos-fork",
+        "scmId": "git",
+        "state": "AVAILABLE",
+        "statusMessage": "Available",
+        "forkable": true,
+        "origin": {
+          "slug": "test-repos",
+          "id": 1,
+          "name": "test-repos",
+          "scmId": "git",
+          "state": "AVAILABLE",
+          "statusMessage": "Available",
+          "forkable": true,
+          "project": {
+            "key": "AMUNIZ",
+            "id": 1,
+            "name": "prj",
+            "description": "This is a test repo",
+            "public": true,
+            "type": "NORMAL",
+            "links": {
+              "self": [{
+                "href": "http://localhost:7990/projects/AMUNIZ"
+              }]
+            }
+          },
+          "public": false,
+          "links": {
+            "clone": [{
+              "href": "ssh://git@localhost:7999/amuniz/test-repos.git",
+              "name": "ssh"
+            }, {
+              "href": "http://localhost:7990/scm/amuniz/test-repos.git",
+              "name": "http"
+            }],
+            "self": [{
+              "href": "http://localhost:7990/projects/AMUNIZ/repos/test-repos/browse"
+            }]
+          }
+        },
+        "project": {
+          "key": "AMUNIZ",
+          "id": 1,
+          "name": "prj",
+          "description": "This is a test repo",
+          "public": true,
+          "type": "NORMAL",
+          "links": {
+            "self": [{
+              "href": "http://localhost:7990/projects/AMUNIZ"
+            }]
+          }
+        },
+        "public": false,
+        "links": {
+          "clone": [{
+            "href": "http://localhost:7990/scm/amuniz/test-repos-fork.git",
+            "name": "http"
+          }, {
+            "href": "ssh://git@localhost:7999/amuniz/test-repos-fork.git",
+            "name": "ssh"
+          }],
+          "self": [{
+            "href": "http://localhost:7990/projects/AMUNIZ/repos/test-repos-fork/browse"
+          }]
+        }
+      }
+    },
+    "toRef": {
+      "id": "refs/heads/master",
+      "displayId": "master",
+      "latestCommit": "bf4f4ce8a3a8d5c7dbfe7d609973a81a6c6664cf",
+      "repository": {
+        "slug": "test-repos",
+        "id": 1,
+        "name": "test-repos",
+        "scmId": "git",
+        "state": "AVAILABLE",
+        "statusMessage": "Available",
+        "forkable": true,
+        "project": {
+          "key": "AMUNIZ",
+          "id": 1,
+          "name": "prj",
+          "description": "This is a test repo",
+          "public": true,
+          "type": "NORMAL",
+          "links": {
+            "self": [{
+              "href": "http://localhost:7990/projects/AMUNIZ"
+            }]
+          }
+        },
+        "public": false,
+        "links": {
+          "clone": [{
+            "href": "ssh://git@localhost:7999/amuniz/test-repos.git",
+            "name": "ssh"
+          }, {
+            "href": "http://localhost:7990/scm/amuniz/test-repos.git",
+            "name": "http"
+          }],
+          "self": [{
+            "href": "http://localhost:7990/projects/AMUNIZ/repos/test-repos/browse"
+          }]
+        }
+      }
+    },
+    "locked": false,
+    "author": {
+      "user": {
+        "name": "admin",
+        "emailAddress": "kaxixus@cmail.club",
+        "id": 1,
+        "displayName": "admin",
+        "active": true,
+        "slug": "admin",
+        "type": "NORMAL",
+        "links": {
+          "self": [{
+            "href": "http://localhost:7990/users/admin"
+          }]
+        }
+      },
+      "role": "AUTHOR",
+      "approved": false,
+      "status": "UNAPPROVED"
+    },
+    "reviewers": [],
+    "participants": [],
+    "properties": {
+      "mergeResult": {
+        "outcome": "CLEAN",
+        "current": true
+      },
+      "resolvedTaskCount": 0,
+      "openTaskCount": 0
+    },
+    "links": {
+      "self": [{
+        "href": "http://localhost:7990/projects/AMUNIZ/repos/test-repos/pull-requests/2"
+      }]
+    }
+}

--- a/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/server/payload/1.0-projects-amuniz-repos-test-repos-pull-requests-2.json
+++ b/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/server/payload/1.0-projects-amuniz-repos-test-repos-pull-requests-2.json
@@ -1,93 +1,26 @@
 {
-    "id": 2,
-    "version": 0,
-    "title": "Add one message more",
-    "description": "test from forked repo",
-    "state": "OPEN",
-    "open": true,
-    "closed": false,
-    "createdDate": 1541687143031,
-    "updatedDate": 1541687143031,
-    "fromRef": {
-      "id": "refs/heads/feature/BB-2",
-      "displayId": "feature/BB-2",
-      "latestCommit": "046d9a3c1532acf4cf08fe93235c00e4d673c1d2",
-      "repository": {
-        "slug": "test-repos-fork",
-        "id": 12,
-        "name": "test-repos-fork",
-        "scmId": "git",
-        "state": "AVAILABLE",
-        "statusMessage": "Available",
-        "forkable": true,
-        "origin": {
-          "slug": "test-repos",
-          "id": 1,
-          "name": "test-repos",
-          "scmId": "git",
-          "state": "AVAILABLE",
-          "statusMessage": "Available",
-          "forkable": true,
-          "project": {
-            "key": "AMUNIZ",
-            "id": 1,
-            "name": "prj",
-            "description": "This is a test repo",
-            "public": true,
-            "type": "NORMAL",
-            "links": {
-              "self": [{
-                "href": "http://localhost:7990/projects/AMUNIZ"
-              }]
-            }
-          },
-          "public": false,
-          "links": {
-            "clone": [{
-              "href": "ssh://git@localhost:7999/amuniz/test-repos.git",
-              "name": "ssh"
-            }, {
-              "href": "http://localhost:7990/scm/amuniz/test-repos.git",
-              "name": "http"
-            }],
-            "self": [{
-              "href": "http://localhost:7990/projects/AMUNIZ/repos/test-repos/browse"
-            }]
-          }
-        },
-        "project": {
-          "key": "AMUNIZ",
-          "id": 1,
-          "name": "prj",
-          "description": "This is a test repo",
-          "public": true,
-          "type": "NORMAL",
-          "links": {
-            "self": [{
-              "href": "http://localhost:7990/projects/AMUNIZ"
-            }]
-          }
-        },
-        "public": false,
-        "links": {
-          "clone": [{
-            "href": "http://localhost:7990/scm/amuniz/test-repos-fork.git",
-            "name": "http"
-          }, {
-            "href": "ssh://git@localhost:7999/amuniz/test-repos-fork.git",
-            "name": "ssh"
-          }],
-          "self": [{
-            "href": "http://localhost:7990/projects/AMUNIZ/repos/test-repos-fork/browse"
-          }]
-        }
-      }
-    },
-    "toRef": {
-      "id": "refs/heads/master",
-      "displayId": "master",
-      "latestCommit": "bf4f4ce8a3a8d5c7dbfe7d609973a81a6c6664cf",
-      "repository": {
+  "id": 2,
+  "version": 0,
+  "title": "Add one message more",
+  "description": "test from forked repo",
+  "state": "OPEN",
+  "open": true,
+  "closed": false,
+  "createdDate": 1541687143031,
+  "updatedDate": 1541687143031,
+  "fromRef": {
+    "id": "refs/heads/feature/BB-2",
+    "displayId": "feature/BB-2",
+    "latestCommit": "046d9a3c1532acf4cf08fe93235c00e4d673c1d2",
+    "repository": {
+      "slug": "test-repos-fork",
+      "id": 12,
+      "name": "test-repos-fork",
+      "scmId": "git",
+      "state": "AVAILABLE",
+      "statusMessage": "Available",
+      "forkable": true,
+      "origin": {
         "slug": "test-repos",
         "id": 1,
         "name": "test-repos",
@@ -121,41 +54,108 @@
             "href": "http://localhost:7990/projects/AMUNIZ/repos/test-repos/browse"
           }]
         }
-      }
-    },
-    "locked": false,
-    "author": {
-      "user": {
-        "name": "admin",
-        "emailAddress": "kaxixus@cmail.club",
+      },
+      "project": {
+        "key": "AMUNIZ",
         "id": 1,
-        "displayName": "admin",
-        "active": true,
-        "slug": "admin",
+        "name": "prj",
+        "description": "This is a test repo",
+        "public": true,
         "type": "NORMAL",
         "links": {
           "self": [{
-            "href": "http://localhost:7990/users/admin"
+            "href": "http://localhost:7990/projects/AMUNIZ"
           }]
         }
       },
-      "role": "AUTHOR",
-      "approved": false,
-      "status": "UNAPPROVED"
-    },
-    "reviewers": [],
-    "participants": [],
-    "properties": {
-      "mergeResult": {
-        "outcome": "CLEAN",
-        "current": true
-      },
-      "resolvedTaskCount": 0,
-      "openTaskCount": 0
-    },
-    "links": {
-      "self": [{
-        "href": "http://localhost:7990/projects/AMUNIZ/repos/test-repos/pull-requests/2"
-      }]
+      "public": false,
+      "links": {
+        "clone": [{
+          "href": "http://localhost:7990/scm/amuniz/test-repos-fork.git",
+          "name": "http"
+        }, {
+          "href": "ssh://git@localhost:7999/amuniz/test-repos-fork.git",
+          "name": "ssh"
+        }],
+        "self": [{
+          "href": "http://localhost:7990/projects/AMUNIZ/repos/test-repos-fork/browse"
+        }]
+      }
     }
+  },
+  "toRef": {
+    "id": "refs/heads/master",
+    "displayId": "master",
+    "latestCommit": "bf4f4ce8a3a8d5c7dbfe7d609973a81a6c6664cf",
+    "repository": {
+      "slug": "test-repos",
+      "id": 1,
+      "name": "test-repos",
+      "scmId": "git",
+      "state": "AVAILABLE",
+      "statusMessage": "Available",
+      "forkable": true,
+      "project": {
+        "key": "AMUNIZ",
+        "id": 1,
+        "name": "prj",
+        "description": "This is a test repo",
+        "public": true,
+        "type": "NORMAL",
+        "links": {
+          "self": [{
+            "href": "http://localhost:7990/projects/AMUNIZ"
+          }]
+        }
+      },
+      "public": false,
+      "links": {
+        "clone": [{
+          "href": "ssh://git@localhost:7999/amuniz/test-repos.git",
+          "name": "ssh"
+        }, {
+          "href": "http://localhost:7990/scm/amuniz/test-repos.git",
+          "name": "http"
+        }],
+        "self": [{
+          "href": "http://localhost:7990/projects/AMUNIZ/repos/test-repos/browse"
+        }]
+      }
+    }
+  },
+  "locked": false,
+  "author": {
+    "user": {
+      "name": "admin",
+      "emailAddress": "kaxixus@cmail.club",
+      "id": 1,
+      "displayName": "admin",
+      "active": true,
+      "slug": "admin",
+      "type": "NORMAL",
+      "links": {
+        "self": [{
+          "href": "http://localhost:7990/users/admin"
+        }]
+      }
+    },
+    "role": "AUTHOR",
+    "approved": false,
+    "status": "UNAPPROVED"
+  },
+  "reviewers": [],
+  "participants": [],
+  "properties": {
+    "mergeResult": {
+      "outcome": "CLEAN",
+      "current": true
+    },
+    "resolvedTaskCount": 0,
+    "openTaskCount": 0
+  },
+  "links": {
+    "self": [{
+      "href": "http://localhost:7990/projects/AMUNIZ/repos/test-repos/pull-requests/2"
+    }]
+  }
 }


### PR DESCRIPTION
There are several cases where all PRs are fetched or PRs are fetched again and again.

**#443 all PRs are fetched (multiple times even) on webhook event**
* Ignore repos that don't match the event
* Instead of fetching all PRs again, reuse the PR information that is already present from the Webhook.

**[JENKINS-65719](https://issues.jenkins.io/browse/JENKINS-65719) Jenkinsfile Retrieval for a PR should not check on All PRs**
* Instead of fetching all PRs, only fetch the relevant one

### Your checklist for this pull request

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Did you provide a test-case? That demonstrates feature works or fixes the issue.

