### PR TITLE
Fix #508: Reduce event registrations in Native 7.x

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/WebhookConfiguration.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/WebhookConfiguration.java
@@ -76,7 +76,7 @@ public class WebhookConfiguration {
     /**
      * The list of events available in Bitbucket Server v7.x.
      */
-    private static final List<String> NATIVE_SERVER_EVENTS_v7 = Collections.unmodifiableList(NATIVE_SERVER_EVENTS.subList(0, 2));
+    private static final List<String> NATIVE_SERVER_EVENTS_v7 = Collections.unmodifiableList(NATIVE_SERVER_EVENTS.subList(0, 5));
 
     /**
      * The list of events available in Bitbucket Server v6.x.  Applies to v5.10+.

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/WebhookConfiguration.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/WebhookConfiguration.java
@@ -76,7 +76,7 @@ public class WebhookConfiguration {
     /**
      * The list of events available in Bitbucket Server v7.x.
      */
-    private static final List<String> NATIVE_SERVER_EVENTS_v7 = Collections.unmodifiableList(NATIVE_SERVER_EVENTS.subList(0, 5));
+    private static final List<String> NATIVE_SERVER_EVENTS_v7 = Collections.unmodifiableList(NATIVE_SERVER_EVENTS.subList(0, 7));
 
     /**
      * The list of events available in Bitbucket Server v6.x.  Applies to v5.10+.

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/WebhookConfiguration.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/WebhookConfiguration.java
@@ -58,9 +58,9 @@ public class WebhookConfiguration {
     ));
 
     /**
-     * The list of events available in Bitbucket Server v7.x.
+     * The list of events available in Bitbucket Server.
      */
-    private static final List<String> NATIVE_SERVER_EVENTS_v7 = Collections.unmodifiableList(Arrays.asList(
+    private static final List<String> NATIVE_SERVER_EVENTS = Collections.unmodifiableList(Arrays.asList(
             HookEventType.SERVER_REFS_CHANGED.getKey(),
             HookEventType.SERVER_PULL_REQUEST_OPENED.getKey(),
             HookEventType.SERVER_PULL_REQUEST_MERGED.getKey(),
@@ -74,14 +74,19 @@ public class WebhookConfiguration {
     ));
 
     /**
+     * The list of events available in Bitbucket Server v7.x.
+     */
+    private static final List<String> NATIVE_SERVER_EVENTS_v7 = Collections.unmodifiableList(NATIVE_SERVER_EVENTS.subList(0, 2));
+
+    /**
      * The list of events available in Bitbucket Server v6.x.  Applies to v5.10+.
      */
-    private static final List<String> NATIVE_SERVER_EVENTS_v6 = Collections.unmodifiableList(NATIVE_SERVER_EVENTS_v7.subList(0, 7));
+    private static final List<String> NATIVE_SERVER_EVENTS_v6 = Collections.unmodifiableList(NATIVE_SERVER_EVENTS.subList(0, 7));
 
     /**
      * The list of events available in Bitbucket Server v5.9-.
      */
-    private static final List<String> NATIVE_SERVER_EVENTS_v5 = Collections.unmodifiableList(NATIVE_SERVER_EVENTS_v7.subList(0, 5));
+    private static final List<String> NATIVE_SERVER_EVENTS_v5 = Collections.unmodifiableList(NATIVE_SERVER_EVENTS.subList(0, 5));
 
     /**
      * The title of the webhook.

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/WebhookConfigurationTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/WebhookConfigurationTest.java
@@ -77,9 +77,12 @@ public class WebhookConfigurationTest {
         when(owner.getServerUrl()).thenReturn(server);
         when(owner.getEndpointJenkinsRootUrl()).thenReturn(server);
         BitbucketWebHook hook = whc.getHook(owner);
-        assertTrue(hook.getEvents().size() == 2);
+        assertTrue(hook.getEvents().size() == 5);
         assertTrue(hook.getEvents().contains(HookEventType.SERVER_REFS_CHANGED.getKey()));
         assertTrue(hook.getEvents().contains(HookEventType.SERVER_PULL_REQUEST_OPENED.getKey()));
+        assertTrue(hook.getEvents().contains(HookEventType.SERVER_PULL_REQUEST_MERGED.getKey()));
+        assertTrue(hook.getEvents().contains(HookEventType.SERVER_PULL_REQUEST_DECLINED.getKey()));
+        assertTrue(hook.getEvents().contains(HookEventType.SERVER_PULL_REQUEST_DELETED.getKey()));
     }
 
 }

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/WebhookConfigurationTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/WebhookConfigurationTest.java
@@ -77,12 +77,14 @@ public class WebhookConfigurationTest {
         when(owner.getServerUrl()).thenReturn(server);
         when(owner.getEndpointJenkinsRootUrl()).thenReturn(server);
         BitbucketWebHook hook = whc.getHook(owner);
-        assertTrue(hook.getEvents().size() == 5);
+        assertTrue(hook.getEvents().size() == 7);
         assertTrue(hook.getEvents().contains(HookEventType.SERVER_REFS_CHANGED.getKey()));
         assertTrue(hook.getEvents().contains(HookEventType.SERVER_PULL_REQUEST_OPENED.getKey()));
         assertTrue(hook.getEvents().contains(HookEventType.SERVER_PULL_REQUEST_MERGED.getKey()));
         assertTrue(hook.getEvents().contains(HookEventType.SERVER_PULL_REQUEST_DECLINED.getKey()));
         assertTrue(hook.getEvents().contains(HookEventType.SERVER_PULL_REQUEST_DELETED.getKey()));
+        assertTrue(hook.getEvents().contains(HookEventType.SERVER_PULL_REQUEST_MODIFIED.getKey()));
+        assertTrue(hook.getEvents().contains(HookEventType.SERVER_PULL_REQUEST_REVIEWER_UPDATED.getKey()));
     }
 
 }

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/WebhookConfigurationTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/WebhookConfigurationTest.java
@@ -77,7 +77,9 @@ public class WebhookConfigurationTest {
         when(owner.getServerUrl()).thenReturn(server);
         when(owner.getEndpointJenkinsRootUrl()).thenReturn(server);
         BitbucketWebHook hook = whc.getHook(owner);
-        assertTrue(hook.getEvents().contains(HookEventType.SERVER_PULL_REQUEST_FROM_REF_UPDATED.getKey()));
+        assertTrue(hook.getEvents().size() == 2);
+        assertTrue(hook.getEvents().contains(HookEventType.SERVER_REFS_CHANGED.getKey()));
+        assertTrue(hook.getEvents().contains(HookEventType.SERVER_PULL_REQUEST_OPENED.getKey()));
     }
 
 }


### PR DESCRIPTION
Update: Ah, sadly all events are required for certain scenarios.

`pr:from_ref_updated` is unfortunately the only way to receive an event on _forked_ PRs. So the only way for now to remedy dupe builds is to have a `quietPeriod`.

Will look into GitHub to see if they cater for duplicate events somehow...

<!--
To mark your pull request as work in progress please create it as a draft pull request
-->

### Your checklist for this pull request

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Did you provide a test-case? That demonstrates feature works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled the information below
Describe your pull request below
-->
