### PR TITLE
Properly handle value "https" in clone link name

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketGitSCMBuilder.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketGitSCMBuilder.java
@@ -308,7 +308,7 @@ public class BitbucketGitSCMBuilder extends GitSCMBuilder<BitbucketGitSCMBuilder
 
     private String getCloneLink(List<BitbucketHref> cloneLinks) {
         return cloneLinks.stream()
-            .filter(link -> protocol.getType().equals(link.getName()))
+            .filter(link -> protocol.matches(link.getName()))
             .findAny()
             .orElseThrow(() -> new IllegalStateException("Can't find clone link for protocol " + protocol))
             .getHref();

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/BitbucketRepositoryProtocol.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/BitbucketRepositoryProtocol.java
@@ -23,7 +23,6 @@
  */
 package com.cloudbees.jenkins.plugins.bitbucket.api;
 
-import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 public enum BitbucketRepositoryProtocol {
@@ -44,18 +43,16 @@ public enum BitbucketRepositoryProtocol {
         this.type = type;
     }
 
-    public String getType() {
-        return type;
+    /**
+     * Check if link name matches protocol.
+     * In Bitbucket Server "http" and "ssh" are used as link names.
+     * In Bitbucket Cloud "https" and "ssh" are used.
+     *
+     * @param linkName link name to check
+     * @return if link name matches
+     */
+    public boolean matches(@NonNull String linkName) {
+        return linkName.startsWith(type);
     }
 
-    @CheckForNull
-    public static BitbucketRepositoryProtocol fromString(String type) {
-        if (SSH.type.equals(type)) {
-            return SSH;
-        } else if (HTTP.type.equals(type)) {
-            return HTTP;
-        } else {
-            return null;
-        }
-    }
 }

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketGitSCMBuilderTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketGitSCMBuilderTest.java
@@ -93,7 +93,7 @@ public class BitbucketGitSCMBuilderTest {
 
         instance.withCloneLinks(
             List.of(
-                new BitbucketHref("http", "https://bitbucket.org/tester/test-repo.git"),
+                new BitbucketHref("https", "https://bitbucket.org/tester/test-repo.git"),
                 new BitbucketHref("ssh", "ssh://git@bitbucket.org/tester/test-repo.git")
             ),
             List.of()
@@ -153,7 +153,7 @@ public class BitbucketGitSCMBuilderTest {
 
         instance.withCloneLinks(
             List.of(
-                new BitbucketHref("http", "https://bitbucket.org/tester/test-repo.git"),
+                new BitbucketHref("https", "https://bitbucket.org/tester/test-repo.git"),
                 new BitbucketHref("ssh", "ssh://git@bitbucket.org/tester/test-repo.git")
             ),
             List.of()
@@ -213,7 +213,7 @@ public class BitbucketGitSCMBuilderTest {
 
         instance.withCloneLinks(
             List.of(
-                new BitbucketHref("http", "https://bitbucket.org/tester/test-repo.git"),
+                new BitbucketHref("https", "https://bitbucket.org/tester/test-repo.git"),
                 new BitbucketHref("ssh", "ssh://git@bitbucket.org/tester/test-repo.git")
             ),
             List.of()
@@ -271,7 +271,7 @@ public class BitbucketGitSCMBuilderTest {
 
         instance.withCloneLinks(
             List.of(
-                new BitbucketHref("http", "https://bitbucket.org/tester/test-repo.git"),
+                new BitbucketHref("https", "https://bitbucket.org/tester/test-repo.git"),
                 new BitbucketHref("ssh", "ssh://git@bitbucket.org/tester/test-repo.git")
             ),
             List.of()
@@ -317,7 +317,7 @@ public class BitbucketGitSCMBuilderTest {
 
         instance.withCloneLinks(
             List.of(
-                new BitbucketHref("http", "https://bitbucket.org/tester/test-repo.git"),
+                new BitbucketHref("https", "https://bitbucket.org/tester/test-repo.git"),
                 new BitbucketHref("ssh", "ssh://git@bitbucket.org/tester/test-repo.git")
             ),
             List.of()
@@ -363,7 +363,7 @@ public class BitbucketGitSCMBuilderTest {
 
         instance.withCloneLinks(
             List.of(
-                new BitbucketHref("http", "https://bitbucket.org/tester/test-repo.git"),
+                new BitbucketHref("https", "https://bitbucket.org/tester/test-repo.git"),
                 new BitbucketHref("ssh", "ssh://git@bitbucket.org/tester/test-repo.git")
             ),
             List.of()
@@ -915,7 +915,7 @@ public class BitbucketGitSCMBuilderTest {
 
         instance.withCloneLinks(
             List.of(
-                new BitbucketHref("http", "https://bitbucket.org/tester/test-repo.git"),
+                new BitbucketHref("https", "https://bitbucket.org/tester/test-repo.git"),
                 new BitbucketHref("ssh", "ssh://git@bitbucket.org/tester/test-repo.git")
             ),
             List.of()
@@ -979,7 +979,7 @@ public class BitbucketGitSCMBuilderTest {
 
         instance.withCloneLinks(
             List.of(
-                new BitbucketHref("http", "https://bitbucket.org/tester/test-repo.git"),
+                new BitbucketHref("https", "https://bitbucket.org/tester/test-repo.git"),
                 new BitbucketHref("ssh", "ssh://git@bitbucket.org/tester/test-repo.git")
             ),
             List.of()
@@ -1042,7 +1042,7 @@ public class BitbucketGitSCMBuilderTest {
 
         instance.withCloneLinks(
             List.of(
-                new BitbucketHref("http", "https://bitbucket.org/tester/test-repo.git"),
+                new BitbucketHref("https", "https://bitbucket.org/tester/test-repo.git"),
                 new BitbucketHref("ssh", "ssh://git@bitbucket.org/tester/test-repo.git")
             ),
             List.of()
@@ -1106,7 +1106,7 @@ public class BitbucketGitSCMBuilderTest {
 
         instance.withCloneLinks(
             List.of(
-                new BitbucketHref("http", "https://bitbucket.org/tester/test-repo.git"),
+                new BitbucketHref("https", "https://bitbucket.org/tester/test-repo.git"),
                 new BitbucketHref("ssh", "ssh://git@bitbucket.org/tester/test-repo.git")
             ),
             List.of()
@@ -1176,7 +1176,7 @@ public class BitbucketGitSCMBuilderTest {
 
         instance.withCloneLinks(
             List.of(
-                new BitbucketHref("http", "https://bitbucket.org/tester/test-repo.git"),
+                new BitbucketHref("https", "https://bitbucket.org/tester/test-repo.git"),
                 new BitbucketHref("ssh", "ssh://git@bitbucket.org/tester/test-repo.git")
             ),
             List.of()
@@ -1246,7 +1246,7 @@ public class BitbucketGitSCMBuilderTest {
 
         instance.withCloneLinks(
             List.of(
-                new BitbucketHref("http", "https://bitbucket.org/tester/test-repo.git"),
+                new BitbucketHref("https", "https://bitbucket.org/tester/test-repo.git"),
                 new BitbucketHref("ssh", "ssh://git@bitbucket.org/tester/test-repo.git")
             ),
             List.of()
@@ -1316,7 +1316,7 @@ public class BitbucketGitSCMBuilderTest {
 
         instance.withCloneLinks(
             List.of(
-                new BitbucketHref("http", "https://bitbucket.org/tester/test-repo.git"),
+                new BitbucketHref("https", "https://bitbucket.org/tester/test-repo.git"),
                 new BitbucketHref("ssh", "ssh://git@bitbucket.org/tester/test-repo.git")
             ),
             List.of()
@@ -1386,7 +1386,7 @@ public class BitbucketGitSCMBuilderTest {
 
         instance.withCloneLinks(
             List.of(
-                new BitbucketHref("http", "https://bitbucket.org/tester/test-repo.git"),
+                new BitbucketHref("https", "https://bitbucket.org/tester/test-repo.git"),
                 new BitbucketHref("ssh", "ssh://git@bitbucket.org/tester/test-repo.git")
             ),
             List.of()
@@ -1456,7 +1456,7 @@ public class BitbucketGitSCMBuilderTest {
 
         instance.withCloneLinks(
             List.of(
-                new BitbucketHref("http", "https://bitbucket.org/tester/test-repo.git"),
+                new BitbucketHref("https", "https://bitbucket.org/tester/test-repo.git"),
                 new BitbucketHref("ssh", "ssh://git@bitbucket.org/tester/test-repo.git")
             ),
             List.of()
@@ -1522,7 +1522,7 @@ public class BitbucketGitSCMBuilderTest {
 
         instance.withCloneLinks(
             List.of(
-                new BitbucketHref("http", "https://bitbucket.org/tester/test-repo.git"),
+                new BitbucketHref("https", "https://bitbucket.org/tester/test-repo.git"),
                 new BitbucketHref("ssh", "ssh://git@bitbucket.org/tester/test-repo.git")
             ),
             List.of()
@@ -1570,7 +1570,7 @@ public class BitbucketGitSCMBuilderTest {
 
         instance.withCloneLinks(
             List.of(
-                new BitbucketHref("http", "https://bitbucket.org/tester/test-repo.git"),
+                new BitbucketHref("https", "https://bitbucket.org/tester/test-repo.git"),
                 new BitbucketHref("ssh", "ssh://git@bitbucket.org/tester/test-repo.git")
             ),
             List.of()
@@ -1618,7 +1618,7 @@ public class BitbucketGitSCMBuilderTest {
 
         instance.withCloneLinks(
             List.of(
-                new BitbucketHref("http", "https://bitbucket.org/tester/test-repo.git"),
+                new BitbucketHref("https", "https://bitbucket.org/tester/test-repo.git"),
                 new BitbucketHref("ssh", "ssh://git@bitbucket.org/tester/test-repo.git")
             ),
             List.of()
@@ -2484,7 +2484,7 @@ public class BitbucketGitSCMBuilderTest {
 
         instance.withCloneLinks(
             List.of(
-                new BitbucketHref("http", "https://bitbucket.org/tester/test-repo.git"),
+                new BitbucketHref("https", "https://bitbucket.org/tester/test-repo.git"),
                 new BitbucketHref("ssh", "ssh://git@bitbucket.org/tester/test-repo.git")
             ),
             List.of()
@@ -2568,7 +2568,7 @@ public class BitbucketGitSCMBuilderTest {
 
         instance.withCloneLinks(
             List.of(
-                new BitbucketHref("http", "https://bitbucket.org/tester/test-repo.git"),
+                new BitbucketHref("https", "https://bitbucket.org/tester/test-repo.git"),
                 new BitbucketHref("ssh", "ssh://git@bitbucket.org/tester/test-repo.git")
             ),
             List.of()
@@ -2652,7 +2652,7 @@ public class BitbucketGitSCMBuilderTest {
 
         instance.withCloneLinks(
             List.of(
-                new BitbucketHref("http", "https://bitbucket.org/tester/test-repo.git"),
+                new BitbucketHref("https", "https://bitbucket.org/tester/test-repo.git"),
                 new BitbucketHref("ssh", "ssh://git@bitbucket.org/tester/test-repo.git")
             ),
             List.of()
@@ -2732,7 +2732,7 @@ public class BitbucketGitSCMBuilderTest {
 
         instance.withCloneLinks(
             List.of(
-                new BitbucketHref("http", "https://bitbucket.org/tester/test-repo.git"),
+                new BitbucketHref("https", "https://bitbucket.org/tester/test-repo.git"),
                 new BitbucketHref("ssh", "ssh://git@bitbucket.org/tester/test-repo.git")
             ),
             List.of()
@@ -2800,7 +2800,7 @@ public class BitbucketGitSCMBuilderTest {
 
         instance.withCloneLinks(
             List.of(
-                new BitbucketHref("http", "https://bitbucket.org/tester/test-repo.git"),
+                new BitbucketHref("https", "https://bitbucket.org/tester/test-repo.git"),
                 new BitbucketHref("ssh", "ssh://git@bitbucket.org/tester/test-repo.git")
             ),
             List.of()


### PR DESCRIPTION
In Bitbucket Server "http" is used as http link name, but in Bitbucket Cloud "https" is used.

Bug was introduced in #796. Fixes #804.

### Your checklist for this pull request

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Did you provide a test-case? That demonstrates feature works or fixes the issue.

