### PR TITLE
feature/324 | skip non PR notifications

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketBuildStatusNotificationsTrait.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketBuildStatusNotificationsTrait.java
@@ -45,6 +45,9 @@ public class BitbucketBuildStatusNotificationsTrait extends SCMSourceTrait {
      */
     private boolean sendSuccessNotificationForUnstableBuild;
 
+
+    private boolean doNotOverridePrBuildStatuses;
+
     /**
      * Constructor.
      *
@@ -61,11 +64,20 @@ public class BitbucketBuildStatusNotificationsTrait extends SCMSourceTrait {
         sendSuccessNotificationForUnstableBuild = isSendSuccess;
     }
 
+    @DataBoundSetter
+    public void setDoNotOverridePrBuildStatuses(boolean isDoNotOverridePrBuildStatuses) {
+        doNotOverridePrBuildStatuses = isDoNotOverridePrBuildStatuses;
+    }
+
     /**
      * @return if unstable builds will be communicated as successful
      */
     public boolean getSendSuccessNotificationForUnstableBuild() {
         return this.sendSuccessNotificationForUnstableBuild;
+    }
+
+    public boolean getDoNotOverridePrBuildStatuses() {
+        return this.doNotOverridePrBuildStatuses;
     }
 
     /**
@@ -74,6 +86,7 @@ public class BitbucketBuildStatusNotificationsTrait extends SCMSourceTrait {
     @Override
     protected void decorateContext(SCMSourceContext<?, ?> context) {
         ((BitbucketSCMSourceContext) context).withSendSuccessNotificationForUnstableBuild(getSendSuccessNotificationForUnstableBuild());
+        ((BitbucketSCMSourceContext) context).withDoNotOverridePrBuildStatuses(getDoNotOverridePrBuildStatuses());
     }
 
     /**

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSourceContext.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSourceContext.java
@@ -91,6 +91,8 @@ public class BitbucketSCMSourceContext extends SCMSourceContext<BitbucketSCMSour
      */
     private boolean sendSuccessNotificationForUnstableBuild;
 
+    private boolean doNotOverridePrBuildStatuses;
+
     /**
      * Constructor.
      *
@@ -213,6 +215,10 @@ public class BitbucketSCMSourceContext extends SCMSourceContext<BitbucketSCMSour
      */
     public final boolean sendSuccessNotificationForUnstableBuild() {
         return sendSuccessNotificationForUnstableBuild;
+    }
+
+    public final boolean doNotOverridePrBuildStatuses() {
+        return doNotOverridePrBuildStatuses;
     }
 
     /**
@@ -349,6 +355,12 @@ public class BitbucketSCMSourceContext extends SCMSourceContext<BitbucketSCMSour
     @NonNull
     public final BitbucketSCMSourceContext withSendSuccessNotificationForUnstableBuild(boolean isUnstableBuildSuccess) {
         this.sendSuccessNotificationForUnstableBuild = isUnstableBuildSuccess;
+        return this;
+    }
+
+    @NonNull
+    public final BitbucketSCMSourceContext withDoNotOverridePrBuildStatuses(boolean doNotOverwritePrBuildStatus) {
+        this.doNotOverridePrBuildStatuses = doNotOverwritePrBuildStatus;
         return this;
     }
 

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/BitbucketApi.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/BitbucketApi.java
@@ -281,6 +281,15 @@ public interface BitbucketApi {
     void postBuildStatus(@NonNull BitbucketBuildStatus status) throws IOException, InterruptedException;
 
     /**
+     * Set the build status for the given commit hash.
+     *
+     * @param hash get the status object for specified key
+     * @throws IOException if there was a network communications error.
+     * @throws InterruptedException if interrupted while waiting on remote communications.
+     */
+    BitbucketBuildStatuses getBuildStatus(@NonNull String hash) throws IOException, InterruptedException;
+
+    /**
      * Returns {@code true} if and only if the repository is private.
      *
      * @return {@code true} if the repository ({@link #getOwner()}/{@link #getRepositoryName()}) is private.

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/BitbucketBuildStatus.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/BitbucketBuildStatus.java
@@ -24,7 +24,6 @@
 package com.cloudbees.jenkins.plugins.bitbucket.api;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import org.apache.commons.codec.digest.DigestUtils;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.DoNotUse;
 
@@ -71,7 +70,7 @@ public class BitbucketBuildStatus {
         this.description = description;
         this.state = state;
         this.url = url;
-        this.key = DigestUtils.md5Hex(key);
+        this.key = key;
         this.name = name;
     }
 
@@ -112,7 +111,7 @@ public class BitbucketBuildStatus {
     }
 
     public void setKey(String key) {
-        this.key = DigestUtils.md5Hex(key);
+        this.key = key;
     }
 
     public String getName() {

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/BitbucketBuildStatuses.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/BitbucketBuildStatuses.java
@@ -1,0 +1,35 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.cloudbees.jenkins.plugins.bitbucket.api;
+
+import java.util.Collections;
+import java.util.List;
+
+public class BitbucketBuildStatuses {
+    private List<BitbucketBuildStatus> values;
+
+    public List<BitbucketBuildStatus> getValues() {
+        return values == null ? Collections.<BitbucketBuildStatus>emptyList() : Collections.unmodifiableList(values);
+    }
+}

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/BitbucketCloudApiClient.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/BitbucketCloudApiClient.java
@@ -28,6 +28,7 @@ import com.cloudbees.jenkins.plugins.bitbucket.JsonParser;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketApi;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketAuthenticator;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketBuildStatus;
+import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketBuildStatuses;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketCloudWorkspace;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketCommit;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketException;
@@ -646,6 +647,21 @@ public class BitbucketCloudApiClient implements BitbucketApi {
                 .set("hash", status.getHash())
                 .expand();
         postRequest(url, JsonParser.toJson(status));
+    }
+
+    @Override
+    public BitbucketBuildStatuses getBuildStatus(@NonNull String hash) throws IOException, InterruptedException {
+        String url = UriTemplate.fromTemplate(REPO_URL_TEMPLATE + "/commit/{hash}/statuses/build")
+            .set("owner", owner)
+            .set("repo", repositoryName)
+            .set("hash", hash)
+            .expand();
+        String response = getRequest(url);
+        try {
+            return JsonParser.toJava(response, BitbucketBuildStatuses.class);
+        } catch (IOException e) {
+            throw new IOException("I/O error when accessing URL: " + url, e);
+        }
     }
 
     /**

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/BitbucketServerAPIClient.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/BitbucketServerAPIClient.java
@@ -27,6 +27,7 @@ import com.cloudbees.jenkins.plugins.bitbucket.JsonParser;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketApi;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketAuthenticator;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketBuildStatus;
+import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketBuildStatuses;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketCommit;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketPullRequest;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketRepository;
@@ -508,6 +509,22 @@ public class BitbucketServerAPIClient implements BitbucketApi {
                 .expand(),
             JsonParser.toJson(status)
         );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public BitbucketBuildStatuses getBuildStatus(@NonNull String hash) throws IOException {
+        String url = UriTemplate
+            .fromTemplate(API_COMMIT_STATUS_PATH)
+            .set("hash", hash)
+            .expand();
+        String response = getRequest(url);
+        try {
+            return JsonParser.toJava(response, BitbucketBuildStatuses.class);
+        } catch (IOException e) {
+            throw new IOException("I/O error when accessing URL: " + url, e);
+        }
     }
 
     /**

--- a/src/main/resources/com/cloudbees/jenkins/plugins/bitbucket/BitbucketBuildStatusNotificationsTrait/config.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/bitbucket/BitbucketBuildStatusNotificationsTrait/config.jelly
@@ -3,4 +3,7 @@
   <f:entry title="${%Communicate Unstable builds to Bitbucket as Successful}" field="sendSuccessNotificationForUnstableBuild">
     <f:checkbox/>
   </f:entry>
+   <f:entry title="${%Skip branch notifications once PR build has started to prevent preliminary successful state of not fully tested PR}" field="doNotOverridePrBuildStatuses">
+    <f:checkbox/>
+  </f:entry>
 </j:jelly>

--- a/src/main/resources/com/cloudbees/jenkins/plugins/bitbucket/BitbucketBuildStatusNotificationsTrait/config.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/bitbucket/BitbucketBuildStatusNotificationsTrait/config.jelly
@@ -3,7 +3,7 @@
   <f:entry title="${%Communicate Unstable builds to Bitbucket as Successful}" field="sendSuccessNotificationForUnstableBuild">
     <f:checkbox/>
   </f:entry>
-   <f:entry title="${%Skip branch notifications once PR build has started to prevent preliminary successful state of not fully tested PR}" field="doNotOverridePrBuildStatuses">
+   <f:entry title="${%Skip Branch build status notifications if PR build already exists}" field="doNotOverridePrBuildStatuses">
     <f:checkbox/>
   </f:entry>
 </j:jelly>

--- a/src/main/resources/com/cloudbees/jenkins/plugins/bitbucket/BitbucketBuildStatusNotificationsTrait/help-doNotOverridePrBuildStatuses.html
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/bitbucket/BitbucketBuildStatusNotificationsTrait/help-doNotOverridePrBuildStatuses.html
@@ -1,0 +1,12 @@
+<div>
+    Prevents a prematurely successful state of not fully tested PRs.
+    <br/>
+    <strong>"Exclude branches that are also filed as PRs"</strong> strategy implies that branch and PR builds
+    do share the same key while publishing the build status to Bitbucket, thus can overwrite statuses of each other.
+    Usually, it happens when the branch build finishes in the middle of a running PR build
+    so Bitbucket has been already notified about the branch status and
+    (in case this status was a success) we can merge the PR until the PR build is completed.
+
+    <br/>
+    <strong>NOTE:</strong> this option is only applicable when <strong>"Exclude branches that are also filed as PRs"</strong> strategy in multibranch configuration is used.
+</div>


### PR DESCRIPTION
Adding a checkbox to avoid overwriting of _PR_ status by the _branch_ build status. Should fix #324 . We had similar problems in our pipelines where branch build can be finished in the middle of running PR build thus allowing to merge un-tested changes into master

### Your checklist for this pull request

- [x ] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [ x] Ensure that the pull request title represents the desired changelog entry
- [x ] Please describe what you did
- [x ] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [x ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Did you provide a test-case? That demonstrates feature works or fixes the issue.

