### PR TITLE
[JENKINS-65719] Only retrieve the PR when fetching a PR head revision

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource.java
@@ -803,7 +803,8 @@ public class BitbucketSCMSource extends SCMSource {
                 sourceRevision = findCommit(h.getBranchName(), branches, listener);
             } else {
                 try {
-                    sourceRevision = findPRCommit(bitbucket.getPullRequestById(Integer.parseInt(h.getId())), listener);
+                    BitbucketPullRequest pr = bitbucket.getPullRequestById(Integer.parseInt(h.getId()));
+                    sourceRevision = findPRCommit(pr, listener);
                 } catch (NumberFormatException nfe) {
                     LOGGER.log(Level.WARNING, "Cannot parse the PR id {0}", h.getId());
                     sourceRevision = null;
@@ -844,7 +845,7 @@ public class BitbucketSCMSource extends SCMSource {
         }
     }
 
-    private BitbucketCommit findCommit(String branchName, List<? extends BitbucketBranch> branches, TaskListener listener) {
+    private BitbucketCommit findCommit(@NonNull String branchName, List<? extends BitbucketBranch> branches, TaskListener listener) {
         for (final BitbucketBranch b : branches) {
             if (branchName.equals(b.getName())) {
                 String revision = b.getRawNode();
@@ -865,7 +866,7 @@ public class BitbucketSCMSource extends SCMSource {
         listener.getLogger().format("Cannot find the branch %s%n", branchName);
         return null;
     }
-
+    
     private BitbucketCommit findPRCommit(BitbucketPullRequest pr, TaskListener listener) {
         // if I use getCommit() the branch closure is trigger immediately
         BitbucketBranch branch = pr.getSource().getBranch();

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource.java
@@ -866,7 +866,7 @@ public class BitbucketSCMSource extends SCMSource {
         listener.getLogger().format("Cannot find the branch %s%n", branchName);
         return null;
     }
-    
+
     private BitbucketCommit findPRCommit(BitbucketPullRequest pr, TaskListener listener) {
         // if I use getCommit() the branch closure is trigger immediately
         BitbucketBranch branch = pr.getSource().getBranch();

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/BitbucketCloudApiClient.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/BitbucketCloudApiClient.java
@@ -298,16 +298,26 @@ public class BitbucketCloudApiClient implements BitbucketApi {
         } while (page.getNext() != null);
 
         // PRs with missing destination branch are invalid and should be ignored.
-        pullRequests.removeIf(pr -> pr.getSource().getRepository() == null
-                || pr.getSource().getCommit() == null
-                || pr.getDestination().getBranch() == null
-                || pr.getDestination().getCommit() == null);
+        pullRequests.removeIf(this::shouldIgnore);
 
         for (BitbucketPullRequestValue pullRequest : pullRequests) {
             setupClosureForPRBranch(pullRequest);
         }
 
         return pullRequests;
+    }
+
+    /**
+     * PRs with missing source / destination branch are invalid and should be ignored.
+     *
+     * @param pr a {@link BitbucketPullRequest}
+     * @return
+     */
+    private boolean shouldIgnore(BitbucketPullRequest pr) {
+        return pr.getSource().getRepository() == null
+            || pr.getSource().getCommit() == null
+            || pr.getDestination().getBranch() == null
+            || pr.getDestination().getCommit() == null;
     }
 
     /**

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/endpoints/BitbucketEndpointConfiguration.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/endpoints/BitbucketEndpointConfiguration.java
@@ -39,6 +39,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Locale;
+import java.util.Optional;
 import java.util.Set;
 import jenkins.model.GlobalConfiguration;
 import jenkins.model.Jenkins;
@@ -263,6 +264,21 @@ public class BitbucketEndpointConfiguration extends GlobalConfiguration {
             }
         }
         return null;
+    }
+
+    /**
+     * Checks to see if the supplied server URL is defined in the global configuration.
+     *
+     * @param serverUrl the server url to check.
+     * @param clazz
+     * @return the global configuration for the specified server url or {@code null} if not defined.
+     */
+    public synchronized Optional<AbstractBitbucketEndpoint> findEndpoint(@CheckForNull String serverUrl,
+                                                                         Class<? extends AbstractBitbucketEndpoint> clazz) {
+        return getEndpoints().stream()
+            .filter(clazz::isInstance)
+            .filter(endpoint -> normalizeServerUrl(serverUrl).equals(endpoint.getServerUrl()))
+            .findFirst();
     }
 
     /**

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/BitbucketServerAPIClient.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/BitbucketServerAPIClient.java
@@ -327,45 +327,57 @@ public class BitbucketServerAPIClient implements BitbucketApi {
     }
 
     private List<BitbucketServerPullRequest> getPullRequests(UriTemplate template)
-            throws IOException, InterruptedException {
+        throws IOException, InterruptedException {
         List<BitbucketServerPullRequest> pullRequests = getResources(template, BitbucketServerPullRequests.class);
 
-        // PRs with missing destination branch are invalid and should be ignored.
-        pullRequests.removeIf(pr -> pr.getSource().getRepository() == null
-                || pr.getSource().getBranch() == null
-                || pr.getDestination().getBranch() == null);
+        pullRequests.removeIf(this::shouldIgnore);
 
-        AbstractBitbucketEndpoint endpointConfig = BitbucketEndpointConfiguration.get().findEndpoint(baseURL);
-        final BitbucketServerEndpoint endpoint = endpointConfig instanceof BitbucketServerEndpoint ?
-            (BitbucketServerEndpoint) endpointConfig : null;
+        BitbucketServerEndpoint endpoint = (BitbucketServerEndpoint) BitbucketEndpointConfiguration.get().
+            findEndpoint(this.baseURL, BitbucketServerEndpoint.class).orElse(null);
 
         for (BitbucketServerPullRequest pullRequest : pullRequests) {
-            // set commit closure to make commit informations available when need, in a similar way to when request branches
-            setupClosureForPRBranch(pullRequest);
-
-            if (endpoint != null) {
-                // This is required for Bitbucket Server to update the refs/pull-requests/* references
-                // See https://community.atlassian.com/t5/Bitbucket-questions/Change-pull-request-refs-after-Commit-instead-of-after-Approval/qaq-p/194702#M6829
-                if (endpoint.isCallCanMerge()) {
-                    try {
-                        pullRequest.setCanMerge(getPullRequestCanMergeById(pullRequest.getId()));
-                    } catch (BitbucketRequestException e) {
-                        // see JENKINS-65718 https://docs.atlassian.com/bitbucket-server/rest/7.2.1/bitbucket-rest.html#errors-and-validation
-                        // in this case we just say cannot merge this one
-                        if(e.getHttpCode()==409){
-                            pullRequest.setCanMerge(false);
-                        } else {
-                            throw e;
-                        }
-                    }
-                }
-                if (endpoint.isCallChanges() && BitbucketServerVersion.VERSION_7.equals(endpoint.getServerVersion())) {
-                    callPullRequestChangesById(pullRequest.getId());
-                }
-            }
+            setupPullRequest(pullRequest, endpoint);
         }
 
         return pullRequests;
+    }
+
+    private void setupPullRequest(BitbucketServerPullRequest pullRequest, BitbucketServerEndpoint endpoint) throws IOException {
+        // set commit closure to make commit information available when need, in a similar way to when request branches
+        setupClosureForPRBranch(pullRequest);
+
+        if (endpoint != null) {
+            // This is required for Bitbucket Server to update the refs/pull-requests/* references
+            // See https://community.atlassian.com/t5/Bitbucket-questions/Change-pull-request-refs-after-Commit-instead-of-after-Approval/qaq-p/194702#M6829
+            if (endpoint.isCallCanMerge()) {
+                try {
+                    pullRequest.setCanMerge(getPullRequestCanMergeById(pullRequest.getId()));
+                } catch (BitbucketRequestException e) {
+                    // see JENKINS-65718 https://docs.atlassian.com/bitbucket-server/rest/7.2.1/bitbucket-rest.html#errors-and-validation
+                    // in this case we just say cannot merge this one
+                    if(e.getHttpCode()==409){
+                        pullRequest.setCanMerge(false);
+                    } else {
+                        throw e;
+                    }
+                }
+            }
+            if (endpoint.isCallChanges() && BitbucketServerVersion.VERSION_7.equals(endpoint.getServerVersion())) {
+                callPullRequestChangesById(pullRequest.getId());
+            }
+        }
+    }
+
+    /**
+     * PRs with missing source / destination branch are invalid and should be ignored.
+     *
+     * @param pullRequest a {@link BitbucketPullRequest}
+     * @return
+     */
+    private boolean shouldIgnore(BitbucketPullRequest pullRequest) {
+        return pullRequest.getSource().getRepository() == null
+            || pullRequest.getSource().getBranch() == null
+            || pullRequest.getDestination().getBranch() == null;
     }
 
     /**
@@ -441,9 +453,9 @@ public class BitbucketServerAPIClient implements BitbucketApi {
         String response = getRequest(url);
         try {
             BitbucketServerPullRequest pr = JsonParser.toJava(response, BitbucketServerPullRequest.class);
-
             setupClosureForPRBranch(pr);
-
+            setupPullRequest(pr, (BitbucketServerEndpoint) BitbucketEndpointConfiguration.get().
+                findEndpoint(this.baseURL, BitbucketServerEndpoint.class).orElse(null));
             return pr;
         } catch (IOException e) {
             throw new IOException("I/O error when accessing URL: " + url, e);

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/BitbucketServerAPIClient.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/BitbucketServerAPIClient.java
@@ -38,7 +38,6 @@ import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketWebHook;
 import com.cloudbees.jenkins.plugins.bitbucket.api.credentials.BitbucketUsernamePasswordAuthenticator;
 import com.cloudbees.jenkins.plugins.bitbucket.avatars.AvatarCacheSource.AvatarImage;
 import com.cloudbees.jenkins.plugins.bitbucket.client.repository.UserRoleInRepository;
-import com.cloudbees.jenkins.plugins.bitbucket.endpoints.AbstractBitbucketEndpoint;
 import com.cloudbees.jenkins.plugins.bitbucket.endpoints.BitbucketEndpointConfiguration;
 import com.cloudbees.jenkins.plugins.bitbucket.endpoints.BitbucketServerEndpoint;
 import com.cloudbees.jenkins.plugins.bitbucket.filesystem.BitbucketSCMFile;

--- a/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/server/payload/1.0-projects-amuniz-repos-test-repos-pull-requests-1.json
+++ b/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/server/payload/1.0-projects-amuniz-repos-test-repos-pull-requests-1.json
@@ -1,0 +1,126 @@
+{
+  "id": 1,
+  "version": 0,
+  "title": "Release/release 1",
+  "description": "* Add license\r\n* [CI] Release version 1.0.0",
+  "state": "OPEN",
+  "open": true,
+  "closed": false,
+  "createdDate": 1537885911512,
+  "updatedDate": 1537885911512,
+  "fromRef": {
+    "id": "refs/heads/release/release-1",
+    "displayId": "release/release-1",
+    "latestCommit": "bf0e8b7962c024026ad01ae09d3a11732e26c0d4",
+    "repository": {
+      "slug": "test-repos",
+      "id": 1,
+      "name": "test-repos",
+      "scmId": "git",
+      "state": "AVAILABLE",
+      "statusMessage": "Available",
+      "forkable": true,
+      "project": {
+        "key": "AMUNIZ",
+        "id": 1,
+        "name": "prj",
+        "description": "This is a test repo",
+        "public": true,
+        "type": "NORMAL",
+        "links": {
+          "self": [{
+            "href": "http://localhost:7990/projects/AMUNIZ"
+          }]
+        }
+      },
+      "public": false,
+      "links": {
+        "clone": [{
+          "href": "ssh://git@localhost:7999/amuniz/test-repos.git",
+          "name": "ssh"
+        }, {
+          "href": "http://localhost:7990/scm/amuniz/test-repos.git",
+          "name": "http"
+        }],
+        "self": [{
+          "href": "http://localhost:7990/projects/AMUNIZ/repos/test-repos/browse"
+        }]
+      }
+    }
+  },
+  "toRef": {
+    "id": "refs/heads/master",
+    "displayId": "master",
+    "latestCommit": "bf4f4ce8a3a8d5c7dbfe7d609973a81a6c6664cf",
+    "repository": {
+      "slug": "test-repos",
+      "id": 1,
+      "name": "test-repos",
+      "scmId": "git",
+      "state": "AVAILABLE",
+      "statusMessage": "Available",
+      "forkable": true,
+      "project": {
+        "key": "AMUNIZ",
+        "id": 1,
+        "name": "prj",
+        "description": "This is a test repo",
+        "public": true,
+        "type": "NORMAL",
+        "links": {
+          "self": [{
+            "href": "http://localhost:7990/projects/AMUNIZ"
+          }]
+        }
+      },
+      "public": false,
+      "links": {
+        "clone": [{
+          "href": "ssh://git@localhost:7999/amuniz/test-repos.git",
+          "name": "ssh"
+        }, {
+          "href": "http://localhost:7990/scm/amuniz/test-repos.git",
+          "name": "http"
+        }],
+        "self": [{
+          "href": "http://localhost:7990/projects/AMUNIZ/repos/test-repos/browse"
+        }]
+      }
+    }
+  },
+  "locked": false,
+  "author": {
+    "user": {
+      "name": "amuniz",
+      "emailAddress": "amuniz@acme.com",
+      "id": 2,
+      "displayName": "Antonio Muniz",
+      "active": true,
+      "slug": "amuniz",
+      "type": "NORMAL",
+      "links": {
+        "self": [{
+          "href": "http://localhost:7990/users/amuniz"
+        }]
+      }
+    },
+    "role": "AUTHOR",
+    "approved": false,
+    "status": "UNAPPROVED"
+  },
+  "reviewers": [],
+  "participants": [],
+  "properties": {
+    "mergeResult": {
+      "outcome": "CLEAN",
+      "current": true
+    },
+    "resolvedTaskCount": 0,
+    "openTaskCount": 0
+  },
+  "links": {
+    "self": [{
+      "href": "http://localhost:7990/projects/AMUNIZ/repos/test-repos/pull-requests/1"
+    }]
+  }
+}

--- a/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/server/payload/1.0-projects-amuniz-repos-test-repos-pull-requests-2.json
+++ b/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/server/payload/1.0-projects-amuniz-repos-test-repos-pull-requests-2.json
@@ -1,0 +1,161 @@
+{
+  "id": 2,
+  "version": 0,
+  "title": "Add one message more",
+  "description": "test from forked repo",
+  "state": "OPEN",
+  "open": true,
+  "closed": false,
+  "createdDate": 1541687143031,
+  "updatedDate": 1541687143031,
+  "fromRef": {
+    "id": "refs/heads/feature/BB-2",
+    "displayId": "feature/BB-2",
+    "latestCommit": "046d9a3c1532acf4cf08fe93235c00e4d673c1d2",
+    "repository": {
+      "slug": "test-repos-fork",
+      "id": 12,
+      "name": "test-repos-fork",
+      "scmId": "git",
+      "state": "AVAILABLE",
+      "statusMessage": "Available",
+      "forkable": true,
+      "origin": {
+        "slug": "test-repos",
+        "id": 1,
+        "name": "test-repos",
+        "scmId": "git",
+        "state": "AVAILABLE",
+        "statusMessage": "Available",
+        "forkable": true,
+        "project": {
+          "key": "AMUNIZ",
+          "id": 1,
+          "name": "prj",
+          "description": "This is a test repo",
+          "public": true,
+          "type": "NORMAL",
+          "links": {
+            "self": [{
+              "href": "http://localhost:7990/projects/AMUNIZ"
+            }]
+          }
+        },
+        "public": false,
+        "links": {
+          "clone": [{
+            "href": "ssh://git@localhost:7999/amuniz/test-repos.git",
+            "name": "ssh"
+          }, {
+            "href": "http://localhost:7990/scm/amuniz/test-repos.git",
+            "name": "http"
+          }],
+          "self": [{
+            "href": "http://localhost:7990/projects/AMUNIZ/repos/test-repos/browse"
+          }]
+        }
+      },
+      "project": {
+        "key": "AMUNIZ",
+        "id": 1,
+        "name": "prj",
+        "description": "This is a test repo",
+        "public": true,
+        "type": "NORMAL",
+        "links": {
+          "self": [{
+            "href": "http://localhost:7990/projects/AMUNIZ"
+          }]
+        }
+      },
+      "public": false,
+      "links": {
+        "clone": [{
+          "href": "http://localhost:7990/scm/amuniz/test-repos-fork.git",
+          "name": "http"
+        }, {
+          "href": "ssh://git@localhost:7999/amuniz/test-repos-fork.git",
+          "name": "ssh"
+        }],
+        "self": [{
+          "href": "http://localhost:7990/projects/AMUNIZ/repos/test-repos-fork/browse"
+        }]
+      }
+    }
+  },
+  "toRef": {
+    "id": "refs/heads/master",
+    "displayId": "master",
+    "latestCommit": "bf4f4ce8a3a8d5c7dbfe7d609973a81a6c6664cf",
+    "repository": {
+      "slug": "test-repos",
+      "id": 1,
+      "name": "test-repos",
+      "scmId": "git",
+      "state": "AVAILABLE",
+      "statusMessage": "Available",
+      "forkable": true,
+      "project": {
+        "key": "AMUNIZ",
+        "id": 1,
+        "name": "prj",
+        "description": "This is a test repo",
+        "public": true,
+        "type": "NORMAL",
+        "links": {
+          "self": [{
+            "href": "http://localhost:7990/projects/AMUNIZ"
+          }]
+        }
+      },
+      "public": false,
+      "links": {
+        "clone": [{
+          "href": "ssh://git@localhost:7999/amuniz/test-repos.git",
+          "name": "ssh"
+        }, {
+          "href": "http://localhost:7990/scm/amuniz/test-repos.git",
+          "name": "http"
+        }],
+        "self": [{
+          "href": "http://localhost:7990/projects/AMUNIZ/repos/test-repos/browse"
+        }]
+      }
+    }
+  },
+  "locked": false,
+  "author": {
+    "user": {
+      "name": "admin",
+      "emailAddress": "kaxixus@cmail.club",
+      "id": 1,
+      "displayName": "admin",
+      "active": true,
+      "slug": "admin",
+      "type": "NORMAL",
+      "links": {
+        "self": [{
+          "href": "http://localhost:7990/users/admin"
+        }]
+      }
+    },
+    "role": "AUTHOR",
+    "approved": false,
+    "status": "UNAPPROVED"
+  },
+  "reviewers": [],
+  "participants": [],
+  "properties": {
+    "mergeResult": {
+      "outcome": "CLEAN",
+      "current": true
+    },
+    "resolvedTaskCount": 0,
+    "openTaskCount": 0
+  },
+  "links": {
+    "self": [{
+      "href": "http://localhost:7990/projects/AMUNIZ/repos/test-repos/pull-requests/2"
+    }]
+  }
+}


### PR DESCRIPTION
[JENKINS-65719](https://issues.jenkins.io/browse/JENKINS-65719) Only retrieve the PR we are interested when retrieving a PR Head revision.

### Your checklist for this pull request

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Did you provide a test-case? That demonstrates feature works or fixes the issue.
