### PR TITLE
Add possibility to disable send any build notification to bitbucket

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketBuildStatusNotificationsTrait.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketBuildStatusNotificationsTrait.java
@@ -51,6 +51,11 @@ public class BitbucketBuildStatusNotificationsTrait extends SCMSourceTrait {
     private boolean disableNotificationForNotBuildJobs;
 
     /**
+     * Should not send any notification to Bitbucket
+     */
+    private boolean disableNotifications;
+
+    /**
      * Constructor.
      *
      */
@@ -85,6 +90,19 @@ public class BitbucketBuildStatusNotificationsTrait extends SCMSourceTrait {
         return this.disableNotificationForNotBuildJobs;
     }
 
+    @DataBoundSetter
+    public void setDisableNotifications(boolean isNotificationDisabled) {
+        disableNotifications = isNotificationDisabled;
+    }
+
+    /**
+     * @return if builds notifications will be communicated
+     */
+    public boolean getDisableNotifications() {
+        return this.disableNotifications;
+    }
+
+
     /**
      * {@inheritDoc}
      */
@@ -92,6 +110,7 @@ public class BitbucketBuildStatusNotificationsTrait extends SCMSourceTrait {
     protected void decorateContext(SCMSourceContext<?, ?> context) {
         ((BitbucketSCMSourceContext) context).withDisableNotificationForNotBuildJobs(getDisableNotificationForNotBuildJobs());
         ((BitbucketSCMSourceContext) context).withSendSuccessNotificationForUnstableBuild(getSendSuccessNotificationForUnstableBuild());
+        ((BitbucketSCMSourceContext) context).withNotificationsDisabled(getDisableNotifications());
     }
 
     /**

--- a/src/main/resources/com/cloudbees/jenkins/plugins/bitbucket/BitbucketBuildStatusNotificationsTrait/config.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/bitbucket/BitbucketBuildStatusNotificationsTrait/config.jelly
@@ -1,5 +1,8 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+  <f:entry title="${%Do no communicate builds status to Bitbucket}" field="disableNotifications">
+    <f:checkbox/>
+  </f:entry>
   <f:entry title="${%Communicate unstable builds to Bitbucket as successful}" field="sendSuccessNotificationForUnstableBuild">
     <f:checkbox/>
   </f:entry>


### PR DESCRIPTION
This PR add the feature to disable notification sending to bitbucket via BitbucketBuildStatusNotificationsTrait

We basically have our own Jenkins pipeline with custom notification steps and this plugin send duplicates notifications and sometime not accurate build status. (Maybe fixed with #472 but still will end up with multiple notifications in Bitbucket Builds) 


### Your checklist for this pull request

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Did you provide a test-case? That demonstrates feature works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled the information below
Describe your pull request below
-->
