### PR TITLE
Feature/enable access tokens for cloud

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/credentials/BitbucketAccessTokenAuthenticatorSource.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/credentials/BitbucketAccessTokenAuthenticatorSource.java
@@ -41,6 +41,7 @@ public class BitbucketAccessTokenAuthenticatorSource extends AuthenticationToken
     @Override
     public boolean isFit(AuthenticationTokenContext ctx) {
         return ctx.mustHave(BitbucketAuthenticator.SCHEME, "https")
-            && ctx.mustHave(BitbucketAuthenticator.BITBUCKET_INSTANCE_TYPE, BitbucketAuthenticator.BITBUCKET_INSTANCE_TYPE_SERVER);
+            && (ctx.mustHave(BitbucketAuthenticator.BITBUCKET_INSTANCE_TYPE, BitbucketAuthenticator.BITBUCKET_INSTANCE_TYPE_SERVER)
+            || ctx.mustHave(BitbucketAuthenticator.BITBUCKET_INSTANCE_TYPE, BitbucketAuthenticator.BITBUCKET_INSTANCE_TYPE_CLOUD));
     }
 }

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/api/credentials/BitbucketAccessTokenAuthenticatorSourceTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/api/credentials/BitbucketAccessTokenAuthenticatorSourceTest.java
@@ -18,7 +18,9 @@ public class BitbucketAccessTokenAuthenticatorSourceTest {
         BitbucketAccessTokenAuthenticatorSource source = new BitbucketAccessTokenAuthenticatorSource();
         AuthenticationTokenContext<BitbucketAuthenticator> cloudContext = BitbucketAuthenticator.authenticationContext("https://bitbucket.org");
         AuthenticationTokenContext<BitbucketAuthenticator> serverContext = BitbucketAuthenticator.authenticationContext("https://bitbucket-server.org");
+        AuthenticationTokenContext<BitbucketAuthenticator> unsecureServerContext = BitbucketAuthenticator.authenticationContext("http://bitbucket-server.org");
         assertThat(source.isFit(cloudContext), is(true));
         assertThat(source.isFit(serverContext), is(true));
+        assertThat(source.isFit(unsecureServerContext), is(false));
     }
 }

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/api/credentials/BitbucketAccessTokenAuthenticatorSourceTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/api/credentials/BitbucketAccessTokenAuthenticatorSourceTest.java
@@ -1,0 +1,24 @@
+package com.cloudbees.jenkins.plugins.bitbucket.api.credentials;
+
+import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketAuthenticator;
+import jenkins.authentication.tokens.api.AuthenticationTokenContext;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class BitbucketAccessTokenAuthenticatorSourceTest {
+    @ClassRule
+    public static JenkinsRule j = new JenkinsRule();
+
+    @Test
+    public void isFitTest() {
+        BitbucketAccessTokenAuthenticatorSource source = new BitbucketAccessTokenAuthenticatorSource();
+        AuthenticationTokenContext<BitbucketAuthenticator> cloudContext = BitbucketAuthenticator.authenticationContext("https://bitbucket.org");
+        AuthenticationTokenContext<BitbucketAuthenticator> serverContext = BitbucketAuthenticator.authenticationContext("https://bitbucket-server.org");
+        assertThat(source.isFit(cloudContext), is(true));
+        assertThat(source.isFit(serverContext), is(true));
+    }
+}


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

<!--
To mark your pull request as work in progress please create it as a draft pull request
-->

### Your checklist for this pull request

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Did you provide a test-case? That demonstrates feature works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled the information below
Describe your pull request below
-->

This PR enables support for Bitbucket HTTP Access Tokens when the selected server URL is a Bitbucket cloud instance (https://bitbucket.org/...).
This was not previously possible, see https://github.com/jenkinsci/bitbucket-branch-source-plugin/issues/706.
