### PR TITLE
Fix binary compatibility for PullRequestSCMRevision.getPull

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -154,6 +154,11 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <dependency>
+      <groupId>com.infradna.tool</groupId>
+      <artifactId>bridge-method-annotation</artifactId>
+      <version>1.29</version>
+    </dependency>
   </dependencies>
 
   <repositories>
@@ -215,6 +220,18 @@
           <execution>
             <id>default-enforce</id>
             <phase /> <!-- https://stackoverflow.com/a/19540026/12916 -->
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>com.infradna.tool</groupId>
+        <artifactId>bridge-method-injector</artifactId>
+        <version>1.29</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>process</goal>
+            </goals>
           </execution>
         </executions>
       </plugin>

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/PullRequestSCMRevision.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/PullRequestSCMRevision.java
@@ -24,8 +24,10 @@
 
 package com.cloudbees.jenkins.plugins.bitbucket;
 
+import com.infradna.tool.bridge_method_injector.WithBridgeMethods;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import jenkins.plugins.git.AbstractGitSCMSource;
+import jenkins.scm.api.SCMRevision;
 import jenkins.scm.api.mixin.ChangeRequestCheckoutStrategy;
 import jenkins.scm.api.mixin.ChangeRequestSCMRevision;
 
@@ -64,7 +66,7 @@ public class PullRequestSCMRevision extends ChangeRequestSCMRevision<PullRequest
      *
      * @return the pull revision.
      */
-    @NonNull
+    @NonNull @WithBridgeMethods(SCMRevision.class)
     public AbstractGitSCMSource.SCMRevisionImpl getPull() {
         return pull;
     }


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
The signature change in recent release caused `NoSuchMethodError` in plugins that are compiled against the old code.

I've tested it with the PCT and ATH of the affected plugin (cloudbees internal).
<!--
To mark your pull request as work in progress please create it as a draft pull request
-->

### Your checklist for this pull request

- [X] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Did you provide a test-case? That demonstrates feature works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled the information below
Describe your pull request below
-->
