### PR TITLE
JENKINS-65741: Implement a new option that will allow to include jenkins url to the commit status

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
   </parent>
 
   <artifactId>cloudbees-bitbucket-branch-source</artifactId>
-  <version>2.9.9</version>
+  <version>${revision}${changelist}</version>
   <packaging>hpi</packaging>
 
   <name>Bitbucket Branch Source Plugin</name>
@@ -49,7 +49,7 @@
   </licenses>
 
   <properties>
-    <revision>2.9.9</revision>
+    <revision>2.9.10</revision>
     <changelist>-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/bitbucket-branch-source-plugin</gitHubRepo>
     <jenkins.version>2.176.4</jenkins.version>
@@ -80,7 +80,7 @@
     <connection>scm:git:git://github.com/${gitHubRepo}.git</connection>
     <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
     <url>https://github.com/${gitHubRepo}</url>
-    <tag>cloudbees-bitbucket-branch-source-2.9.9</tag>
+    <tag>${scmTag}</tag>
   </scm>
 
   <dependencyManagement>

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketBuildStatusNotifications.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketBuildStatusNotifications.java
@@ -137,6 +137,7 @@ public class BitbucketBuildStatusNotifications {
         BitbucketBuildStatus status;
         Result result = build.getResult();
         String buildDescription = build.getDescription();
+        String statusNamePrefix = "";
         String statusDescriptionSuffix = "";
         String statusDescription;
         String state;
@@ -166,9 +167,13 @@ public class BitbucketBuildStatusNotifications {
             state = INPROGRESS_STATE;
         }
         if (sourceContext.buildStatusIncludeJenkinsURL()) {
-            statusDescriptionSuffix = "\n" + rootUrl;
+            statusNamePrefix = rootUrl + " » ";
+            statusDescriptionSuffix = " @ " + rootUrl;
         }
-        status = new BitbucketBuildStatus(hash, statusDescription + statusDescriptionSuffix, state, url, key, name);
+        status = new BitbucketBuildStatus(hash,
+                statusDescription + statusDescriptionSuffix,
+                state, url, key,
+                statusNamePrefix + name);
         new BitbucketChangesetCommentNotifier(bitbucket).buildStatus(status);
         if (result != null) {
             listener.getLogger().println("[Bitbucket] Build result notified");

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketBuildStatusNotificationsTrait.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketBuildStatusNotificationsTrait.java
@@ -46,6 +46,11 @@ public class BitbucketBuildStatusNotificationsTrait extends SCMSourceTrait {
     private boolean sendSuccessNotificationForUnstableBuild;
 
     /**
+     * Include Jenkins URL as a status key/name
+     */
+    private boolean includeJenkinsURL;
+
+    /**
      * Constructor.
      *
      */
@@ -68,12 +73,26 @@ public class BitbucketBuildStatusNotificationsTrait extends SCMSourceTrait {
         return this.sendSuccessNotificationForUnstableBuild;
     }
 
+    @DataBoundSetter
+    public void setIncludeJenkinsURL(boolean isIncludeJenkinsURL) {
+        includeJenkinsURL = isIncludeJenkinsURL;
+    }
+
+    /**
+     * @return {@code true} if commit status should include Jenkins URL
+     */
+    public boolean getIncludeJenkinsURL() {
+        return this.includeJenkinsURL;
+    }
+
     /**
      * {@inheritDoc}
      */
     @Override
     protected void decorateContext(SCMSourceContext<?, ?> context) {
-        ((BitbucketSCMSourceContext) context).withSendSuccessNotificationForUnstableBuild(getSendSuccessNotificationForUnstableBuild());
+        ((BitbucketSCMSourceContext) context)
+                .withSendSuccessNotificationForUnstableBuild(getSendSuccessNotificationForUnstableBuild())
+                .withBuildStatusIncludeJenkinsURL(getIncludeJenkinsURL());
     }
 
     /**

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSourceContext.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSourceContext.java
@@ -92,6 +92,11 @@ public class BitbucketSCMSourceContext extends SCMSourceContext<BitbucketSCMSour
     private boolean sendSuccessNotificationForUnstableBuild;
 
     /**
+     * {@code true} if need to include Jenkins URL to the build status name and key.
+     */
+    private boolean buildStatusIncludeJenkinsURL;
+
+    /**
      * Constructor.
      *
      * @param criteria (optional) criteria.
@@ -213,6 +218,15 @@ public class BitbucketSCMSourceContext extends SCMSourceContext<BitbucketSCMSour
      */
     public final boolean sendSuccessNotificationForUnstableBuild() {
         return sendSuccessNotificationForUnstableBuild;
+    }
+
+    /**
+     * Returns {@code true} if should include Jenkins URL to a build status name and key.
+     *
+     * @return {@code false} if should NOT include Jenkins URL to a build status name and key.
+     */
+    public final boolean buildStatusIncludeJenkinsURL() {
+        return buildStatusIncludeJenkinsURL;
     }
 
     /**
@@ -349,6 +363,18 @@ public class BitbucketSCMSourceContext extends SCMSourceContext<BitbucketSCMSour
     @NonNull
     public final BitbucketSCMSourceContext withSendSuccessNotificationForUnstableBuild(boolean isUnstableBuildSuccess) {
         this.sendSuccessNotificationForUnstableBuild = isUnstableBuildSuccess;
+        return this;
+    }
+
+    /**
+     * Defines behaviour of build status name and key.
+     *
+     * @param buildStatusIncludeJenkinsURL {@code true} to inluce Jenkins URL to the build status key/name.
+     * @return {@code this} for method chaining.
+     */
+    @NonNull
+    public final BitbucketSCMSourceContext withBuildStatusIncludeJenkinsURL(boolean buildStatusIncludeJenkinsURL) {
+        this.buildStatusIncludeJenkinsURL = buildStatusIncludeJenkinsURL;
         return this;
     }
 

--- a/src/main/resources/com/cloudbees/jenkins/plugins/bitbucket/BitbucketBuildStatusNotificationsTrait/config.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/bitbucket/BitbucketBuildStatusNotificationsTrait/config.jelly
@@ -3,4 +3,7 @@
   <f:entry title="${%Communicate Unstable builds to Bitbucket as Successful}" field="sendSuccessNotificationForUnstableBuild">
     <f:checkbox/>
   </f:entry>
+  <f:entry title="${%Include Jenkins URL}" field="includeJenkinsURL">
+    <f:checkbox/>
+  </f:entry>
 </j:jelly>


### PR DESCRIPTION
This PR will add a new option to the existing commit status trait. Enabling this option will add Jenkins URL to the commit status key and description to differentiate notifications from different systems.

I initially wanted to include URL into the build status name, but at least Bitbucket Server does not making status popup windows wider to accommodate that. The end of the name getting shrined into `...`. I thought it is more important to see info about the job atop, so I included URL to the description instead of the name.

https://issues.jenkins.io/browse/JENKINS-65741

I could not find any existing tests for the commit statuses, and I am not really up to the challenge to cover it all with tests in the scope of this PR, so no tests in this PR. I did tested it locally on my Bitbucket Server instance.

<!--
To mark your pull request as work in progress please create it as a draft pull request
-->

### Your checklist for this pull request

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Did you provide a test-case? That demonstrates feature works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled the information below
Describe your pull request below
-->

![screencapture-stash-mtvi-projects-CDCNRY-repos-vmn-dummy-canary-app-pull-requests-12-builds-2021-06-21-19_12_47](https://user-images.githubusercontent.com/109895/122852296-3ab0fd00-d2c5-11eb-92e9-735429f18119.png)
