### PR TITLE
Fix 'missing the Job/Configure permssion' error on Branch Sources page

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMNavigator.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMNavigator.java
@@ -639,7 +639,7 @@ public class BitbucketSCMNavigator extends SCMNavigator {
         @SuppressWarnings("unused") // used By stapler
         public ListBoxModel doFillServerUrlItems(@AncestorInPath SCMSourceOwner context) {
             AccessControlled contextToCheck = context == null ? Jenkins.get() : context;
-            if (!contextToCheck.hasPermission(Item.CONFIGURE)) {
+            if (!contextToCheck.hasAnyPermission(Item.CONFIGURE, Item.EXTENDED_READ)) {
                 return new ListBoxModel();
             }
             return BitbucketEndpointConfiguration.get().getEndpointItems();

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource.java
@@ -1346,7 +1346,7 @@ public class BitbucketSCMSource extends SCMSource {
         @SuppressWarnings("unused") // used By stapler
         public static FormValidation doCheckServerUrl(@AncestorInPath SCMSourceOwner context, @QueryParameter String value) {
             AccessControlled contextToCheck = context == null ? Jenkins.get() : context;
-            contextToCheck.checkPermission(Item.CONFIGURE);
+            contextToCheck.checkAnyPermission(Item.CONFIGURE, Item.EXTENDED_READ);
             if (BitbucketEndpointConfiguration.get().findEndpoint(value) == null) {
                 return FormValidation.error("Unregistered Server: " + value);
             }
@@ -1373,7 +1373,7 @@ public class BitbucketSCMSource extends SCMSource {
         @SuppressWarnings("unused") // used By stapler
         public ListBoxModel doFillServerUrlItems(@AncestorInPath SCMSourceOwner context) {
             AccessControlled contextToCheck = context == null ? Jenkins.get() : context;
-            if (!contextToCheck.hasPermission(Item.CONFIGURE)) {
+            if (!contextToCheck.hasAnyPermission(Item.CONFIGURE, Item.EXTENDED_READ)) {
                 return new ListBoxModel();
             }
             return BitbucketEndpointConfiguration.get().getEndpointItems();


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
Fix 'missing the Job/Configure permssion' error on Branch Sources page when used with the Role-Based Authorization Strategy plugin ([JENKINS-72821](https://issues.jenkins.io/browse/JENKINS-72821))

<!--
To mark your pull request as work in progress please create it as a draft pull request
-->

### Your checklist for this pull request

- [X] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Did you provide a test-case? That demonstrates feature works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled the information below
Describe your pull request below
-->
When this plugin is used in combination with the "Role-Based Authorization Strategy", the "Branch Sources" job configuration page throws the following error:

    $USER is missing the Job/Configure permission

This error is shown even when the user has full Admin rights on the Jenkins instance.

I'm not sure that this fix is 100% correct, but it does resolve the problem. I noticed that [another PR](https://github.com/jenkinsci/atlassian-bitbucket-server-integration-plugin/pull/165) in a similar project fixed a similar issue ([JENKINS-60116](https://issues.jenkins.io/browse/JENKINS-60116)) by checking for the `EXTENDED_READ` permission.

So, I blindly did the same thing. Would appreciate someone checking my work!

Fixes #823 