### PR TITLE
Exclude archived repositories

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/BitbucketRepository.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/BitbucketRepository.java
@@ -70,6 +70,13 @@ public interface BitbucketRepository {
     boolean isPrivate();
 
     /**
+     * Is the repository marked as archived. Bitbucket 8.0 introduced the ability to "Archive" a repository which
+     * makes the repository read-only and distinguishable from "Active" repositories.
+     * @return true if the repository is marked as archived, false otherwise
+     */
+    boolean isArchived();
+
+    /**
      * Gets the links for this repository.
      * @return the links for this repository.
      */

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/repository/BitbucketCloudRepository.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/repository/BitbucketCloudRepository.java
@@ -123,6 +123,11 @@ public class BitbucketCloudRepository implements BitbucketRepository {
         return priv;
     }
 
+    @Override
+    public boolean isArchived() {
+        return false;
+    }
+
     @JsonProperty("is_private")
     public void setPrivate(Boolean priv) {
         this.priv = priv;

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/BitbucketServerAPIClient.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/BitbucketServerAPIClient.java
@@ -853,6 +853,7 @@ public class BitbucketServerAPIClient implements BitbucketApi {
         } catch (FileNotFoundException e) {
             return new ArrayList<>();
         }
+        repositories.removeIf(BitbucketServerRepository::isArchived);
         repositories.sort(Comparator.comparing(BitbucketServerRepository::getRepositoryName));
 
         return repositories;

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/repository/BitbucketServerRepository.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/repository/BitbucketServerRepository.java
@@ -51,6 +51,8 @@ public class BitbucketServerRepository implements BitbucketRepository {
     // JSON mapping added in setter because the field can not be called "public"
     private Boolean public_;
 
+    private Boolean archived;
+
     @JsonProperty
     @JsonDeserialize(keyAs = String.class, contentUsing = BitbucketHref.Deserializer.class)
     private Map<String, List<BitbucketHref>> links;
@@ -99,6 +101,16 @@ public class BitbucketServerRepository implements BitbucketRepository {
     @Override
     public boolean isPrivate() {
         return !public_;
+    }
+
+    @Override
+    public boolean isArchived() {
+        return archived != null && archived;
+    }
+
+    @JsonProperty("archived")
+    public void setArchived(Boolean archived) {
+        this.archived = archived;
     }
 
     @JsonProperty("public")

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/BitbucketServerAPIClientTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/BitbucketServerAPIClientTest.java
@@ -1,11 +1,14 @@
 package com.cloudbees.jenkins.plugins.bitbucket.server.client;
 
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketApi;
+import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketRepository;
 import com.cloudbees.jenkins.plugins.bitbucket.client.BitbucketIntegrationClientFactory;
 import com.cloudbees.jenkins.plugins.bitbucket.client.BitbucketIntegrationClientFactory.BitbucketServerIntegrationClient;
 import com.damnhandy.uri.template.UriTemplate;
 import com.damnhandy.uri.template.impl.Operator;
+import java.util.List;
 import java.util.logging.Level;
+import java.util.stream.Collectors;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -18,6 +21,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 
 public class BitbucketServerAPIClientTest {
 
@@ -58,6 +63,23 @@ public class BitbucketServerAPIClientTest {
         ((BitbucketServerIntegrationClient)client).rateLimitNextRequest();
         assertThat(client.getRepository().getProject().getKey(), equalTo("AMUNIZ"));
         assertThat(logger.getMessages(), hasItem(containsString("Bitbucket server API rate limit reached")));
+    }
+
+    @Test
+    public void filterArchivedRepositories() throws Exception {
+        BitbucketApi client = BitbucketIntegrationClientFactory.getClient("localhost", "foo", "test-repos");;
+        List<? extends BitbucketRepository> repos = client.getRepositories();
+        List<String> names = repos.stream().map(BitbucketRepository::getRepositoryName).collect(Collectors.toList());
+        assertThat(names, not(hasItem("bar-archived")));
+        assertThat(names, is(List.of("bar-active")));
+    }
+
+    @Test
+    public void sortRepositoriesByName() throws Exception {
+        BitbucketApi client = BitbucketIntegrationClientFactory.getClient("localhost", "amuniz", "test-repos");;
+        List<? extends BitbucketRepository> repos = client.getRepositories();
+        List<String> names = repos.stream().map(BitbucketRepository::getRepositoryName).collect(Collectors.toList());
+        assertThat(names, is(List.of("another-repo", "dogs-repo", "test-repos")));
     }
 
 }

--- a/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/server/payload/1.0-projects-amuniz-repos_start_0_limit_200.json
+++ b/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/server/payload/1.0-projects-amuniz-repos_start_0_limit_200.json
@@ -1,0 +1,113 @@
+{
+  "size": 1,
+  "limit": 200,
+  "isLastPage": true,
+  "values": [
+    {
+      "slug": "test-repos",
+      "id": 1,
+      "name": "test-repos",
+      "scmId": "git",
+      "state": "AVAILABLE",
+      "statusMessage": "Available",
+      "forkable": false,
+      "project": {
+        "key": "AMUNIZ",
+        "id": 1,
+        "name": "prj",
+        "description": "This is a test repo",
+        "public": true,
+        "type": "NORMAL",
+        "links": {
+          "self": [{
+            "href": "http://localhost:7990/projects/AMUNIZ"
+          }]
+        }
+      },
+      "public": false,
+      "links": {
+        "clone": [{
+          "href": "ssh://git@localhost:7999/amuniz/test-repos.git",
+          "name": "ssh"
+        }, {
+          "href": "http://localhost:7990/scm/amuniz/test-repos.git",
+          "name": "http"
+        }],
+        "self": [{
+          "href": "http://localhost:7990/projects/AMUNIZ/repos/test-repos/browse"
+        }]
+      }
+    },
+    {
+      "slug": "another-repo",
+      "id": 2,
+      "name": "another-repo",
+      "scmId": "git",
+      "state": "AVAILABLE",
+      "statusMessage": "Available",
+      "forkable": false,
+      "project": {
+        "key": "AMUNIZ",
+        "id": 1,
+        "name": "prj",
+        "description": "This is a test repo",
+        "public": true,
+        "type": "NORMAL",
+        "links": {
+          "self": [{
+            "href": "http://localhost:7990/projects/AMUNIZ"
+          }]
+        }
+      },
+      "public": false,
+      "links": {
+        "clone": [{
+          "href": "ssh://git@localhost:7999/amuniz/another-repo.git",
+          "name": "ssh"
+        }, {
+          "href": "http://localhost:7990/scm/amuniz/another-repo.git",
+          "name": "http"
+        }],
+        "self": [{
+          "href": "http://localhost:7990/projects/AMUNIZ/repos/another-repo/browse"
+        }]
+      }
+    },
+    {
+      "slug": "dogs-repo",
+      "id": 3,
+      "name": "dogs-repo",
+      "scmId": "git",
+      "state": "AVAILABLE",
+      "statusMessage": "Available",
+      "forkable": false,
+      "project": {
+        "key": "AMUNIZ",
+        "id": 1,
+        "name": "prj",
+        "description": "This is a test repo",
+        "public": true,
+        "type": "NORMAL",
+        "links": {
+          "self": [{
+            "href": "http://localhost:7990/projects/AMUNIZ"
+          }]
+        }
+      },
+      "public": false,
+      "links": {
+        "clone": [{
+          "href": "ssh://git@localhost:7999/amuniz/dogs-repo.git",
+          "name": "ssh"
+        }, {
+          "href": "http://localhost:7990/scm/amuniz/dogs-repo.git",
+          "name": "http"
+        }],
+        "self": [{
+          "href": "http://localhost:7990/projects/AMUNIZ/repos/dogs-repo/browse"
+        }]
+      }
+    }
+  ],
+  "start": 0
+}

--- a/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/server/payload/1.0-projects-foo-repos_start_0_limit_200.json
+++ b/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/server/payload/1.0-projects-foo-repos_start_0_limit_200.json
@@ -1,0 +1,80 @@
+{
+  "size": 1,
+  "limit": 200,
+  "isLastPage": true,
+  "values": [
+    {
+      "slug": "bar-active",
+      "id": 1,
+      "name": "bar-active",
+      "scmId": "git",
+      "state": "AVAILABLE",
+      "statusMessage": "Available",
+      "forkable": false,
+      "project": {
+        "key": "FOO",
+        "id": 1,
+        "name": "prj",
+        "description": "This is a test repo",
+        "public": true,
+        "type": "NORMAL",
+        "links": {
+          "self": [{
+            "href": "http://localhost:7990/projects/FOO"
+          }]
+        }
+      },
+      "public": false,
+      "archived": false,
+      "links": {
+        "clone": [{
+          "href": "ssh://git@localhost:7999/foo/bar-active.git",
+          "name": "ssh"
+        }, {
+          "href": "http://localhost:7990/scm/foo/bar-active.git",
+          "name": "http"
+        }],
+        "self": [{
+          "href": "http://localhost:7990/projects/FOO/repos/bar-active/browse"
+        }]
+      }
+    },
+    {
+      "slug": "bar-archived",
+      "id": 1,
+      "name": "test-repos",
+      "scmId": "git",
+      "state": "AVAILABLE",
+      "statusMessage": "Available",
+      "forkable": false,
+      "project": {
+        "key": "FOO",
+        "id": 1,
+        "name": "prj",
+        "description": "This is a test repo",
+        "public": true,
+        "type": "NORMAL",
+        "links": {
+          "self": [{
+            "href": "http://localhost:7990/projects/FOO"
+          }]
+        }
+      },
+      "public": false,
+      "archived": true,
+      "links": {
+        "clone": [{
+          "href": "ssh://git@localhost:7999/foo/bar-archived.git",
+          "name": "ssh"
+        }, {
+          "href": "http://localhost:7990/scm/foo/bar-archived.git",
+          "name": "http"
+        }],
+        "self": [{
+          "href": "http://localhost:7990/projects/FOO/repos/bar-archived/browse"
+        }]
+      }
+    }
+  ],
+  "start": 0
+}


### PR DESCRIPTION
Bitbucket server 8.0 introduced the ability to archive repositories. An archived repository makes it read-only as well as other restrictions.

https://confluence.atlassian.com/bitbucketserver/archive-a-repository-1128304317.html

This change filters out archived repositories from the returned repositories list.

Fixes #703

<!-- Please describe your pull request here. -->

<!--
To mark your pull request as work in progress please create it as a draft pull request
-->

### Your checklist for this pull request

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Did you provide a test-case? That demonstrates feature works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled the information below
Describe your pull request below
-->
