### PR TITLE
Fix backward compatibility of PullRequestSCMRevision

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketGitSCMBuilder.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketGitSCMBuilder.java
@@ -39,6 +39,7 @@ import hudson.Util;
 import hudson.plugins.git.GitSCM;
 import hudson.plugins.git.browser.BitbucketWeb;
 import java.util.List;
+import jenkins.plugins.git.AbstractGitSCMSource;
 import jenkins.plugins.git.GitSCMBuilder;
 import jenkins.scm.api.SCMHead;
 import jenkins.scm.api.SCMRevision;
@@ -223,14 +224,15 @@ public class BitbucketGitSCMBuilder extends GitSCMBuilder<BitbucketGitSCMBuilder
                 String primaryRemoteName = remoteName().equals("primary") ? "primary-primary" : "primary";
                 String cloneLink = getCloneLink(primaryCloneLinks);
                 List<BranchWithHash> branchWithHashes;
+                AbstractGitSCMSource.SCMRevisionImpl pullRevision = (AbstractGitSCMSource.SCMRevisionImpl) pullRequestSCMRevision.getPull();
                 if (checkoutStrategy == ChangeRequestCheckoutStrategy.MERGE) {
                     branchWithHashes = List.of(
-                        new BranchWithHash(branchName, pullRequestSCMRevision.getPull().getHash()),
+                        new BranchWithHash(branchName, pullRevision.getHash()),
                         new BranchWithHash(targetBranch, pullRequestSCMRevision.getTargetImpl().getHash())
                     );
                 } else {
                     branchWithHashes = List.of(
-                        new BranchWithHash(branchName, pullRequestSCMRevision.getPull().getHash())
+                        new BranchWithHash(branchName, pullRevision.getHash())
                     );
                 }
                 withExtension(new FallbackToOtherRepositoryGitSCMExtension(cloneLink, primaryRemoteName, branchWithHashes));

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/PullRequestSCMRevision.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/PullRequestSCMRevision.java
@@ -26,6 +26,7 @@ package com.cloudbees.jenkins.plugins.bitbucket;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import jenkins.plugins.git.AbstractGitSCMSource;
+import jenkins.scm.api.SCMRevision;
 import jenkins.scm.api.mixin.ChangeRequestCheckoutStrategy;
 import jenkins.scm.api.mixin.ChangeRequestSCMRevision;
 
@@ -65,7 +66,7 @@ public class PullRequestSCMRevision extends ChangeRequestSCMRevision<PullRequest
      * @return the pull revision.
      */
     @NonNull
-    public AbstractGitSCMSource.SCMRevisionImpl getPull() {
+    public SCMRevision getPull() {
         return pull;
     }
 


### PR DESCRIPTION
Method `getPull` is used in some private plugins.
#796 changed signature of this method.

Now signature is returned back.
See also #817.

<!-- Please describe your pull request here. -->

<!--
To mark your pull request as work in progress please create it as a draft pull request
-->

### Your checklist for this pull request

- [ ] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Did you provide a test-case? That demonstrates feature works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled the information below
Describe your pull request below
-->
