### PR TITLE
Decode webhook request body as UTF-8

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/BitbucketSCMSourcePushHookReceiver.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/BitbucketSCMSourcePushHookReceiver.java
@@ -28,6 +28,7 @@ import hudson.model.UnprotectedRootAction;
 import hudson.security.csrf.CrumbExclusion;
 import hudson.util.HttpResponses;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.servlet.FilterChain;
@@ -77,7 +78,7 @@ public class BitbucketSCMSourcePushHookReceiver extends CrumbExclusion implement
      */
     public HttpResponse doNotify(StaplerRequest req) throws IOException {
         String origin = SCMEvent.originOf(req);
-        String body = IOUtils.toString(req.getInputStream());
+        String body = IOUtils.toString(req.getInputStream(), StandardCharsets.UTF_8);
         String eventKey = req.getHeader("X-Event-Key");
         if (eventKey == null) {
             return HttpResponses.error(HttpServletResponse.SC_BAD_REQUEST, "X-Event-Key HTTP header not found");


### PR DESCRIPTION
When receiving a webhook request at bitbucket-scmsource-hook and converting the HTTP request body to a string, always use UTF-8 even if the system default charset is different.
This is mainly relevant to a Jenkins controller running on Windows, where the system charset might be Windows-1252, but Bitbucket Server encodes the webhook request JSON in UTF-8.

Fix <https://github.com/jenkinsci/bitbucket-branch-source-plugin/issues/762>

<!-- Please describe your pull request here. -->

<!--
To mark your pull request as work in progress please create it as a draft pull request
-->

### Your checklist for this pull request

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Did you provide a test-case? That demonstrates feature works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled the information below
Describe your pull request below
-->
