### PR TITLE
Use revision to get files from bitbucket api

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/BitbucketServerAPIClient.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/BitbucketServerAPIClient.java
@@ -1202,12 +1202,13 @@ public class BitbucketServerAPIClient implements BitbucketApi {
     public Iterable<SCMFile> getDirectoryContent(BitbucketSCMFile directory) throws IOException, InterruptedException {
         List<SCMFile> files = new ArrayList<>();
         int start=0;
+        String branchOrHash = directory.getHash().contains("+") ? directory.getRef() : directory.getHash();
         UriTemplate template = UriTemplate
                 .fromTemplate(API_BROWSE_PATH + "{&start,limit}")
                 .set("owner", getUserCentricOwner())
                 .set("repo", repositoryName)
                 .set("path", directory.getPath().split(Operator.PATH.getSeparator()))
-                .set("at", directory.getRef())
+                .set("at", branchOrHash)
                 .set("start", start)
                 .set("limit", 500);
         String url = template.expand();
@@ -1250,12 +1251,13 @@ public class BitbucketServerAPIClient implements BitbucketApi {
     public InputStream getFileContent(BitbucketSCMFile file) throws IOException, InterruptedException {
         List<String> lines = new ArrayList<>();
         int start=0;
+        String branchOrHash = file.getHash().contains("+") ? file.getRef() : file.getHash();
         UriTemplate template = UriTemplate
                 .fromTemplate(API_BROWSE_PATH + "{&start,limit}")
                 .set("owner", getUserCentricOwner())
                 .set("repo", repositoryName)
                 .set("path", file.getPath().split(Operator.PATH.getSeparator()))
-                .set("at", file.getRef())
+                .set("at", branchOrHash)
                 .set("start", start)
                 .set("limit", 500);
         String url = template.expand();


### PR DESCRIPTION
Use hash to get files from BB server API, currently we always use ref that leads to reading files from incorrect places e.g. if you use `readTrusted` in long running pipeline and revision of ref changes during execution. It seems logical to use revision here as we should always have revision specification in multibranch pipeline runs.

<!--
To mark your pull request as work in progress please create it as a draft pull request
-->

### Your checklist for this pull request

- [ x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [ x] Ensure that the pull request title represents the desired changelog entry
- [ x] Please describe what you did
- [ ] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Did you provide a test-case? That demonstrates feature works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled the information below
Describe your pull request below
-->
