### PR TITLE
Leverage Project Key property in Cloud Bitbucket API - fetching repos…

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMNavigator.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMNavigator.java
@@ -108,6 +108,8 @@ public class BitbucketSCMNavigator extends SCMNavigator {
     private String credentialsId;
     @NonNull
     private final String repoOwner;
+    @CheckForNull
+    private String projectKey;
     @NonNull
     private List<SCMTrait<? extends SCMTrait<?>>> traits;
     @Deprecated
@@ -209,6 +211,15 @@ public class BitbucketSCMNavigator extends SCMNavigator {
 
     public String getRepoOwner() {
         return repoOwner;
+    }
+
+    public String getProjectKey() {
+        return projectKey;
+    }
+
+    @DataBoundSetter
+    public void setProjectKey(@CheckForNull String projectKey) {
+        this.projectKey = Util.fixEmpty(projectKey);
     }
 
     @Override
@@ -486,7 +497,7 @@ public class BitbucketSCMNavigator extends SCMNavigator {
 
             BitbucketAuthenticator authenticator = AuthenticationTokens.convert(BitbucketAuthenticator.authenticationContext(serverUrl), credentials);
 
-            BitbucketApi bitbucket = BitbucketApiFactory.newInstance(serverUrl, authenticator, repoOwner, null);
+            BitbucketApi bitbucket = BitbucketApiFactory.newInstance(serverUrl, authenticator, repoOwner, projectKey, null);
             BitbucketTeam team = bitbucket.getTeam();
             if (team != null) {
                 // Navigate repositories of the team
@@ -535,7 +546,7 @@ public class BitbucketSCMNavigator extends SCMNavigator {
 
         BitbucketAuthenticator authenticator = AuthenticationTokens.convert(BitbucketAuthenticator.authenticationContext(serverUrl), credentials);
 
-        BitbucketApi bitbucket = BitbucketApiFactory.newInstance(serverUrl, authenticator, repoOwner, null);
+        BitbucketApi bitbucket = BitbucketApiFactory.newInstance(serverUrl, authenticator, repoOwner, null, null);
         BitbucketTeam team = bitbucket.getTeam();
         if (team != null) {
             String defaultTeamUrl;

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource.java
@@ -524,7 +524,7 @@ public class BitbucketSCMSource extends SCMSource {
     }
 
     public BitbucketApi buildBitbucketClient(String repoOwner, String repository) {
-        return BitbucketApiFactory.newInstance(getServerUrl(), authenticator(), repoOwner, repository);
+        return BitbucketApiFactory.newInstance(getServerUrl(), authenticator(), repoOwner, null, repository);
     }
 
     @Override
@@ -667,6 +667,7 @@ public class BitbucketSCMSource extends SCMSource {
                     getServerUrl(),
                     authenticator(),
                     pullRepoOwner,
+                    null,
                     pullRepository
             )
                     : originBitbucket;
@@ -1261,7 +1262,7 @@ public class BitbucketSCMSource extends SCMSource {
             BitbucketAuthenticator authenticator = AuthenticationTokens.convert(BitbucketAuthenticator.authenticationContext(serverUrl), credentials);
 
             try {
-                BitbucketApi bitbucket = BitbucketApiFactory.newInstance(serverUrl, authenticator, repoOwner, null);
+                BitbucketApi bitbucket = BitbucketApiFactory.newInstance(serverUrl, authenticator, repoOwner, null, null);
                 BitbucketTeam team = bitbucket.getTeam();
                 List<? extends BitbucketRepository> repositories =
                         bitbucket.getRepositories(team != null ? null : UserRoleInRepository.CONTRIBUTOR);

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketTeamMetadataAction.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketTeamMetadataAction.java
@@ -127,7 +127,7 @@ public class BitbucketTeamMetadataAction extends AvatarMetadataAction {
         private AvatarImage doFetch(StandardCredentials credentials) throws IOException, InterruptedException {
             BitbucketAuthenticator authenticator = AuthenticationTokens
                     .convert(BitbucketAuthenticator.authenticationContext(serverUrl), credentials);
-            BitbucketApi bitbucket = BitbucketApiFactory.newInstance(serverUrl, authenticator, repoOwner, null);
+            BitbucketApi bitbucket = BitbucketApiFactory.newInstance(serverUrl, authenticator, repoOwner, null, null);
             return bitbucket.getTeamAvatar();
         }
 

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/SCMHeadWithOwnerAndRepo.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/SCMHeadWithOwnerAndRepo.java
@@ -110,6 +110,7 @@ public class SCMHeadWithOwnerAndRepo extends SCMHead {
                     source.getServerUrl(),
                     source.authenticator(),
                     source.getRepoOwner(),
+                    null,
                     source.getRepository()
             );
             for (BitbucketPullRequest pr : bitbucket.getPullRequests()) {

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/BitbucketApiFactory.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/BitbucketApiFactory.java
@@ -31,6 +31,7 @@ public abstract class BitbucketApiFactory implements ExtensionPoint {
      * @param serverUrl   the server URL.
      * @param authenticator the (optional) authenticator.
      * @param owner       the owner name.
+     * @param projectKey  the (optional) project key.
      * @param repository  the (optional) repository name.
      * @return the {@link BitbucketApi}.
      */
@@ -38,6 +39,7 @@ public abstract class BitbucketApiFactory implements ExtensionPoint {
     protected abstract BitbucketApi create(@Nullable String serverUrl,
                                            @Nullable BitbucketAuthenticator authenticator,
                                            @NonNull String owner,
+                                           @CheckForNull String projectKey,
                                            @CheckForNull String repository);
 
     @NonNull
@@ -47,7 +49,7 @@ public abstract class BitbucketApiFactory implements ExtensionPoint {
                                            @NonNull String owner,
                                            @CheckForNull String repository) {
         BitbucketAuthenticator auth = credentials != null ? new BitbucketUsernamePasswordAuthenticator(credentials) : null;
-        return create(serverUrl, auth, owner, repository);
+        return create(serverUrl, auth, owner, null, repository);
     }
 
     /**
@@ -57,6 +59,7 @@ public abstract class BitbucketApiFactory implements ExtensionPoint {
      * @param serverUrl   the server URL.
      * @param authenticator the (optional) authenticator.
      * @param owner       the owner name.
+     * @param projectKey  the (optional) project key.
      * @param repository  the (optional) repository name.
      * @return the {@link BitbucketApi}.
      * @throws IllegalArgumentException if the supplied URL is not supported.
@@ -65,10 +68,11 @@ public abstract class BitbucketApiFactory implements ExtensionPoint {
     public static BitbucketApi newInstance(@Nullable String serverUrl,
                                            @Nullable BitbucketAuthenticator authenticator,
                                            @NonNull String owner,
+                                           @CheckForNull String projectKey,
                                            @CheckForNull String repository) {
         for (BitbucketApiFactory factory : ExtensionList.lookup(BitbucketApiFactory.class)) {
             if (factory.isMatch(serverUrl)) {
-                return factory.create(serverUrl, authenticator, owner, repository);
+                return factory.create(serverUrl, authenticator, owner, projectKey, repository);
             }
         }
         throw new IllegalArgumentException("Unsupported Bitbucket server URL: " + serverUrl);
@@ -79,8 +83,9 @@ public abstract class BitbucketApiFactory implements ExtensionPoint {
     public static BitbucketApi newInstance(@Nullable String serverUrl,
                                            @Nullable StandardUsernamePasswordCredentials credentials,
                                            @NonNull String owner,
+                                           @CheckForNull String projectKey,
                                            @CheckForNull String repository) {
         BitbucketAuthenticator auth = credentials != null ? new BitbucketUsernamePasswordAuthenticator(credentials) : null;
-        return newInstance(serverUrl, auth, owner, repository);
+        return newInstance(serverUrl, auth, owner, projectKey, repository);
     }
 }

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/BitbucketCloudApiClient.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/BitbucketCloudApiClient.java
@@ -137,6 +137,7 @@ public class BitbucketCloudApiClient implements BitbucketApi {
     private CloseableHttpClient client;
     private HttpClientContext context;
     private final String owner;
+    private final String projectKey;
     private final String repositoryName;
     private final boolean enableCache;
     private final BitbucketAuthenticator authenticator;
@@ -167,14 +168,15 @@ public class BitbucketCloudApiClient implements BitbucketApi {
     @Deprecated
     public BitbucketCloudApiClient(boolean enableCache, int teamCacheDuration, int repositoriesCacheDuration,
                                    String owner, String repositoryName, StandardUsernamePasswordCredentials credentials) {
-        this(enableCache, teamCacheDuration, repositoriesCacheDuration, owner, repositoryName,
+        this(enableCache, teamCacheDuration, repositoriesCacheDuration, owner, null, repositoryName,
                 new BitbucketUsernamePasswordAuthenticator(credentials));
     }
 
     public BitbucketCloudApiClient(boolean enableCache, int teamCacheDuration, int repositoriesCacheDuration,
-            String owner, String repositoryName, BitbucketAuthenticator authenticator) {
+            String owner, String projectKey, String repositoryName, BitbucketAuthenticator authenticator) {
         this.authenticator = authenticator;
         this.owner = owner;
+        this.projectKey = projectKey;
         this.repositoryName = repositoryName;
         this.enableCache = enableCache;
         if (enableCache) {
@@ -752,9 +754,12 @@ public class BitbucketCloudApiClient implements BitbucketApi {
             cacheKey.append("::<anonymous>");
         }
 
-        final UriTemplate template = UriTemplate.fromTemplate(V2_API_BASE_URL + "{/owner}{?role,page,pagelen}")
+        final UriTemplate template = UriTemplate.fromTemplate(V2_API_BASE_URL + "{/owner}{?role,page,pagelen,q}")
                 .set("owner", owner)
                 .set("pagelen", MAX_PAGE_LENGTH);
+        if (StringUtils.isNotBlank(projectKey)) {
+            template.set("q", "project.key=" + "\"" + projectKey + "\""); // q=project.key="<projectKey>"
+        }
         if (role != null &&  authenticator != null) {
             template.set("role", role.getId());
             cacheKey.append("::").append(role.getId());

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/BitbucketCloudApiFactory.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/BitbucketCloudApiFactory.java
@@ -21,7 +21,7 @@ public class BitbucketCloudApiFactory extends BitbucketApiFactory {
     @NonNull
     @Override
     protected BitbucketApi create(@Nullable String serverUrl, @Nullable BitbucketAuthenticator authenticator,
-                                  @NonNull String owner, @CheckForNull String repository) {
+                                  @NonNull String owner, @CheckForNull String projectKey, @CheckForNull String repository) {
         AbstractBitbucketEndpoint endpoint = BitbucketEndpointConfiguration.get().findEndpoint(BitbucketCloudEndpoint.SERVER_URL);
         boolean enableCache = false;
         int teamCacheDuration = 0;
@@ -33,6 +33,6 @@ public class BitbucketCloudApiFactory extends BitbucketApiFactory {
         }
         return new BitbucketCloudApiClient(
                 enableCache, teamCacheDuration, repositoriesCacheDuration,
-                owner, repository, authenticator);
+                owner, projectKey, repository, authenticator);
     }
 }

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/filesystem/BitbucketSCMFileSystem.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/filesystem/BitbucketSCMFileSystem.java
@@ -155,7 +155,7 @@ public class BitbucketSCMFileSystem extends SCMFileSystem {
 
             BitbucketAuthenticator authenticator = AuthenticationTokens.convert(BitbucketAuthenticator.authenticationContext(serverUrl), credentials);
 
-            BitbucketApi apiClient = BitbucketApiFactory.newInstance(serverUrl, authenticator, owner, repository);
+            BitbucketApi apiClient = BitbucketApiFactory.newInstance(serverUrl, authenticator, owner, null, repository);
             String ref = null;
 
             if (head instanceof BranchSCMHead) {

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/PullRequestHookProcessor.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/PullRequestHookProcessor.java
@@ -59,6 +59,7 @@ import jenkins.scm.api.SCMNavigator;
 import jenkins.scm.api.SCMRevision;
 import jenkins.scm.api.SCMSource;
 import jenkins.scm.api.mixin.ChangeRequestCheckoutStrategy;
+import org.apache.commons.lang.StringUtils;
 
 import static com.cloudbees.jenkins.plugins.bitbucket.hooks.HookEventType.PULL_REQUEST_DECLINED;
 import static com.cloudbees.jenkins.plugins.bitbucket.hooks.HookEventType.PULL_REQUEST_MERGED;
@@ -113,10 +114,24 @@ public class PullRequestHookProcessor extends HookProcessor {
                 return false;
             }
             BitbucketSCMNavigator bbNav = (BitbucketSCMNavigator) navigator;
+            if (!isProjectKeyMatch(bbNav.getProjectKey())) {
+                return false;
+            }
+
             if (!isServerUrlMatch(bbNav.getServerUrl())) {
                 return false;
             }
             return bbNav.getRepoOwner().equalsIgnoreCase(getPayload().getRepository().getOwnerName());
+        }
+
+        private boolean isProjectKeyMatch(String projectKey) {
+            if (StringUtils.isBlank(projectKey)) {
+                return true;
+            }
+            if (this.getPayload().getRepository().getProject() != null) {
+                return projectKey.equals(this.getPayload().getRepository().getProject().getKey());
+            }
+            return true;
         }
 
         private boolean isServerUrlMatch(String serverUrl) {

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/PushHookProcessor.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/PushHookProcessor.java
@@ -55,6 +55,7 @@ import jenkins.scm.api.SCMHeadEvent;
 import jenkins.scm.api.SCMNavigator;
 import jenkins.scm.api.SCMRevision;
 import jenkins.scm.api.SCMSource;
+import org.apache.commons.lang.StringUtils;
 
 public class PushHookProcessor extends HookProcessor {
 
@@ -94,10 +95,23 @@ public class PushHookProcessor extends HookProcessor {
                                 return false;
                             }
                             BitbucketSCMNavigator bbNav = (BitbucketSCMNavigator) navigator;
+                            if (!isProjectKeyMatch(bbNav.getProjectKey())) {
+                                return false;
+                            }
                             if (!isServerUrlMatch(bbNav.getServerUrl())) {
                                 return false;
                             }
                             return bbNav.getRepoOwner().equalsIgnoreCase(getPayload().getRepository().getOwnerName());
+                        }
+
+                        private boolean isProjectKeyMatch(String projectKey) {
+                            if (StringUtils.isBlank(projectKey)) {
+                                return true;
+                            }
+                            if (this.getPayload().getRepository().getProject() != null) {
+                                return projectKey.equals(this.getPayload().getRepository().getProject().getKey());
+                            }
+                            return true;
                         }
 
                         private boolean isServerUrlMatch(String serverUrl) {

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/WebhookAutoRegisterListener.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/WebhookAutoRegisterListener.java
@@ -223,6 +223,7 @@ public class WebhookAutoRegisterListener extends ItemListener {
                                 endpoint.getServerUrl(),
                                 endpoint.authenticator(),
                                 source.getRepoOwner(),
+                                null,
                                 source.getRepository()
                         );
             case ITEM:

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/BitbucketServerApiFactory.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/BitbucketServerApiFactory.java
@@ -20,7 +20,7 @@ public class BitbucketServerApiFactory extends BitbucketApiFactory {
     @NonNull
     @Override
     protected BitbucketApi create(@Nullable String serverUrl, @Nullable BitbucketAuthenticator authenticator,
-                                  @NonNull String owner, @CheckForNull String repository) {
+                                  @NonNull String owner, @CheckForNull String projectKey, @CheckForNull String repository) {
         if(StringUtils.isBlank(serverUrl)){
             throw new IllegalArgumentException("serverUrl is required");
         }

--- a/src/main/resources/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMNavigator/config.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMNavigator/config.jelly
@@ -19,6 +19,9 @@
   <f:entry title="${%Owner}" field="repoOwner">
     <f:textbox/>
   </f:entry>
+  <f:entry title="${%Project Key}" field="projectKey">
+    <f:textbox/>
+  </f:entry>
   <f:entry title="${%Behaviours}" field="traits">
     <scm:traits field="traits"/>
   </f:entry>

--- a/src/main/resources/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMNavigator/help-projectKey.html
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMNavigator/help-projectKey.html
@@ -1,0 +1,3 @@
+<div>
+    (Optionally) If you're using <strong>Bitbucket Cloud</strong> specify project key to select only repositories belonging to that project.
+</div>

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketMockApiFactory.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketMockApiFactory.java
@@ -42,7 +42,7 @@ public class BitbucketMockApiFactory extends BitbucketApiFactory {
     @NonNull
     @Override
     protected BitbucketApi create(@Nullable String serverUrl, @Nullable BitbucketAuthenticator authenticator,
-                                  @NonNull String owner, @CheckForNull String repository) {
+                                  @NonNull String owner, @CheckForNull String projectKey, @CheckForNull String repository) {
         return mocks.get(StringUtils.defaultString(serverUrl, NULL));
     }
 }

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMNavigatorTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMNavigatorTest.java
@@ -94,6 +94,52 @@ public class BitbucketSCMNavigatorTest {
     }
 
     @Test
+    public void cloud_project_key() throws Exception {
+        BitbucketSCMNavigator instance = load();
+        assertThat(instance.id(), is("https://bitbucket.org::cloudbeers"));
+        assertThat(instance.getRepoOwner(), is("cloudbeers"));
+        assertThat(instance.getProjectKey(), is("PK"));
+        assertThat(instance.getServerUrl(), is(BitbucketCloudEndpoint.SERVER_URL));
+        assertThat(instance.getCredentialsId(), is("bcaef157-f105-407f-b150-df7722eab6c1"));
+        assertThat("SAME checkout credentials should mean no checkout trait",
+            instance.getTraits(),
+            not(hasItem(instanceOf(SSHCheckoutTrait.class))));
+        assertThat(".* as a pattern should mean no RegexSCMSourceFilterTrait",
+            instance.getTraits(),
+            not(hasItem(instanceOf(RegexSCMSourceFilterTrait.class))));
+        assertThat(instance.getTraits(),
+            containsInAnyOrder(
+                allOf(
+                    instanceOf(BranchDiscoveryTrait.class),
+                    hasProperty("buildBranch", is(true)),
+                    hasProperty("buildBranchesWithPR", is(true))
+                ),
+                allOf(
+                    instanceOf(OriginPullRequestDiscoveryTrait.class),
+                    hasProperty("strategyId", is(2))
+                ),
+                allOf(
+                    instanceOf(ForkPullRequestDiscoveryTrait.class),
+                    hasProperty("strategyId", is(2)),
+                    hasProperty("trust", instanceOf(ForkPullRequestDiscoveryTrait.TrustEveryone.class))
+                ),
+                instanceOf(PublicRepoPullRequestFilterTrait.class),
+                allOf(
+                    instanceOf(WebhookRegistrationTrait.class),
+                    hasProperty("mode", is(WebhookRegistration.DISABLE))
+                )
+            )
+        );
+        // legacy API
+        assertThat(instance.getBitbucketServerUrl(), is(nullValue()));
+        assertThat(instance.getCheckoutCredentialsId(), is("SAME"));
+        assertThat(instance.getPattern(), is(".*"));
+        assertThat(instance.isAutoRegisterHooks(), is(false));
+        assertThat(instance.getIncludes(), is("*"));
+        assertThat(instance.getExcludes(), is(""));
+    }
+
+    @Test
     public void basic_server() throws Exception {
         BitbucketSCMNavigator instance = load();
         assertThat(instance.id(), is("https://bitbucket.test::DUB"));

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/UriResolverTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/UriResolverTest.java
@@ -37,7 +37,7 @@ public class UriResolverTest {
 
     @Test
     public void httpUriResolver() throws Exception {
-        BitbucketApi api = new BitbucketCloudApiClient(false, 0, 0, "test", null, (BitbucketAuthenticator) null);
+        BitbucketApi api = new BitbucketCloudApiClient(false, 0, 0, "test", null, null, (BitbucketAuthenticator) null);
         assertEquals("https://bitbucket.org/user1/repo1.git", api.getRepositoryUri(
                 BitbucketRepositoryProtocol.HTTP,
                 null,
@@ -72,7 +72,7 @@ public class UriResolverTest {
 
     @Test
     public void sshUriResolver() throws Exception {
-        BitbucketApi api = new BitbucketCloudApiClient(false, 0, 0, "test", null, (BitbucketAuthenticator) null);
+        BitbucketApi api = new BitbucketCloudApiClient(false, 0, 0, "test", null, null, (BitbucketAuthenticator) null);
         assertEquals("git@bitbucket.org:user1/repo1.git", api.getRepositoryUri(
                 BitbucketRepositoryProtocol.SSH,
                 null,

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/client/BitbucketIntegrationClientFactory.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/client/BitbucketIntegrationClientFactory.java
@@ -141,7 +141,7 @@ public class BitbucketIntegrationClientFactory {
         private final IRequestAudit audit;
 
         private BitbucketClouldIntegrationClient(String payloadRootPath, String owner, String repositoryName) {
-            super(false, 0, 0, owner, repositoryName, (BitbucketAuthenticator) null);
+            super(false, 0, 0, owner, null, repositoryName, (BitbucketAuthenticator) null);
 
             if (payloadRootPath == null) {
                 this.payloadRootPath = PAYLOAD_RESOURCE_ROOTPATH;

--- a/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMNavigatorTest/cloud_project_key.xml
+++ b/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMNavigatorTest/cloud_project_key.xml
@@ -1,0 +1,9 @@
+<com.cloudbees.jenkins.plugins.bitbucket.BitbucketSCMNavigator>
+  <repoOwner>cloudbeers</repoOwner>
+  <credentialsId>bcaef157-f105-407f-b150-df7722eab6c1</credentialsId>
+  <projectKey>PK</projectKey>
+  <checkoutCredentialsId>SAME</checkoutCredentialsId>
+  <pattern>.*</pattern>
+  <autoRegisterHooks>false</autoRegisterHooks>
+  <sshPort>-1</sshPort>
+</com.cloudbees.jenkins.plugins.bitbucket.BitbucketSCMNavigator>


### PR DESCRIPTION
…itories, pullrequest and push hook processors.

<!-- Please describe your pull request here. -->
Added possibility to use project key property to query for repositories in Bitbucket Cloud API (ignored Bitbucket Server for now).
Described as parameter "q" in https://developer.atlassian.com/cloud/bitbucket/rest/api-group-repositories/#api-repositories-get.

BitbucketSCMNavigator has new optional property projectKey that is used in:
- com.cloudbees.jenkins.plugins.bitbucket.BitbucketSCMNavigator#visitSources
- com.cloudbees.jenkins.plugins.bitbucket.hooks.PullRequestHookProcessor.HeadEvent#isMatch(jenkins.scm.api.SCMNavigator)
- jenkins.scm.api.SCMHeadEvent#isMatch(jenkins.scm.api.SCMNavigator)

[#579](https://github.com/jenkinsci/bitbucket-branch-source-plugin/issues/579)
[#636](https://github.com/jenkinsci/bitbucket-branch-source-plugin/issues/636)

<!--
To mark your pull request as work in progress please create it as a draft pull request

### Your checklist for this pull request

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Did you provide a test-case? That demonstrates feature works or fixes the issue.

Put an `x` into the [ ] to show you have filled the information below
Describe your pull request below
-->
