### PR TITLE
Fix for "Invalid cookie header"-warning using HttpClient and Bitbucket Server Interaction

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/BitbucketServerAPIClient.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/BitbucketServerAPIClient.java
@@ -1038,6 +1038,7 @@ public class BitbucketServerAPIClient implements BitbucketApi {
         HttpClientBuilder httpClientBuilder = HttpClientBuilder.create();
         httpClientBuilder.useSystemProperties();
         httpClientBuilder.setRetryHandler(new StandardHttpRequestRetryHandler());
+        httpClientBuilder.disableCookieManagement();
 
         RequestConfig.Builder requestConfig = RequestConfig.custom();
         String connectTimeout = System.getProperty("http.connect.timeout", "10");


### PR DESCRIPTION
I've identified an issue in the HttpClient configuration when interacting with Bitbucket Server. Encountering a warning: "WARNING ... processCookies: Invalid cookie header." This warning is triggered during the cookie parsing process, which seems to be incompatible with the cookie formats sent by Bitbucket Server.

Initially, I considered changing the default cookie specification to CookieSpecs.STANDARD to address this compatibility issue. However, I realized that this might not be the most efficient solution. Current code seems to create a new cookie store for each request.

Therefore, to simplify the HTTP interactions and eliminate the warning, I've opted to deactivate cookie handling in the HttpClient when interacting with Bitbucket Server. By disabling cookie management, we not only avoid the warning but also prevent other cookie-related problems.

Please review the changes and let me know if you have any concerns or if further adjustments are required.

### Your checklist for this pull request

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Did you provide a test-case? That demonstrates feature works or fixes the issue.

