### PR TITLE
Organisation Folder Scan - newly discovered repositories are now processed first

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMNavigatorRequest.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMNavigatorRequest.java
@@ -26,9 +26,12 @@ package com.cloudbees.jenkins.plugins.bitbucket;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketRepository;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Collection;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.TreeMap;
+import java.util.stream.Collectors;
 import jenkins.scm.api.SCMNavigator;
 import jenkins.scm.api.SCMSourceObserver;
 import jenkins.scm.api.trait.SCMNavigatorRequest;
@@ -46,6 +49,11 @@ public class BitbucketSCMNavigatorRequest extends SCMNavigatorRequest {
     private final Map<String, BitbucketRepository> repositoryMap = new TreeMap<>();
 
     /**
+     * keep a reference to the observer so we can cross-reference
+     */
+    private final SCMSourceObserver observer;
+
+    /**
      * Constructor.
      *
      * @param source   the source.
@@ -56,6 +64,7 @@ public class BitbucketSCMNavigatorRequest extends SCMNavigatorRequest {
                                            @NonNull BitbucketSCMNavigatorContext context,
                                            @NonNull SCMSourceObserver observer) {
         super(source, context, observer);
+        this.observer = observer;
     }
 
     public void withRepositories(List<? extends BitbucketRepository> repositories) {
@@ -66,7 +75,19 @@ public class BitbucketSCMNavigatorRequest extends SCMNavigatorRequest {
     }
 
     public Collection<BitbucketRepository> repositories() {
-        return this.repositoryMap.values();
+        final List<String> existingRepositories = this.observer.getContext().getSCMSources().stream()
+                                                               .map(BitbucketSCMSource.class::cast)
+                                                               .map(BitbucketSCMSource::getRepository)
+                                                               .collect(Collectors.toList());
+        // process new repositories first
+        final Set<BitbucketRepository> newRepositories = this.repositoryMap.entrySet()
+                                                                           .stream()
+                                                                           .filter(e -> !existingRepositories.contains(e.getKey()))
+                                                                           .map(Map.Entry::getValue)
+                                                                           .collect(Collectors.toCollection(LinkedHashSet::new));
+        // add remaining repositories back in. duplicates will be rejected
+        newRepositories.addAll(this.repositoryMap.values());
+        return newRepositories;
     }
 
     public BitbucketRepository getBitbucketRepository(String repositoryName) {

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMNavigatorRequest.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMNavigatorRequest.java
@@ -76,6 +76,7 @@ public class BitbucketSCMNavigatorRequest extends SCMNavigatorRequest {
 
     public Collection<BitbucketRepository> repositories() {
         final List<String> existingRepositories = this.observer.getContext().getSCMSources().stream()
+                                                               .filter(BitbucketSCMSource.class::isInstance)
                                                                .map(BitbucketSCMSource.class::cast)
                                                                .map(BitbucketSCMSource::getRepository)
                                                                .collect(Collectors.toList());

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/SCMNavigatorTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/SCMNavigatorTest.java
@@ -27,6 +27,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.model.TaskListener;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import jenkins.scm.api.SCMSource;
 import jenkins.scm.api.SCMSourceObserver;
@@ -39,6 +40,7 @@ import org.mockito.Mockito;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
 
 public class SCMNavigatorTest {
 
@@ -52,8 +54,10 @@ public class SCMNavigatorTest {
         BitbucketSCMNavigator navigator = new BitbucketSCMNavigator("myteam", null, null);
         navigator.setPattern("repo(.*)");
         navigator.setBitbucketServerUrl("http://bitbucket.test");
+        final SCMSourceOwner mock = Mockito.mock(SCMSourceOwner.class);
+        when(mock.getSCMSources()).thenReturn(Collections.singletonList(new BitbucketSCMSource("myteam", "repo1")));
         SCMSourceObserverImpl observer = new SCMSourceObserverImpl(BitbucketClientMockUtils.getTaskListenerMock(),
-                Mockito.mock(SCMSourceOwner.class));
+                                                                   mock);
         navigator.visitSources(observer);
 
         assertEquals("myteam", navigator.getRepoOwner());
@@ -62,8 +66,8 @@ public class SCMNavigatorTest {
         List<String> observed = observer.getObserved();
         // Only 2 repositories match the pattern
         assertEquals("There must be 2 repositories in the team", 2, observed.size());
-        assertEquals("repo1", observed.get(0));
-        assertEquals("repo2", observed.get(1));
+        assertEquals("repo2 should be first", "repo2", observed.get(0));
+        assertEquals("repo1 should be second", "repo1", observed.get(1));
 
         List<ProjectObserver> observers = observer.getProjectObservers();
         for (ProjectObserver obs : observers) {

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/SCMNavigatorTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/SCMNavigatorTest.java
@@ -23,6 +23,7 @@
  */
 package com.cloudbees.jenkins.plugins.bitbucket;
 
+import com.google.common.collect.ImmutableList;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.model.TaskListener;
 import java.io.IOException;
@@ -33,6 +34,7 @@ import jenkins.scm.api.SCMSource;
 import jenkins.scm.api.SCMSourceObserver;
 import jenkins.scm.api.SCMSourceObserver.ProjectObserver;
 import jenkins.scm.api.SCMSourceOwner;
+import jenkins.scm.impl.NullSCMSource;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
@@ -56,6 +58,42 @@ public class SCMNavigatorTest {
         navigator.setBitbucketServerUrl("http://bitbucket.test");
         final SCMSourceOwner mock = Mockito.mock(SCMSourceOwner.class);
         when(mock.getSCMSources()).thenReturn(Collections.singletonList(new BitbucketSCMSource("myteam", "repo1")));
+        SCMSourceObserverImpl observer = new SCMSourceObserverImpl(BitbucketClientMockUtils.getTaskListenerMock(),
+                                                                   mock);
+        navigator.visitSources(observer);
+
+        assertEquals("myteam", navigator.getRepoOwner());
+        assertEquals("repo(.*)", navigator.getPattern());
+
+        List<String> observed = observer.getObserved();
+        // Only 2 repositories match the pattern
+        assertEquals("There must be 2 repositories in the team", 2, observed.size());
+        assertEquals("repo2 should be first", "repo2", observed.get(0));
+        assertEquals("repo1 should be second", "repo1", observed.get(1));
+
+        List<ProjectObserver> observers = observer.getProjectObservers();
+        for (ProjectObserver obs : observers) {
+            List<SCMSource> sources = ((SCMSourceObserverImpl.ProjectObserverImpl) obs).getSources();
+            // It should contain only one source
+            assertEquals("Only one source must be created per observed repository", 1, sources.size());
+            SCMSource scmSource = sources.get(0);
+            assertTrue("BitbucketSCMSource instances must be added", scmSource instanceof BitbucketSCMSource);
+            // Check correct repoOwner (team name in this case) was set
+            assertEquals(((BitbucketSCMSource) scmSource).getRepoOwner(), "myteam");
+        }
+    }
+
+    @Test
+    public void teamRepositoriesDiscoveringNullSource() throws IOException, InterruptedException {
+        BitbucketMockApiFactory.add("http://bitbucket.test",
+                                    BitbucketClientMockUtils.getAPIClientMock(true, false));
+        BitbucketSCMNavigator navigator = new BitbucketSCMNavigator("myteam", null, null);
+        navigator.setPattern("repo(.*)");
+        navigator.setBitbucketServerUrl("http://bitbucket.test");
+        final SCMSourceOwner mock = Mockito.mock(SCMSourceOwner.class);
+        when(mock.getSCMSources())
+        .thenReturn(ImmutableList.of(new BitbucketSCMSource("myteam", "repo1"),
+                                     new NullSCMSource()));
         SCMSourceObserverImpl observer = new SCMSourceObserverImpl(BitbucketClientMockUtils.getTaskListenerMock(),
                                                                    mock);
         navigator.visitSources(observer);


### PR DESCRIPTION
This changes the behaviour of the organisation scan so that newly discovered repositories are processed first.

### Your checklist for this pull request

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [  ] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [  ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Did you provide a test-case? That demonstrates feature works or fixes the issue.

When team folders get to several hundred repositories in size, adding new ones can take many hours to be processed and added by the organisation scan. This change ensures they are done first, meaning newly created repositories can be integrated into CI chains much sooner than otherwise.
