### PR TITLE
Added instructions on using Bitbucket App Passwords to the user guide.

### DIFF
--- a/docs/USER_GUIDE.adoc
+++ b/docs/USER_GUIDE.adoc
@@ -123,6 +123,18 @@ Then create new _Secret text credentials_ in Jenkins and enter the Bitbucket per
 
 When configuring a multi-branch project, add the _Checkout over SSH_ behavior to a branch source, as the token can only be used for the Bitbucket API.
 
+=== App Passwords
+
+Bitbucket https://community.atlassian.com/t5/Bitbucket-articles/Announcement-Bitbucket-Cloud-account-password-usage-for-Git-over/ba-p/1948231[deprecated usage of Atlassian account password] for Bitbucket API and Git over HTTPS starting from March 1st, 2022 (Bitbucket Cloud only).
+
+The plugin can make use of an app password instead of the standard username/password.
+
+First create a new _app password_ in Bitbucket as instructed in the https://support.atlassian.com/bitbucket-cloud/docs/app-passwords/[Bitbucket App Passwords Documentation]. At least allow _read_ access for repositories. Also, you may need to allow _read_ and _write_ access for webhooks depending on your pipeline's triggers.
+
+Then create a new _Username with password credentials_ in Jenkins, enter the Bitbucket username (not the email) in the _Username_ field and the created app password in the _Password_ field.
+
+ IMPORTANT: App passwords do not support email address as a username for authentication. Using the email address will raise an authentication error in scanning/checkout process.
+
 === OAuth credentials
 
 The plugin can make use of OAuth credentials (Bitbucket Cloud only) instead of the standard username/password.


### PR DESCRIPTION
Users (and myself) were having trouble using App passwords after Bitbucket deprecated usage of Atlassian account passwords in Git over HTTPS and API. 

See [issue 573](https://github.com/jenkinsci/bitbucket-branch-source-plugin/issues/573)

Mainly the cause was the use of email address as the username. To avoid confusion, I added a section with instructions on using App passwords emphasizing on use of _username_ instead of email address.

<!--
To mark your pull request as work in progress please create it as a draft pull request
-->

### Your checklist for this pull request

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Did you provide a test-case? That demonstrates feature works or fixes the issue.
