### PR TITLE
fix: call the /changes API to make the commit hash available in the target repo

### DIFF
--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSourceRetrieveTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSourceRetrieveTest.java
@@ -1,0 +1,218 @@
+package com.cloudbees.jenkins.plugins.bitbucket;
+
+import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketApi;
+import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketBranch;
+import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketCommit;
+import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketPullRequest;
+import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketPullRequestDestination;
+import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketPullRequestEvent;
+import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketPullRequestSource;
+import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketRepository;
+import com.cloudbees.jenkins.plugins.bitbucket.client.BitbucketCloudApiClient;
+import com.cloudbees.jenkins.plugins.bitbucket.client.branch.BitbucketCloudBranch;
+import com.cloudbees.jenkins.plugins.bitbucket.endpoints.BitbucketCloudEndpoint;
+import com.cloudbees.jenkins.plugins.bitbucket.hooks.HasPullRequests;
+import com.cloudbees.jenkins.plugins.bitbucket.server.client.BitbucketServerAPIClient;
+import com.cloudbees.jenkins.plugins.bitbucket.server.client.branch.BitbucketServerBranch;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.model.TaskListener;
+import hudson.scm.SCM;
+import java.net.URL;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import jenkins.model.Jenkins;
+import jenkins.scm.api.SCMHead;
+import jenkins.scm.api.SCMHeadEvent;
+import jenkins.scm.api.SCMHeadObserver;
+import jenkins.scm.api.SCMNavigator;
+import jenkins.scm.api.SCMRevision;
+import jenkins.scm.api.SCMSource;
+import jenkins.scm.api.SCMSourceCriteria;
+import org.hamcrest.Matchers;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests different scenarios of the
+ * {@link BitbucketSCMSource#retrieve(SCMSourceCriteria, SCMHeadObserver, SCMHeadEvent, TaskListener)} method.
+ *
+ * This test was created to validate a fix for the issue described in:
+ * https://github.com/jenkinsci/bitbucket-branch-source-plugin/issues/469
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class BitbucketSCMSourceRetrieveTest {
+
+    private static final String CLOUD_REPO_OWNER = "cloudbeers";
+    private static final String SERVER_REPO_OWNER = "DUB";
+    private static final String SERVER_REPO_URL = "https://bitbucket.test";
+    private static final String REPO_NAME = "stunning-adventure";
+    private static final String BRANCH_NAME = "branch1";
+    private static final String COMMIT_HASH = "e851558f77c098d21af6bb8cc54a423f7cf12147";
+    private static final Integer PR_ID = 1;
+
+    @ClassRule
+    public static JenkinsRule jenkinsRule = new JenkinsRule();
+
+    @Mock
+    private BitbucketRepository repository;
+    @Mock
+    private BitbucketBranch sourceBranch;
+    @Mock
+    private BitbucketBranch destinationBranch;
+    @Mock
+    private BitbucketPullRequestDestination prDestination;
+    @Mock
+    private BitbucketPullRequestSource prSource;
+    @Mock
+    private BitbucketCommit commit;
+    @Mock
+    private BitbucketPullRequest pullRequest;
+    @Mock
+    private SCMSourceCriteria criteria;
+
+    @Before
+    public void setUp() {
+        when(prDestination.getRepository()).thenReturn(repository);
+        when(prDestination.getBranch()).thenReturn(destinationBranch);
+        when(destinationBranch.getName()).thenReturn("main");
+
+        when(sourceBranch.getName()).thenReturn(BRANCH_NAME);
+        when(prSource.getRepository()).thenReturn(repository);
+        when(prSource.getBranch()).thenReturn(sourceBranch);
+        when(commit.getHash()).thenReturn(COMMIT_HASH);
+        when(prSource.getCommit()).thenReturn(commit);
+
+        when(pullRequest.getSource()).thenReturn(prSource);
+        when(pullRequest.getDestination()).thenReturn(prDestination);
+        when(pullRequest.getId()).thenReturn(PR_ID.toString());
+    }
+
+    @Test
+    public void retrieveTriggersRequiredApiCalls_cloud() throws Exception {
+        BitbucketSCMSource instance = load("retrieve_prs_test_cloud");
+        assertThat(instance.getId(), is("retrieve_prs_test_cloud"));
+        assertThat(instance.getServerUrl(), is(BitbucketCloudEndpoint.SERVER_URL));
+        assertThat(instance.getRepoOwner(), is(CLOUD_REPO_OWNER));
+        assertThat(instance.getRepository(), is(REPO_NAME));
+        BitbucketCloudApiClient client = BitbucketClientMockUtils.getAPIClientMock(true, false);
+        BitbucketMockApiFactory.add(BitbucketCloudEndpoint.SERVER_URL, client);
+
+        List<BitbucketCloudBranch> branches =
+            Collections.singletonList(new BitbucketCloudBranch(BRANCH_NAME, COMMIT_HASH, 0));
+        when(client.getBranches()).thenReturn(branches);
+
+        verifyExpectedClientApiCalls(instance, client);
+    }
+
+    @Test
+    public void retrieveTriggersRequiredApiCalls_server() throws Exception {
+        BitbucketSCMSource instance = load("retrieve_prs_test_server");
+        assertThat(instance.getServerUrl(), is(SERVER_REPO_URL));
+        assertThat(instance.getRepoOwner(), is(SERVER_REPO_OWNER));
+        assertThat(instance.getRepository(), is(REPO_NAME));
+
+        BitbucketServerAPIClient client = mock(BitbucketServerAPIClient.class);
+        BitbucketMockApiFactory.add(SERVER_REPO_URL, client);
+
+        List<BitbucketServerBranch> branches =
+            Collections.singletonList(new BitbucketServerBranch(BRANCH_NAME, COMMIT_HASH));
+        when(client.getBranches()).thenReturn(branches);
+        when(client.getRepository()).thenReturn(repository);
+
+        verifyExpectedClientApiCalls(instance, client);
+    }
+
+    /**
+     * Given a BitbucketSCMSource, call the retrieve(SCMSourceCriteria, SCMHeadObserver, SCMHeadEvent, TaskListener)
+     * method with an event having a PR and verify the expected client API calls
+     *
+     * @param instance The BitbucketSCMSource instance that has been configured with the traits required
+     *                 for testing this code path.
+     */
+    private void verifyExpectedClientApiCalls(BitbucketSCMSource instance, BitbucketApi apiClient) throws Exception {
+        String fullRepoName = instance.getRepoOwner() + '/' + instance.getRepository();
+        when(repository.getFullName()).thenReturn(fullRepoName);
+        when(repository.getRepositoryName()).thenReturn(instance.getRepository());
+
+        when(pullRequest.getLink()).thenReturn(instance.getServerUrl() + '/' + fullRepoName + "/pull-requests/" + PR_ID);
+        when(apiClient.getPullRequestById(PR_ID)).thenReturn(pullRequest);
+
+        SCMHeadEvent<?> event = new HeadEvent(Collections.singleton(pullRequest));
+        TaskListener taskListener = BitbucketClientMockUtils.getTaskListenerMock();
+        SCMHeadObserver.Collector headObserver = new SCMHeadObserver.Collector();
+        when(criteria.isHead(Mockito.any(), Mockito.same(taskListener))).thenReturn(true);
+
+        instance.retrieve(criteria, headObserver, event, taskListener);
+
+        // Expect the observer to collect the branch and the PR
+        Set<String> heads =
+            headObserver.result().keySet().stream().map(SCMHead::getName).collect(Collectors.toSet());
+        assertThat(heads, Matchers.containsInAnyOrder("PR-1", BRANCH_NAME));
+
+        // Ensures PR is properly initialized, especially fork-based PRs
+        // see BitbucketServerAPIClient.setupPullRequest()
+        verify(apiClient, Mockito.times(1)).getPullRequestById(PR_ID);
+        // The event is a HasPullRequests, so this call should be skipped in favor of getting PRs from the event itself
+        verify(apiClient, Mockito.never()).getPullRequests();
+        // Fetch tags trait was not enabled on the BitbucketSCMSource
+        verify(apiClient, Mockito.never()).getTags();
+    }
+
+    private static final class HeadEvent extends SCMHeadEvent<BitbucketPullRequestEvent> implements HasPullRequests {
+        private final Collection<BitbucketPullRequest> pullRequests;
+
+        private HeadEvent(Collection<BitbucketPullRequest> pullRequests) {
+            super(Type.UPDATED, 0, mock(BitbucketPullRequestEvent.class), "origin");
+            this.pullRequests = pullRequests;
+        }
+
+        @Override
+        public Iterable<BitbucketPullRequest> getPullRequests(BitbucketSCMSource src) {
+            return pullRequests;
+        }
+
+        @Override
+        public boolean isMatch(@NonNull SCMNavigator navigator) {
+            return false;
+        }
+
+        @NonNull
+        @Override
+        public String getSourceName() {
+            return REPO_NAME;
+        }
+
+        @NonNull
+        @Override
+        public Map<SCMHead, SCMRevision> heads(@NonNull SCMSource source) {
+            return Collections.emptyMap();
+        }
+
+        @Override
+        public boolean isMatch(@NonNull SCM scm) {
+            return false;
+        }
+    }
+
+    private BitbucketSCMSource load(String configuration) {
+        String path = getClass().getSimpleName() + "/" + configuration + ".xml";
+        URL url = getClass().getResource(path);
+        return (BitbucketSCMSource) Jenkins.XSTREAM2.fromXML(url);
+    }
+}

--- a/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSourceRetrieveTest/retrieve_prs_test_cloud.xml
+++ b/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSourceRetrieveTest/retrieve_prs_test_cloud.xml
@@ -1,0 +1,32 @@
+<com.cloudbees.jenkins.plugins.bitbucket.BitbucketSCMSource>
+  <id>retrieve_prs_test_cloud</id>
+  <serverUrl>https://bitbucket.org</serverUrl>
+  <credentialsId>bb-cloud-creds</credentialsId>
+  <repoOwner>cloudbeers</repoOwner>
+  <repository>stunning-adventure</repository>
+  <traits>
+    <jenkins.scm.impl.trait.RegexSCMHeadFilterTrait>
+      <regex>.*</regex>
+    </jenkins.scm.impl.trait.RegexSCMHeadFilterTrait>
+    <com.cloudbees.jenkins.plugins.bitbucket.BranchDiscoveryTrait>
+      <strategyId>3</strategyId>
+    </com.cloudbees.jenkins.plugins.bitbucket.BranchDiscoveryTrait>
+    <com.cloudbees.jenkins.plugins.bitbucket.WebhookRegistrationTrait>
+      <mode>ITEM</mode>
+    </com.cloudbees.jenkins.plugins.bitbucket.WebhookRegistrationTrait>
+    <com.cloudbees.jenkins.plugins.bitbucket.OriginPullRequestDiscoveryTrait>
+      <strategyId>1</strategyId>
+    </com.cloudbees.jenkins.plugins.bitbucket.OriginPullRequestDiscoveryTrait>
+    <jenkins.plugins.git.traits.RefSpecsSCMSourceTrait>
+      <templates>
+        <jenkins.plugins.git.traits.RefSpecsSCMSourceTrait_-RefSpecTemplate>
+          <value>+refs/heads/*:refs/remotes/@{remote}/*</value>
+        </jenkins.plugins.git.traits.RefSpecsSCMSourceTrait_-RefSpecTemplate>
+      </templates>
+    </jenkins.plugins.git.traits.RefSpecsSCMSourceTrait>
+    <com.cloudbees.jenkins.plugins.bitbucket.ForkPullRequestDiscoveryTrait>
+      <strategyId>1</strategyId>
+      <trust class="com.cloudbees.jenkins.plugins.bitbucket.ForkPullRequestDiscoveryTrait$TrustEveryone"/>
+    </com.cloudbees.jenkins.plugins.bitbucket.ForkPullRequestDiscoveryTrait>
+  </traits>
+</com.cloudbees.jenkins.plugins.bitbucket.BitbucketSCMSource>

--- a/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSourceRetrieveTest/retrieve_prs_test_server.xml
+++ b/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSourceRetrieveTest/retrieve_prs_test_server.xml
@@ -1,0 +1,38 @@
+<com.cloudbees.jenkins.plugins.bitbucket.BitbucketSCMSource>
+  <id>retrieve_prs_test_server</id>
+  <credentialsId>bb-server-creds</credentialsId>
+  <checkoutCredentialsId>SAME</checkoutCredentialsId>
+  <repoOwner>DUB</repoOwner>
+  <repository>stunning-adventure</repository>
+  <includes>*</includes>
+  <excludes></excludes>
+  <autoRegisterHook>false</autoRegisterHook>
+  <bitbucketServerUrl>https://bitbucket.test</bitbucketServerUrl>
+  <sshPort>7999</sshPort>
+  <repositoryType>GIT</repositoryType>
+  <traits>
+    <jenkins.scm.impl.trait.RegexSCMHeadFilterTrait>
+      <regex>.*</regex>
+    </jenkins.scm.impl.trait.RegexSCMHeadFilterTrait>
+    <com.cloudbees.jenkins.plugins.bitbucket.BranchDiscoveryTrait>
+      <strategyId>3</strategyId>
+    </com.cloudbees.jenkins.plugins.bitbucket.BranchDiscoveryTrait>
+    <com.cloudbees.jenkins.plugins.bitbucket.WebhookRegistrationTrait>
+      <mode>ITEM</mode>
+    </com.cloudbees.jenkins.plugins.bitbucket.WebhookRegistrationTrait>
+    <com.cloudbees.jenkins.plugins.bitbucket.OriginPullRequestDiscoveryTrait>
+      <strategyId>1</strategyId>
+    </com.cloudbees.jenkins.plugins.bitbucket.OriginPullRequestDiscoveryTrait>
+    <jenkins.plugins.git.traits.RefSpecsSCMSourceTrait>
+      <templates>
+        <jenkins.plugins.git.traits.RefSpecsSCMSourceTrait_-RefSpecTemplate>
+          <value>+refs/heads/*:refs/remotes/@{remote}/*</value>
+        </jenkins.plugins.git.traits.RefSpecsSCMSourceTrait_-RefSpecTemplate>
+      </templates>
+    </jenkins.plugins.git.traits.RefSpecsSCMSourceTrait>
+    <com.cloudbees.jenkins.plugins.bitbucket.ForkPullRequestDiscoveryTrait>
+      <strategyId>1</strategyId>
+      <trust class="com.cloudbees.jenkins.plugins.bitbucket.ForkPullRequestDiscoveryTrait$TrustEveryone"/>
+    </com.cloudbees.jenkins.plugins.bitbucket.ForkPullRequestDiscoveryTrait>
+  </traits>
+</com.cloudbees.jenkins.plugins.bitbucket.BitbucketSCMSource>


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
## Description

Proposed fix for the problem raised in [ issue #469](https://github.com/jenkinsci/bitbucket-branch-source-plugin/issues/469) regarding fork-based PRs not triggering builds.  In order for a commit hash from a fork-based PR to be made visible in the target repo, a call to the `/changes` API must be made.  The fix was based on comments found in [BitbucketServerAPIClient.setupPullRequest()](https://github.com/jenkinsci/bitbucket-branch-source-plugin/blob/master/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/BitbucketServerAPIClient.java#L338-L362) which were discussed with and confirmed by Atlassian support.

### Testing

A new unit test has been provided that exercises code paths within `BitbucketSCMSource.retrieve(SCMSourceCriteria, SCMHeadObserver observer, SCMHeadEvent, TaskListener)`.  As this method is void, the test attempts to verify its side effects, namely specific API calls that are made by the client.

#### Manual Testing

This change has been tested using Bitbucket Server v7.6.7 with native webhooks and Jenkins 2.319.1. We've been running with this fix on our production Jenkins instances for about two weeks and have not noticed any problems.  
Test scenarios include:
* Open new fork-based PR
* Push new commits to fork-based PR (including rebase and force push)
* Decline and re-open fork-based PR
* Open new feature branch-based PR
* Push new commits to feature branch-based (including rebase and force push)
* Decline and re-open feature branch-based PR
As the issue for us was primarily with fork-based PRs, the testing against feature branches was for regression purposes.

## 04-15-2022 Update on Bitbucket Cloud Testing
I was able able to create an environment that allowed me to test this change against Bitbucket Cloud
* Jenkins version: `2.332.2`
* Plugin version : `762.v969cfe087fc0` + my changes

Testing summary below:

### With version `762.v969cfe087fc0` (no changes)

#### Fork-based PR Created

```
[Fri Apr 15 14:45:03 UTC 2022] Received com.cloudbees.jenkins.plugins.bitbucket.hooks.PullRequestHookProcessor$HeadEvent CREATED event from 18.246.31.227 ⇒ http://my-jenkins-host/bitbucket-scmsource-hook/notify with timestamp Fri Apr 15 14:44:58 UTC 2022
Connecting to https://bitbucket.org using scott_jarvi/******
Repository type: Git
Looking up scott_jarvi/bb-branch-source-plugin for branches
Checking branch feature/doc-updates from scott_jarvi/bb-branch-source-plugin
Checking branch main from scott_jarvi/bb-branch-source-plugin

  2 branches were processed
Looking up scott_jarvi/bb-branch-source-plugin for pull requests
Checking PR-4 from scott_jarvi/bb-branch-source-plugin-fork and branch feature/refactor-docs
      ‘Jenkinsfile’ found
    Met criteria
Scheduled build for branch: PR-4
```

#### Fork-based PR Updated

```
[Fri Apr 15 14:52:26 UTC 2022] Received com.cloudbees.jenkins.plugins.bitbucket.hooks.PullRequestHookProcessor$HeadEvent UPDATED event from 18.246.31.232 ⇒ http://my-jenkins-host/bitbucket-scmsource-hook/notify with timestamp Fri Apr 15 14:52:21 UTC 2022
Connecting to https://bitbucket.org using scott_jarvi/******
Repository type: Git
Looking up scott_jarvi/bb-branch-source-plugin for branches
Checking branch feature/doc-updates from scott_jarvi/bb-branch-source-plugin
Checking branch main from scott_jarvi/bb-branch-source-plugin

  2 branches were processed
Looking up scott_jarvi/bb-branch-source-plugin for pull requests
Checking PR-4 from scott_jarvi/bb-branch-source-plugin-fork and branch feature/refactor-docs
      ‘Jenkinsfile’ found
    Met criteria
Changes detected: PR-4 (a2600ebcc065+6eb6736cba2a → b7e50a0d9281+6eb6736cba2a)
Scheduled build for branch: PR-4
```

#### Fork-based PR Declined

```
[Fri Apr 15 14:56:24 UTC 2022] Received com.cloudbees.jenkins.plugins.bitbucket.hooks.PullRequestHookProcessor$HeadEvent REMOVED event from 18.246.31.227 ⇒ http://my-jenkins-host/bitbucket-scmsource-hook/notify with timestamp Fri Apr 15 14:56:19 UTC 2022
Connecting to https://bitbucket.org using scott_jarvi/******
Repository type: Git
Looking up scott_jarvi/bb-branch-source-plugin for branches
Checking branch feature/doc-updates from scott_jarvi/bb-branch-source-plugin
Checking branch main from scott_jarvi/bb-branch-source-plugin

  2 branches were processed
Looking up scott_jarvi/bb-branch-source-plugin for pull requests

  0 pull requests were processed
  ```


### With version `762.v969cfe087fc0` + my fix

#### Fork-based PR Created

```
[Fri Apr 15 01:38:34 UTC 2022] com.cloudbees.jenkins.plugins.bitbucket.hooks.PullRequestHookProcessor$HeadEvent CREATED event from 18.246.31.227 ⇒ http://my-jenkins-host/bitbucket-scmsource-hook/notify with timestamp Fri Apr 15 01:38:28 UTC 2022 processed in 0.53 sec
[Fri Apr 15 13:06:37 UTC 2022] Received com.cloudbees.jenkins.plugins.bitbucket.hooks.PullRequestHookProcessor$HeadEvent CREATED event from 18.246.31.224 ⇒ http://my-jenkins-host/bitbucket-scmsource-hook/notify with timestamp Fri Apr 15 13:06:31 UTC 2022
Connecting to https://bitbucket.org using scott_jarvi/******
Repository type: Git
Looking up scott_jarvi/bb-branch-source-plugin for branches
Checking branch feature/doc-updates from scott_jarvi/bb-branch-source-plugin
Checking branch main from scott_jarvi/bb-branch-source-plugin

  2 branches were processed
Looking up scott_jarvi/bb-branch-source-plugin for pull requests
Initialized PR: https://bitbucket.org/scott_jarvi/bb-branch-source-plugin/pull-requests/3
Checking PR-3 from scott_jarvi/bb-branch-source-plugin-fork and branch feature/more-doc-updates
      ‘Jenkinsfile’ found
    Met criteria
Scheduled build for branch: PR-3
```

#### Fork-based PR Updated

```
[Fri Apr 15 14:01:15 UTC 2022] Received com.cloudbees.jenkins.plugins.bitbucket.hooks.PullRequestHookProcessor$HeadEvent UPDATED event from 18.246.31.231 ⇒ http://my-jenkins-host/bitbucket-scmsource-hook/notify with timestamp Fri Apr 15 14:01:10 UTC 2022
Connecting to https://bitbucket.org using scott_jarvi/******
Repository type: Git
Looking up scott_jarvi/bb-branch-source-plugin for branches
Checking branch feature/doc-updates from scott_jarvi/bb-branch-source-plugin
Checking branch main from scott_jarvi/bb-branch-source-plugin

  2 branches were processed
Looking up scott_jarvi/bb-branch-source-plugin for pull requests
Initialized PR: https://bitbucket.org/scott_jarvi/bb-branch-source-plugin/pull-requests/3
Checking PR-3 from scott_jarvi/bb-branch-source-plugin-fork and branch feature/more-doc-updates
      ‘Jenkinsfile’ found
    Met criteria
Changes detected: PR-3 (36e988c88ba5+6eb6736cba2a → 283f5098f707+6eb6736cba2a)
Scheduled build for branch: PR-3
```

#### Fork-based PR Declined

```
[Fri Apr 15 14:10:42 UTC 2022] Received com.cloudbees.jenkins.plugins.bitbucket.hooks.PullRequestHookProcessor$HeadEvent REMOVED event from 18.246.31.232 ⇒ http://my-jenkins-host/bitbucket-scmsource-hook/notify with timestamp Fri Apr 15 14:10:37 UTC 2022
Connecting to https://bitbucket.org using scott_jarvi/******
Repository type: Git
Looking up scott_jarvi/bb-branch-source-plugin for branches
Checking branch feature/doc-updates from scott_jarvi/bb-branch-source-plugin
Checking branch main from scott_jarvi/bb-branch-source-plugin

  2 branches were processed
Looking up scott_jarvi/bb-branch-source-plugin for pull requests
```

While this issue does not impact feature branches from the main repo, I ran the same test scenarios using feature branches and found no issues.


<!--
To mark your pull request as work in progress please create it as a draft pull request
-->

### Your checklist for this pull request

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Did you provide a test-case? That demonstrates feature works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled the information below
Describe your pull request below
-->
