### PR TITLE
Avoid "Success" Bitbucket notification, case build was aborted

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketBuildStatusNotificationsTrait.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketBuildStatusNotificationsTrait.java
@@ -46,6 +46,11 @@ public class BitbucketBuildStatusNotificationsTrait extends SCMSourceTrait {
     private boolean sendSuccessNotificationForUnstableBuild;
 
     /**
+     * Should not build jobs be communicated to Bitbucket
+     */
+    private boolean disableNotificationForNotBuildJobs;
+
+    /**
      * Constructor.
      *
      */
@@ -68,11 +73,24 @@ public class BitbucketBuildStatusNotificationsTrait extends SCMSourceTrait {
         return this.sendSuccessNotificationForUnstableBuild;
     }
 
+    @DataBoundSetter
+    public void setDisableNotificationForNotBuildJobs(boolean isNotificationDisabled) {
+        disableNotificationForNotBuildJobs = isNotificationDisabled;
+    }
+
+    /**
+     * @return if unstable builds will be communicated
+     */
+    public boolean getDisableNotificationForNotBuildJobs() {
+        return this.disableNotificationForNotBuildJobs;
+    }
+
     /**
      * {@inheritDoc}
      */
     @Override
     protected void decorateContext(SCMSourceContext<?, ?> context) {
+        ((BitbucketSCMSourceContext) context).withDisableNotificationForNotBuildJobs(getDisableNotificationForNotBuildJobs());
         ((BitbucketSCMSourceContext) context).withSendSuccessNotificationForUnstableBuild(getSendSuccessNotificationForUnstableBuild());
     }
 

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource.java
@@ -565,7 +565,8 @@ public class BitbucketSCMSource extends SCMSource {
                         CredentialsNameProvider.name(scanCredentials));
             }
             // this has the side effect of ensuring that repository type is always populated.
-            listener.getLogger().format("Repository type: %s%n", WordUtils.capitalizeFully(getRepositoryType().name()));
+            final BitbucketRepositoryType repositoryType = getRepositoryType();
+            listener.getLogger().format("Repository type: %s%n", WordUtils.capitalizeFully(repositoryType != null ? repositoryType.name() : "Unknown"));
 
             // populate the request with its data sources
             if (request.isFetchPRs()) {

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSourceContext.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSourceContext.java
@@ -92,6 +92,11 @@ public class BitbucketSCMSourceContext extends SCMSourceContext<BitbucketSCMSour
     private boolean sendSuccessNotificationForUnstableBuild;
 
     /**
+     * {@code false} if not build jobs should be send to Bitbucket.
+     */
+    private boolean disableNotificationForNotBuildJobs;
+
+    /**
      * Constructor.
      *
      * @param criteria (optional) criteria.
@@ -213,6 +218,15 @@ public class BitbucketSCMSourceContext extends SCMSourceContext<BitbucketSCMSour
      */
     public final boolean sendSuccessNotificationForUnstableBuild() {
         return sendSuccessNotificationForUnstableBuild;
+    }
+
+    /**
+     * Returns {@code false} if not build jobs should be passed to Bitbucket.
+     *
+     * @return {@code false} if not build jobs should be passed to Bitbucket.
+     */
+    public boolean disableNotificationForNotBuildJobs() {
+        return disableNotificationForNotBuildJobs;
     }
 
     /**
@@ -349,6 +363,18 @@ public class BitbucketSCMSourceContext extends SCMSourceContext<BitbucketSCMSour
     @NonNull
     public final BitbucketSCMSourceContext withSendSuccessNotificationForUnstableBuild(boolean isUnstableBuildSuccess) {
         this.sendSuccessNotificationForUnstableBuild = isUnstableBuildSuccess;
+        return this;
+    }
+
+    /**
+     * Defines behaviour of unstable builds in Bitbucket.
+     *
+     * @param disabled {@code false} to report not build jobs to Bitbucket.
+     * @return {@code this} for method chaining.
+     */
+    @NonNull
+    public final BitbucketSCMSourceContext withDisableNotificationForNotBuildJobs(boolean disabled) {
+        this.disableNotificationForNotBuildJobs = disabled;
         return this;
     }
 

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/BitbucketBuildStatus.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/BitbucketBuildStatus.java
@@ -31,6 +31,27 @@ import org.kohsuke.accmod.restrictions.DoNotUse;
 public class BitbucketBuildStatus {
 
     /**
+     * Enumeration of possible Bitbucket commit notification states
+     */
+    public enum Status {
+        INPROGRESS("INPROGRESS"),
+        FAILED("FAILED"),
+        STOPPED("STOPPED"),
+        SUCCESSFUL("SUCCESSFUL");
+
+        private final String status;
+
+        Status(final String status) {
+            this.status = status;
+        }
+
+        @Override
+        public String toString() {
+            return status;
+        }
+    }
+
+    /**
      * The commit hash to set the status on
      */
     @JsonIgnore
@@ -42,9 +63,9 @@ public class BitbucketBuildStatus {
     private String description;
 
     /**
-     * One of: INPROGRESS|SUCCESSFUL|FAILED
+     * One of: INPROGRESS|FAILED|STOPPED|SUCCESSFUL
      */
-    private String state;
+    private Status state;
 
     /**
      * The URL to link from the status details
@@ -66,7 +87,7 @@ public class BitbucketBuildStatus {
     @Restricted(DoNotUse.class)
     public BitbucketBuildStatus() {}
 
-    public BitbucketBuildStatus(String hash, String description, String state, String url, String key, String name) {
+    public BitbucketBuildStatus(String hash, String description, Status state, String url, String key, String name) {
         this.hash = hash;
         this.description = description;
         this.state = state;
@@ -92,10 +113,10 @@ public class BitbucketBuildStatus {
     }
 
     public String getState() {
-        return state;
+        return state.toString();
     }
 
-    public void setState(String state) {
+    public void setState(Status state) {
         this.state = state;
     }
 

--- a/src/main/resources/com/cloudbees/jenkins/plugins/bitbucket/BitbucketBuildStatusNotificationsTrait/config.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/bitbucket/BitbucketBuildStatusNotificationsTrait/config.jelly
@@ -3,4 +3,7 @@
   <f:entry title="${%Communicate Unstable builds to Bitbucket as Successful}" field="sendSuccessNotificationForUnstableBuild">
     <f:checkbox/>
   </f:entry>
+  <f:entry title="${%Don't Communicate not build jobs to Bitbucket}" field="disableNotificationForNotBuildJobs">
+    <f:checkbox/>
+  </f:entry>
 </j:jelly>


### PR DESCRIPTION
Current implementation notifies the BitBucket as successfull, the case build was aborted. If BitBucket has a "need at least one successfull build" as quality gate for pull-request merge, then aborted builds will fulfill the quality gate. This PR solves the issue, that no notification is performed.

### Your checklist for this pull request

- [ X] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [ X] Ensure that the pull request title represents the desired changelog entry
- [ X] Please describe what you did
- [ ] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Did you provide a test-case? That demonstrates feature works or fixes the issue.

Signed-off: alexander.falkenstern@gmail.com