### PR TITLE
Option to disable bitbucket notifications on aborted jobs

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketBuildStatusNotifications.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketBuildStatusNotifications.java
@@ -146,6 +146,14 @@ public class BitbucketBuildStatusNotifications {
             } else {
                 state = BitbucketBuildStatus.Status.SUCCESSFUL;
             }
+        } else if (Result.ABORTED.equals(result)) {
+            statusDescription = StringUtils.defaultIfBlank(buildDescription, "This commit build was aborted");
+            BitbucketSCMSourceContext context = new BitbucketSCMSourceContext(null, SCMHeadObserver.none()).withTraits(source.getTraits());
+            if (context.disableNotificationForAbortedJobs()) {
+                state = null;
+            } else {
+                state = BitbucketBuildStatus.Status.FAILED;
+            }
         } else if (result != null) { // ABORTED etc.
             statusDescription = StringUtils.defaultIfBlank(buildDescription, "Something is wrong with the build of this commit.");
             state = BitbucketBuildStatus.Status.FAILED;

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketBuildStatusNotificationsTrait.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketBuildStatusNotificationsTrait.java
@@ -51,6 +51,11 @@ public class BitbucketBuildStatusNotificationsTrait extends SCMSourceTrait {
     private boolean disableNotificationForNotBuildJobs;
 
     /**
+     * Should aborted jobs be communicated to Bitbucket
+     */
+    private boolean disableNotificationForAbortedJobs;
+
+    /**
      * Constructor.
      *
      */
@@ -78,6 +83,11 @@ public class BitbucketBuildStatusNotificationsTrait extends SCMSourceTrait {
         disableNotificationForNotBuildJobs = isNotificationDisabled;
     }
 
+    @DataBoundSetter
+    public void setDisableNotificationForAbortedJobs(boolean isNotificationDisabled) {
+        disableNotificationForAbortedJobs = isNotificationDisabled;
+    }
+
     /**
      * @return if unstable builds will be communicated
      */
@@ -86,11 +96,19 @@ public class BitbucketBuildStatusNotificationsTrait extends SCMSourceTrait {
     }
 
     /**
+     * @return if aborted builds will be communicated
+     */
+    public boolean getDisableNotificationForAbortedJobs() {
+        return this.disableNotificationForAbortedJobs;
+    }
+
+    /**
      * {@inheritDoc}
      */
     @Override
     protected void decorateContext(SCMSourceContext<?, ?> context) {
         ((BitbucketSCMSourceContext) context).withDisableNotificationForNotBuildJobs(getDisableNotificationForNotBuildJobs());
+        ((BitbucketSCMSourceContext) context).withDisableNotificationForAbortedJobs(getDisableNotificationForAbortedJobs());
         ((BitbucketSCMSourceContext) context).withSendSuccessNotificationForUnstableBuild(getSendSuccessNotificationForUnstableBuild());
     }
 

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSourceContext.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSourceContext.java
@@ -97,6 +97,11 @@ public class BitbucketSCMSourceContext extends SCMSourceContext<BitbucketSCMSour
     private boolean disableNotificationForNotBuildJobs;
 
     /**
+     * {@code false} if aborted jobs should be sent to Bitbucket.
+     */
+    private boolean disableNotificationForAbortedJobs;
+
+    /**
      * Constructor.
      *
      * @param criteria (optional) criteria.
@@ -227,6 +232,13 @@ public class BitbucketSCMSourceContext extends SCMSourceContext<BitbucketSCMSour
      */
     public boolean disableNotificationForNotBuildJobs() {
         return disableNotificationForNotBuildJobs;
+    }
+
+    /**
+     * @return {@code false} if aborted jobs should be passed to Bitbucket.
+     */
+    public boolean disableNotificationForAbortedJobs() {
+        return disableNotificationForAbortedJobs;
     }
 
     /**
@@ -375,6 +387,18 @@ public class BitbucketSCMSourceContext extends SCMSourceContext<BitbucketSCMSour
     @NonNull
     public final BitbucketSCMSourceContext withDisableNotificationForNotBuildJobs(boolean disabled) {
         this.disableNotificationForNotBuildJobs = disabled;
+        return this;
+    }
+
+    /**
+     * Defines behaviour of aborted jobs in Bitbucket.
+     *
+     * @param disabled {@code false} to report not-built jobs to Bitbucket.
+     * @return {@code this} for method chaining.
+     */
+    @NonNull
+    public final BitbucketSCMSourceContext withDisableNotificationForAbortedJobs(boolean disabled) {
+        this.disableNotificationForAbortedJobs = disabled;
         return this;
     }
 

--- a/src/main/resources/com/cloudbees/jenkins/plugins/bitbucket/BitbucketBuildStatusNotificationsTrait/config.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/bitbucket/BitbucketBuildStatusNotificationsTrait/config.jelly
@@ -6,4 +6,7 @@
   <f:entry title="${%Do not communicate not-built jobs to Bitbucket}" field="disableNotificationForNotBuildJobs">
     <f:checkbox/>
   </f:entry>
+  <f:entry title="${%Do not communicate aborted jobs to Bitbucket}" field="disableNotificationForAbortedJobs">
+    <f:checkbox/>
+  </f:entry>
 </j:jelly>


### PR DESCRIPTION
This PR adds option to disable notifications for aborted Jobs. 

My use case is that we are aborting some branch builds in multibranch pipelines, leaving only PR builds to finish successfully.
Bitbucket shows all Jobs, including aborted ones, and shows them as failed. It is misleading for many bitbucket users.

Similar request was discussed here (to mark them as Cancelled): https://github.com/jenkinsci/bitbucket-branch-source-plugin/issues/606 however as I understand, it won't be implemented.

### Your checklist for this pull request

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Did you provide a test-case? That demonstrates feature works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled the information below
Describe your pull request below
-->