### PR TITLE
Make Git use LF newlines in *.java, *.properties

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.java crlf=input

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 *.java crlf=input
+*.properties crlf=input


### PR DESCRIPTION
In .gitattributes, set `crlf=input` for `*.java` and `*.properties`, so that:

* "git checkout" does not convert newlines, so they remain LF, even if the system Git configuration on Windows specifies core.autocrlf=true.
* "git add" converts CRLF to LF.

This fixes the numerous checkstyle errors about CRLF newlines that show up in the console log of ci.jenkins.io when it builds the plugin on Windows.  Stuff like these:

```
[2023-09-16T18:26:36.688Z] [INFO] --- checkstyle:3.3.0:check (default) @ cloudbees-bitbucket-branch-source ---
[2023-09-16T18:26:45.633Z] [INFO] There are 201 errors reported by Checkstyle 10.12.3 with C:\Jenkins\agent\workspace\cket-branch-source-plugin_master/checkstyle.xml ruleset.
[2023-09-16T18:26:45.737Z] [ERROR] src\main\java\com\cloudbees\jenkins\plugins\bitbucket\api\AbstractBitbucketTeam.java:[1] (misc) NewlineAtEndOfFile: Expected line ending for file is LF(\n), but CRLF(\r\n) is detected.
[2023-09-16T18:26:45.739Z] [ERROR] src\main\java\com\cloudbees\jenkins\plugins\bitbucket\api\BitbucketApi.java:[1] (misc) NewlineAtEndOfFile: Expected line ending for file is LF(\n), but CRLF(\r\n) is detected.
```

Those errors do not affect the Warnings NG reports at ci.jenkins.io because [buildPlugin](https://github.com/jenkins-infra/pipeline-library/blob/978c955560530e91afeb6a6cf0fa71e8912f425e/vars/buildPlugin.groovy) runs the `recordIssues` steps in the first build configuration only, i.e. on Linux.  Regardless, they make real problems more difficult to find in the console log.

### Your checklist for this pull request

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
  * None found.
- [x] Link to relevant pull requests, esp. upstream and downstream changes
  * The checkstyle newline checking was added in <https://github.com/jenkinsci/bitbucket-branch-source-plugin/pull/219>.
- [ ] Did you provide a test-case? That demonstrates feature works or fixes the issue.
  * No explicit test case, but the ci.jenkins.io build of this PR shows that the checkstyle errors went away.
