### PR TITLE
Retry idempotent requests to Bitbucket server

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/BitbucketServerAPIClient.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/BitbucketServerAPIClient.java
@@ -113,6 +113,7 @@ import org.apache.http.impl.client.BasicAuthCache;
 import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.client.StandardHttpRequestRetryHandler;
 import org.apache.http.message.BasicNameValuePair;
 import org.apache.http.util.EntityUtils;
 
@@ -930,6 +931,7 @@ public class BitbucketServerAPIClient implements BitbucketApi {
     private CloseableHttpClient getHttpClient(final HttpRequestBase request) {
         HttpClientBuilder httpClientBuilder = HttpClientBuilder.create();
         httpClientBuilder.useSystemProperties();
+        httpClientBuilder.setRetryHandler(new StandardHttpRequestRetryHandler());
 
         RequestConfig.Builder requestConfig = RequestConfig.custom();
         String connectTimeout = System.getProperty("http.connect.timeout", "10");


### PR DESCRIPTION
PR https://github.com/jenkinsci/bitbucket-branch-source-plugin/pull/214 introduced retries for requests to Bitbucket cloud. This PR makes the same change for Bitbucket Server requests, because I'm currently dealing with an unreliable Bitbucket Server.

### Your checklist for this pull request

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Did you provide a test-case? That demonstrates feature works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled the information below
Describe your pull request below
-->
