### PR TITLE
Remove ref-specs cleanup during initialization of BitbucketGitSCMBuilder

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketGitSCMBuilder.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketGitSCMBuilder.java
@@ -189,7 +189,6 @@ public class BitbucketGitSCMBuilder extends GitSCMBuilder<BitbucketGitSCMBuilder
     @NonNull
     public BitbucketGitSCMBuilder withBitbucketRemote() {
         SCMHead head = head();
-        withoutRefSpecs();
         String headName = head.getName();
         if (head instanceof PullRequestSCMHead) {
             withPullRequestRemote((PullRequestSCMHead) head, headName);


### PR DESCRIPTION
Makes RefSpecsSCMSourceTrait working again.

Fixes #814.
See also #812.
Problem was introduced in #796.

<!-- Please describe your pull request here. -->

<!--
To mark your pull request as work in progress please create it as a draft pull request
-->

### Your checklist for this pull request

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Did you provide a test-case? That demonstrates feature works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled the information below
Describe your pull request below
-->
