### PR TITLE
Replace Guava's Files.copy with commons FileUtils in test

### DIFF
--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/endpoints/BitbucketEndpointConfigurationTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/endpoints/BitbucketEndpointConfigurationTest.java
@@ -30,7 +30,6 @@ import com.cloudbees.plugins.credentials.CredentialsScope;
 import com.cloudbees.plugins.credentials.SystemCredentialsProvider;
 import com.cloudbees.plugins.credentials.domains.Domain;
 import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl;
-import com.google.common.io.Files;
 import com.google.common.io.Resources;
 import hudson.XmlFile;
 import hudson.security.ACL;
@@ -45,6 +44,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import jenkins.model.Jenkins;
+import org.apache.commons.io.FileUtils;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -634,7 +634,7 @@ public class BitbucketEndpointConfigurationTest {
     public void given__serverConfig__without__webhookImplementation__then__usePlugin() throws Exception {
         final URL configWithoutWebhookImpl = Resources.getResource(getClass(), "config-without-webhook-impl.xml");
         final File configFile = new File(Jenkins.get().getRootDir(), BitbucketEndpointConfiguration.class.getName() + ".xml");
-        Files.copy(Resources.newInputStreamSupplier(configWithoutWebhookImpl), configFile);
+        FileUtils.copyURLToFile(configWithoutWebhookImpl, configFile);
 
         final BitbucketEndpointConfiguration instance = new BitbucketEndpointConfiguration();
 


### PR DESCRIPTION
As there is no way to make simple code that works for both Guava 11 and 31. I could wait for `2.332.1` to be released, update the baseline and make all the needed changes in the code to the new Guava classes, but in two years I will have to do it again...

Note this is affecting only a test, no production code, so just running the test proves it works.

<!-- Please describe your pull request here. -->

<!--
To mark your pull request as work in progress please create it as a draft pull request
-->

### Your checklist for this pull request

- [ ] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Did you provide a test-case? That demonstrates feature works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled the information below
Describe your pull request below
-->
