### PR TITLE
Remove java.level from pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,6 @@
     <changelist>999999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/bitbucket-branch-source-plugin</gitHubRepo>
     <jenkins.version>2.303.3</jenkins.version>
-    <java.level>8</java.level>
     <hpi.compatibleSinceVersion>2.0</hpi.compatibleSinceVersion>
   </properties>
 


### PR DESCRIPTION
As recommended here: https://github.com/jenkinsci/maven-hpi-plugin/releases/tag/maven-hpi-plugin-3.28