### PR TITLE
[JENKINS-71355] Avoid Fetching all branches and Tags to retrieve SCM …

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/BitbucketApi.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/BitbucketApi.java
@@ -137,6 +137,16 @@ public interface BitbucketApi {
     String getDefaultBranch() throws IOException, InterruptedException;
 
     /**
+     * Returns a branch in the repository.
+     *
+     * @return a branch in the repository.
+     * @throws IOException if there was a network communications error.
+     * @throws InterruptedException if interrupted while waiting on remote communications.
+     */
+    @CheckForNull
+    BitbucketBranch getBranch(@NonNull String branchName) throws IOException, InterruptedException;
+
+    /**
      * Returns the branches in the repository.
      *
      * @return the list of branches in the repository.
@@ -145,6 +155,16 @@ public interface BitbucketApi {
      */
     @NonNull
     List<? extends BitbucketBranch> getBranches() throws IOException, InterruptedException;
+
+    /**
+     * Returns a tag in the repository.
+     *
+     * @return a tag in the repository.
+     * @throws IOException if there was a network communications error.
+     * @throws InterruptedException if interrupted while waiting on remote communications.
+     */
+    @CheckForNull
+    BitbucketBranch getTag(@NonNull String tagName) throws IOException, InterruptedException;
 
      /**
      * Returns the tags in the repository.

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/BitbucketCloudApiClient.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/BitbucketCloudApiClient.java
@@ -475,10 +475,46 @@ public class BitbucketCloudApiClient implements BitbucketApi {
     /**
      * {@inheritDoc}
      */
+    @Override
+    public BitbucketCloudBranch getTag(@NonNull String tagName) throws IOException, InterruptedException {
+        String url = UriTemplate.fromTemplate(REPO_URL_TEMPLATE + "/refs/tags/{name}")
+            .set("owner", owner)
+            .set("repo", repositoryName)
+            .set("name", tagName)
+            .expand();
+        String response = getRequest(url);
+        try {
+            return getSingleBranch(response);
+        } catch (IOException e) {
+            throw new IOException("I/O error when parsing response from URL: " + url, e);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     @NonNull
     @Override
     public List<BitbucketCloudBranch> getTags() throws IOException, InterruptedException {
         return getBranchesByRef("/refs/tags");
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public BitbucketCloudBranch getBranch(@NonNull String branchName) throws IOException, InterruptedException {
+        String url = UriTemplate.fromTemplate(REPO_URL_TEMPLATE + "/refs/branches/{name}")
+            .set("owner", owner)
+            .set("repo", repositoryName)
+            .set("name", branchName)
+            .expand();
+        String response = getRequest(url);
+        try {
+            return getSingleBranch(response);
+        } catch (IOException e) {
+            throw new IOException("I/O error when parsing response from URL: " + url, e);
+        }
     }
 
     /**
@@ -1060,6 +1096,10 @@ public class BitbucketCloudApiClient implements BitbucketApi {
         }
 
         return activeBranches;
+    }
+
+    private BitbucketCloudBranch getSingleBranch(String response) throws IOException {
+        return JsonParser.mapper.readValue(response, new TypeReference<BitbucketCloudBranch>(){});
     }
 
     @Override

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketBuildStatusNotificationsTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketBuildStatusNotificationsTest.java
@@ -110,6 +110,7 @@ public class BitbucketBuildStatusNotificationsTest {
         BitbucketBranch branch = Mockito.mock(BitbucketBranch.class);
         List<? extends BitbucketBranch> branchList = Collections.singletonList(branch);
         when(api.getBranches()).thenAnswer(new Returns(branchList));
+        when(api.getBranch("master")).thenAnswer(new Returns(branch));
         when(branch.getName()).thenReturn(branchName);
         when(branch.getRawNode()).thenReturn(sampleRepo.head());
         BitbucketCommit commit = Mockito.mock(BitbucketCommit.class);

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketClientMockUtils.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketClientMockUtils.java
@@ -60,12 +60,18 @@ public class BitbucketClientMockUtils {
         when(bitbucket.getRepositoryUri(any(BitbucketRepositoryProtocol.class), nullable(String.class),
             anyString(), anyString())).thenCallRealMethod();
 
+        // mock branches
+        BitbucketCloudBranch branch1 = getBranch("branch1", "52fc8e220d77ec400f7fc96a91d2fd0bb1bc553a");
+        BitbucketCloudBranch branch2 = getBranch("branch2", "707c59ce8292c927dddb6807fcf9c3c5e7c9b00f");
+
         // mock branch list
         List<BitbucketCloudBranch> branches = new ArrayList<>();
-        branches.add(getBranch("branch1", "52fc8e220d77ec400f7fc96a91d2fd0bb1bc553a"));
-        branches.add(getBranch("branch2", "707c59ce8292c927dddb6807fcf9c3c5e7c9b00f"));
+        branches.add(branch1);
+        branches.add(branch2);
         // add branches
         when(bitbucket.getBranches()).thenReturn(branches);
+        when(bitbucket.getBranch("branch1")).thenReturn(branch1);
+        when(bitbucket.getBranch("branch2")).thenReturn(branch2);
         withMockGitRepos(bitbucket);
 
         if (includePullRequests) {

--- a/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/client/payload/2.0-repositories-amuniz-test-repos-pullrequests-1.json
+++ b/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/client/payload/2.0-repositories-amuniz-test-repos-pullrequests-1.json
@@ -1,0 +1,140 @@
+{
+  "description": "* Add license\r\n\r\n* [CI] Release version 1.0.0",
+  "links": {
+    "decline": {
+      "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/pullrequests/1/decline"
+    },
+    "commits": {
+      "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/pullrequests/1/commits"
+    },
+    "self": {
+      "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/pullrequests/1"
+    },
+    "comments": {
+      "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/pullrequests/1/comments"
+    },
+    "merge": {
+      "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/pullrequests/1/merge"
+    },
+    "html": {
+      "href": "https://bitbucket.org/amuniz/test-repos/pull-requests/1"
+    },
+    "activity": {
+      "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/pullrequests/1/activity"
+    },
+    "diff": {
+      "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/pullrequests/1/diff"
+    },
+    "approve": {
+      "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/pullrequests/1/approve"
+    },
+    "statuses": {
+      "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/pullrequests/1/statuses"
+    }
+  },
+  "title": "Release/release 1",
+  "close_source_branch": true,
+  "type": "pullrequest",
+  "id": 1,
+  "destination": {
+    "commit": {
+      "hash": "bf4f4ce8a3a8",
+      "type": "commit",
+      "links": {
+        "self": {
+          "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/commit/bf4f4ce8a3a8"
+        },
+        "html": {
+          "href": "https://bitbucket.org/amuniz/test-repos/commits/bf4f4ce8a3a8"
+        }
+      }
+    },
+    "repository": {
+      "links": {
+        "self": {
+          "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos"
+        },
+        "html": {
+          "href": "https://bitbucket.org/amuniz/test-repos"
+        },
+        "avatar": {
+          "href": "https://bytebucket.org/ravatar/%7B3deb8c29-778a-450c-8f69-3e50a18079df%7D?ts=default"
+        }
+      },
+      "type": "repository",
+      "name": "test-repos",
+      "full_name": "amuniz/test-repos",
+      "uuid": "{3deb8c29-778a-450c-8f69-3e50a18079df}"
+    },
+    "branch": {
+      "name": "main"
+    }
+  },
+  "created_on": "2018-09-21T14:57:59.455870+00:00",
+  "summary": {
+    "raw": "* Add license\r\n\r\n* [CI] Release version 1.0.0",
+    "markup": "markdown",
+    "html": "<ul>\n<li>\n<p>Add license</p>\n</li>\n<li>\n<p>[CI] Release version 1.0.0</p>\n</li>\n</ul>",
+    "type": "rendered"
+  },
+  "source": {
+    "commit": {
+      "hash": "bf0e8b7962c0",
+      "type": "commit",
+      "links": {
+        "self": {
+          "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/commit/bf0e8b7962c0"
+        },
+        "html": {
+          "href": "https://bitbucket.org/amuniz/test-repos/commits/bf0e8b7962c0"
+        }
+      }
+    },
+    "repository": {
+      "links": {
+        "self": {
+          "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos"
+        },
+        "html": {
+          "href": "https://bitbucket.org/amuniz/test-repos"
+        },
+        "avatar": {
+          "href": "https://bytebucket.org/ravatar/%7B3deb8c29-778a-450c-8f69-3e50a18079df%7D?ts=default"
+        }
+      },
+      "type": "repository",
+      "name": "test-repos",
+      "full_name": "amuniz/test-repos",
+      "uuid": "{3deb8c29-778a-450c-8f69-3e50a18079df}"
+    },
+    "branch": {
+      "name": "release/release-1"
+    }
+  },
+  "comment_count": 0,
+  "state": "OPEN",
+  "task_count": 0,
+  "reason": "",
+  "updated_on": "2018-09-21T14:57:59.488719+00:00",
+  "author": {
+    "username": "amuniz",
+    "display_name": "Nikolas Falco",
+    "account_id": "557058:ca1cd232-2017-4216-94be-99637899e18d",
+    "links": {
+      "self": {
+        "href": "https://api.bitbucket.org/2.0/users/amuniz"
+      },
+      "html": {
+        "href": "https://bitbucket.org/amuniz/"
+      },
+      "avatar": {
+        "href": "https://bitbucket.org/account/amuniz/avatar/"
+      }
+    },
+    "nickname": "amuniz",
+    "type": "user",
+    "uuid": "{644c7fc2-b15a-4445-9f89-35390694fac9}"
+  },
+  "merge_commit": null,
+  "closed_by": null
+}

--- a/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/client/payload/2.0-repositories-amuniz-test-repos-pullrequests-2.json
+++ b/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/client/payload/2.0-repositories-amuniz-test-repos-pullrequests-2.json
@@ -1,0 +1,138 @@
+{
+  "description": "test from forked repo",
+  "links": {
+    "decline": {
+      "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/pullrequests/2/decline"
+    },
+    "commits": {
+      "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/pullrequests/2/commits"
+    },
+    "self": {
+      "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/pullrequests/2"
+    },
+    "comments": {
+      "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/pullrequests/2/comments"
+    },
+    "merge": {
+      "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/pullrequests/2/merge"
+    },
+    "html": {
+      "href": "https://bitbucket.org/amuniz/test-repos/pull-requests/3"
+    },
+    "activity": {
+      "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/pullrequests/2/activity"
+    },
+    "diff": {
+      "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/pullrequests/2/diff"
+    },
+    "approve": {
+      "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/pullrequests/2/approve"
+    },
+    "statuses": {
+      "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/pullrequests/2/statuses"
+    }
+  },
+  "title": "Add one message more",
+  "close_source_branch": true,
+  "type": "pullrequest",
+  "id": 2,
+  "destination": {
+    "commit": {
+      "hash": "bf4f4ce8a3a8",
+      "type": "commit",
+      "links": {
+        "self": {
+          "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/commit/bf4f4ce8a3a8"
+        },
+        "html": {
+          "href": "https://bitbucket.org/amuniz/test-repos/commits/bf4f4ce8a3a8"
+        }
+      }
+    },
+    "repository": {
+      "links": {
+        "self": {
+          "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos"
+        },
+        "html": {
+          "href": "https://bitbucket.org/amuniz/test-repos"
+        },
+        "avatar": {
+          "href": "https://bytebucket.org/ravatar/%7B3deb8c29-778a-450c-8f69-3e50a18079df%7D?ts=default"
+        }
+      },
+      "type": "repository",
+      "name": "test-repos",
+      "full_name": "amuniz/test-repos",
+      "uuid": "{3deb8c29-778a-450c-8f69-3e50a18079df}"
+    },
+    "branch": {
+      "name": "main"
+    }
+  },
+  "created_on": "2018-11-08T13:45:13.837779+00:00",
+  "summary": {
+    "raw": "test from forked repo",
+    "markup": "markdown",
+    "html": "<p>test from forked repo</p>",
+    "type": "rendered"
+  },
+  "source": {
+    "commit": {
+      "hash": "046d9a3c1532",
+      "type": "commit",
+      "links": {
+        "self": {
+          "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos-fork/commit/046d9a3c1532"
+        },
+        "html": {
+          "href": "https://bitbucket.org/amuniz/test-repos-fork/commits/046d9a3c1532"
+        }
+      }
+    },
+    "repository": {
+      "links": {
+        "self": {
+          "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos-fork"
+        },
+        "html": {
+          "href": "https://bitbucket.org/amuniz/test-repos-fork"
+        },
+        "avatar": {
+          "href": "https://bytebucket.org/ravatar/%7B62dbf0d6-95bb-44da-82ca-70d162135379%7D?ts=default"
+        }
+      },
+      "type": "repository",
+      "name": "test-repos-fork",
+      "full_name": "amuniz/test-repos-fork",
+      "uuid": "{62dbf0d6-95bb-44da-82ca-70d162135379}"
+    },
+    "branch": {
+      "name": "feature/BB-2"
+    }
+  },
+  "comment_count": 0,
+  "state": "OPEN",
+  "task_count": 0,
+  "reason": "",
+  "updated_on": "2018-11-08T13:45:13.958677+00:00",
+  "author": {
+    "username": "amuniz",
+    "display_name": "Nikolas Falco",
+    "account_id": "557058:ca1cd232-2017-4216-94be-99637899e18d",
+    "links": {
+      "self": {
+        "href": "https://api.bitbucket.org/2.0/users/amuniz"
+      },
+      "html": {
+        "href": "https://bitbucket.org/amuniz/"
+      },
+      "avatar": {
+        "href": "https://bitbucket.org/account/amuniz/avatar/"
+      }
+    },
+    "nickname": "amuniz",
+    "type": "user",
+    "uuid": "{644c7fc2-b15a-4445-9f89-35390694fac9}"
+  }
+}

--- a/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/client/payload/2.0-repositories-amuniz-test-repos-refs-branches-feature_2FBB-1.json
+++ b/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/client/payload/2.0-repositories-amuniz-test-repos-refs-branches-feature_2FBB-1.json
@@ -1,0 +1,85 @@
+{
+  "name": "feature/BB-1",
+  "links": {
+    "commits": {
+      "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/commits/feature/BB-1"
+    },
+    "self": {
+      "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/refs/branches/feature/BB-1"
+    },
+    "html": {
+      "href": "https://bitbucket.org/amuniz/test-repos/branch/feature/BB-1"
+    }
+  },
+  "default_merge_strategy": "merge_commit",
+  "merge_strategies": [
+    "merge_commit",
+    "squash",
+    "fast_forward"
+  ],
+  "type": "branch",
+  "target": {
+    "hash": "fb522a6f08c7c7df337312e4e65ec1b57710672e",
+    "repository": {
+      "links": {
+        "self": {
+          "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos"
+        },
+        "html": {
+          "href": "https://bitbucket.org/amuniz/test-repos"
+        },
+        "avatar": {
+          "href": "https://bytebucket.org/ravatar/%7B3deb8c29-778a-450c-8f69-3e50a18079df%7D?ts=default"
+        }
+      },
+      "type": "repository",
+      "name": "test-repos",
+      "full_name": "amuniz/test-repos",
+      "uuid": "{3deb8c29-778a-450c-8f69-3e50a18079df}"
+    },
+    "links": {
+      "self": {
+        "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/commit/fb522a6f08c7c7df337312e4e65ec1b57710672e"
+      },
+      "comments": {
+        "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/commit/fb522a6f08c7c7df337312e4e65ec1b57710672e/comments"
+      },
+      "patch": {
+        "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/patch/fb522a6f08c7c7df337312e4e65ec1b57710672e"
+      },
+      "html": {
+        "href": "https://bitbucket.org/amuniz/test-repos/commits/fb522a6f08c7c7df337312e4e65ec1b57710672e"
+      },
+      "diff": {
+        "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/diff/fb522a6f08c7c7df337312e4e65ec1b57710672e"
+      },
+      "approve": {
+        "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/commit/fb522a6f08c7c7df337312e4e65ec1b57710672e/approve"
+      },
+      "statuses": {
+        "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/commit/fb522a6f08c7c7df337312e4e65ec1b57710672e/statuses"
+      }
+    },
+    "author": {
+      "raw": "Antonio Muniz <amuniz@example.com>",
+      "type": "author"
+    },
+    "parents": [
+      {
+        "hash": "ae995d7a37069d0988462a9c92828971e8a42b5d",
+        "type": "commit",
+        "links": {
+          "self": {
+            "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/commit/ae995d7a37069d0988462a9c92828971e8a42b5d"
+          },
+          "html": {
+            "href": "https://bitbucket.org/amuniz/test-repos/commits/ae995d7a37069d0988462a9c92828971e8a42b5d"
+          }
+        }
+      }
+    ],
+    "date": "2018-09-21T14:09:51+00:00",
+    "message": "Suppress echo command part",
+    "type": "commit"
+  }
+}

--- a/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/client/payload/2.0-repositories-amuniz-test-repos-refs-branches-feature_2FBB-2.json
+++ b/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/client/payload/2.0-repositories-amuniz-test-repos-refs-branches-feature_2FBB-2.json
@@ -1,0 +1,79 @@
+{
+  "name": "feature/BB-2",
+  "links": {
+    "commits": {
+      "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/commits/feature/BB-2"
+    },
+    "self": {
+      "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/refs/branches/feature/BB-2"
+    },
+    "html": {
+      "href": "https://bitbucket.org/amuniz/test-repos/branch/feature/BB-2"
+    }
+  },
+  "default_merge_strategy": "merge_commit",
+  "merge_strategies": ["merge_commit", "squash", "fast_forward"],
+  "type": "branch",
+  "target": {
+    "hash": "046d9a3c1532acf4cf08fe93235c00e4d673c1d2",
+    "repository": {
+      "links": {
+        "self": {
+          "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos"
+        },
+        "html": {
+          "href": "https://bitbucket.org/amuniz/test-repos"
+        },
+        "avatar": {
+          "href": "https://bytebucket.org/ravatar/%7B3deb8c29-778a-450c-8f69-3e50a18079df%7D?ts=default"
+        }
+      },
+      "type": "repository",
+      "name": "test-repos",
+      "full_name": "amuniz/test-repos",
+      "uuid": "{3deb8c29-778a-450c-8f69-3e50a18079df}"
+    },
+    "links": {
+      "self": {
+        "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/commit/046d9a3c1532acf4cf08fe93235c00e4d673c1d2"
+      },
+      "comments": {
+        "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/commit/046d9a3c1532acf4cf08fe93235c00e4d673c1d2/comments"
+      },
+      "patch": {
+        "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/patch/046d9a3c1532acf4cf08fe93235c00e4d673c1d2"
+      },
+      "html": {
+        "href": "https://bitbucket.org/amuniz/test-repos/commits/046d9a3c1532acf4cf08fe93235c00e4d673c1d2"
+      },
+      "diff": {
+        "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/diff/046d9a3c1532acf4cf08fe93235c00e4d673c1d2"
+      },
+      "approve": {
+        "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/commit/046d9a3c1532acf4cf08fe93235c00e4d673c1d2/approve"
+      },
+      "statuses": {
+        "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/commit/046d9a3c1532acf4cf08fe93235c00e4d673c1d2/statuses"
+      }
+    },
+    "author": {
+      "raw": "Nikolas Falco <amuniz@acme.com>",
+      "type": "author"
+    },
+    "parents": [{
+      "hash": "bf4f4ce8a3a8d5c7dbfe7d609973a81a6c6664cf",
+      "type": "commit",
+      "links": {
+        "self": {
+          "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/commit/bf4f4ce8a3a8d5c7dbfe7d609973a81a6c6664cf"
+        },
+        "html": {
+          "href": "https://bitbucket.org/amuniz/test-repos/commits/bf4f4ce8a3a8d5c7dbfe7d609973a81a6c6664cf"
+        }
+      }
+    }],
+    "date": "2018-09-21T14:49:23+00:00",
+    "message": "Add one message more",
+    "type": "commit"
+  }
+}

--- a/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/client/payload/2.0-repositories-amuniz-test-repos-refs-branches-main.json
+++ b/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/client/payload/2.0-repositories-amuniz-test-repos-refs-branches-main.json
@@ -1,0 +1,85 @@
+{
+  "name": "main",
+  "links": {
+    "commits": {
+      "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/commits/main"
+    },
+    "self": {
+      "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/refs/branches/main"
+    },
+    "html": {
+      "href": "https://bitbucket.org/amuniz/test-repos/branch/main"
+    }
+  },
+  "default_merge_strategy": "merge_commit",
+  "merge_strategies": [
+    "merge_commit",
+    "squash",
+    "fast_forward"
+  ],
+  "type": "branch",
+  "target": {
+    "hash": "bf4f4ce8a3a8d5c7dbfe7d609973a81a6c6664cf",
+    "repository": {
+      "links": {
+        "self": {
+          "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos"
+        },
+        "html": {
+          "href": "https://bitbucket.org/amuniz/test-repos"
+        },
+        "avatar": {
+          "href": "https://bytebucket.org/ravatar/%7B3deb8c29-778a-450c-8f69-3e50a18079df%7D?ts=default"
+        }
+      },
+      "type": "repository",
+      "name": "test-repos",
+      "full_name": "amuniz/test-repos",
+      "uuid": "{3deb8c29-778a-450c-8f69-3e50a18079df}"
+    },
+    "links": {
+      "self": {
+        "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/commit/bf4f4ce8a3a8d5c7dbfe7d609973a81a6c6664cf"
+      },
+      "comments": {
+        "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/commit/bf4f4ce8a3a8d5c7dbfe7d609973a81a6c6664cf/comments"
+      },
+      "patch": {
+        "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/patch/bf4f4ce8a3a8d5c7dbfe7d609973a81a6c6664cf"
+      },
+      "html": {
+        "href": "https://bitbucket.org/amuniz/test-repos/commits/bf4f4ce8a3a8d5c7dbfe7d609973a81a6c6664cf"
+      },
+      "diff": {
+        "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/diff/bf4f4ce8a3a8d5c7dbfe7d609973a81a6c6664cf"
+      },
+      "approve": {
+        "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/commit/bf4f4ce8a3a8d5c7dbfe7d609973a81a6c6664cf/approve"
+      },
+      "statuses": {
+        "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/commit/bf4f4ce8a3a8d5c7dbfe7d609973a81a6c6664cf/statuses"
+      }
+    },
+    "author": {
+      "raw": "Antonio Muniz <amuniz@example.com>",
+      "type": "author"
+    },
+    "parents": [
+      {
+        "hash": "8d0fa145bde5151f1d103ab1c3dc1033e6ec4ac1",
+        "type": "commit",
+        "links": {
+          "self": {
+            "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/commit/8d0fa145bde5151f1d103ab1c3dc1033e6ec4ac1"
+          },
+          "html": {
+            "href": "https://bitbucket.org/amuniz/test-repos/commits/8d0fa145bde5151f1d103ab1c3dc1033e6ec4ac1"
+          }
+        }
+      }
+    ],
+    "date": "2018-09-21T14:07:25+00:00",
+    "message": "Add sample script hello world",
+    "type": "commit"
+  }
+}

--- a/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/client/payload/2.0-repositories-amuniz-test-repos-refs-branches-release_2Frelease-1.json
+++ b/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/client/payload/2.0-repositories-amuniz-test-repos-refs-branches-release_2Frelease-1.json
@@ -1,0 +1,79 @@
+{
+  "name": "release/release-1",
+  "links": {
+    "commits": {
+      "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/commits/release/release-1"
+    },
+    "self": {
+      "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/refs/branches/release/release-1"
+    },
+    "html": {
+      "href": "https://bitbucket.org/amuniz/test-repos/branch/release/release-1"
+    }
+  },
+  "default_merge_strategy": "merge_commit",
+  "merge_strategies": ["merge_commit", "squash", "fast_forward"],
+  "type": "branch",
+  "target": {
+    "hash": "bf0e8b7962c024026ad01ae09d3a11732e26c0d4",
+    "repository": {
+      "links": {
+        "self": {
+          "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos"
+        },
+        "html": {
+          "href": "https://bitbucket.org/amuniz/test-repos"
+        },
+        "avatar": {
+          "href": "https://bytebucket.org/ravatar/%7B3deb8c29-778a-450c-8f69-3e50a18079df%7D?ts=default"
+        }
+      },
+      "type": "repository",
+      "name": "test-repos",
+      "full_name": "amuniz/test-repos",
+      "uuid": "{3deb8c29-778a-450c-8f69-3e50a18079df}"
+    },
+    "links": {
+      "self": {
+        "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/commit/bf0e8b7962c024026ad01ae09d3a11732e26c0d4"
+      },
+      "comments": {
+        "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/commit/bf0e8b7962c024026ad01ae09d3a11732e26c0d4/comments"
+      },
+      "patch": {
+        "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/patch/bf0e8b7962c024026ad01ae09d3a11732e26c0d4"
+      },
+      "html": {
+        "href": "https://bitbucket.org/amuniz/test-repos/commits/bf0e8b7962c024026ad01ae09d3a11732e26c0d4"
+      },
+      "diff": {
+        "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/diff/bf0e8b7962c024026ad01ae09d3a11732e26c0d4"
+      },
+      "approve": {
+        "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/commit/bf0e8b7962c024026ad01ae09d3a11732e26c0d4/approve"
+      },
+      "statuses": {
+        "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/commit/bf0e8b7962c024026ad01ae09d3a11732e26c0d4/statuses"
+      }
+    },
+    "author": {
+      "raw": "Builder <no-reply@acme.com>",
+      "type": "author"
+    },
+    "parents": [{
+      "hash": "4bec6858eade48522da1d2f295a9d1b2360982ba",
+      "type": "commit",
+      "links": {
+        "self": {
+          "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/commit/4bec6858eade48522da1d2f295a9d1b2360982ba"
+        },
+        "html": {
+          "href": "https://bitbucket.org/amuniz/test-repos/commits/4bec6858eade48522da1d2f295a9d1b2360982ba"
+        }
+      }
+    }],
+    "date": "2018-09-21T14:53:12+00:00",
+    "message": "[CI] Release version 1.0.0",
+    "type": "commit"
+  }
+}

--- a/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/server/payload/1.0-projects-amuniz-repos-test-repos-branches-_filterText_feature_2FBB-1.json
+++ b/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/server/payload/1.0-projects-amuniz-repos-test-repos-branches-_filterText_feature_2FBB-1.json
@@ -1,0 +1,14 @@
+{
+  "size": 1,
+  "limit": 200,
+  "isLastPage": true,
+  "values": [{
+    "id": "refs/heads/feature/BB-1",
+    "displayId": "feature/BB-1",
+    "type": "BRANCH",
+    "latestCommit": "fb522a6f08c7c7df337312e4e65ec1b57710672e",
+    "latestChangeset": "fb522a6f08c7c7df337312e4e65ec1b57710672e",
+    "isDefault": false
+  }],
+  "start": 0
+}

--- a/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/server/payload/1.0-projects-amuniz-repos-test-repos-branches-_filterText_feature_2FBB-2.json
+++ b/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/server/payload/1.0-projects-amuniz-repos-test-repos-branches-_filterText_feature_2FBB-2.json
@@ -1,0 +1,14 @@
+{
+  "size": 1,
+  "limit": 200,
+  "isLastPage": true,
+  "values": [{
+    "id": "refs/heads/feature/BB-2",
+    "displayId": "feature/BB-2",
+    "type": "BRANCH",
+    "latestCommit": "046d9a3c1532acf4cf08fe93235c00e4d673c1d2",
+    "latestChangeset": "046d9a3c1532acf4cf08fe93235c00e4d673c1d2",
+    "isDefault": false
+  }],
+  "start": 0
+}

--- a/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/server/payload/1.0-projects-amuniz-repos-test-repos-branches-_filterText_main.json
+++ b/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/server/payload/1.0-projects-amuniz-repos-test-repos-branches-_filterText_main.json
@@ -1,0 +1,14 @@
+{
+  "size": 1,
+  "limit": 200,
+  "isLastPage": true,
+  "values": [{
+    "id": "refs/heads/main",
+    "displayId": "main",
+    "type": "BRANCH",
+    "latestCommit": "bf4f4ce8a3a8d5c7dbfe7d609973a81a6c6664cf",
+    "latestChangeset": "bf4f4ce8a3a8d5c7dbfe7d609973a81a6c6664cf",
+    "isDefault": true
+  }],
+  "start": 0
+}

--- a/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/server/payload/1.0-projects-amuniz-repos-test-repos-branches-_filterText_release_2Frelease-1.json
+++ b/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/server/payload/1.0-projects-amuniz-repos-test-repos-branches-_filterText_release_2Frelease-1.json
@@ -1,0 +1,14 @@
+{
+  "size": 1,
+  "limit": 200,
+  "isLastPage": true,
+  "values": [{
+    "id": "refs/heads/release/release-1",
+    "displayId": "release/release-1",
+    "type": "BRANCH",
+    "latestCommit": "bf0e8b7962c024026ad01ae09d3a11732e26c0d4",
+    "latestChangeset": "bf0e8b7962c024026ad01ae09d3a11732e26c0d4",
+    "isDefault": false
+  }],
+  "start": 0
+}


### PR DESCRIPTION
…Head

See [JENKINS-71355](https://issues.jenkins.io/browse/JENKINS-71355). When retrieving a single SCM Head, BitbucketBranchSource currently fetches all branches (and also tags in the case of a Tag) although it is not necessary.

Note: One challenge / limitation is with Bitbucket Server API that does not have an endpoint to get a single branch information. We can however send a [filterText](https://developer.atlassian.com/server/bitbucket/rest/v810/api-group-repository/#api-api-latest-projects-projectkey-repos-repositoryslug-branches-get) parameter to get what we want and then use a predicate to make sure we have the correct branch (because per my understanding the filter may returns several matches if for example a branch name is a substring of another one). But in most cases, just the branch we look for will be returned.

### Your checklist for this pull request

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Did you provide a test-case? That demonstrates feature works or fixes the issue.