### PR TITLE
Feature/add support for pr approved

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/NativeServerPullRequestHookProcessor.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/NativeServerPullRequestHookProcessor.java
@@ -83,6 +83,7 @@ public class NativeServerPullRequestHookProcessor extends HookProcessor {
             case SERVER_PULL_REQUEST_MODIFIED:
             case SERVER_PULL_REQUEST_REVIEWER_UPDATED:
             case SERVER_PULL_REQUEST_FROM_REF_UPDATED:
+            case SERVER_PULL_REQUEST_APPROVED:
                 eventType = SCMEvent.Type.UPDATED;
                 break;
             default:


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

This PR is a reroll from https://github.com/jenkinsci/bitbucket-branch-source-plugin/pull/429
The original PR seems to be in a rather abandoned state. I'm in a need of this feature, so I chose to start a new PR from the work of @MayaPetter.

The goal of this PR is to introduce the possibility to launch a pipeline from a Bitbucket webhook event triggered by a reviewer approving a PR in Bitbucket.
This user case is described in https://github.com/jenkinsci/bitbucket-branch-source-plugin/issues/428

Important to note : for the cloud version, the event has only been added to the WebHookConfiguration class. It has not been added to the Cloud webhook processor (PullRequestHookProcessor.java) as the default behaviour is to consider any event as an update event.
This begs the question why this isn't the case for the server version?

### Your checklist for this pull request

- [X] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Added support for the Bitbucket webhook pr:reviewer:approved event for server V 7.X and above, as well as pullrequest:approved event for cloud version.
- [X] [Link to relevant issues in GitHub : 428](https://issues.jenkins-ci.org)](https://github.com/jenkinsci/bitbucket-branch-source-plugin/issues/428)
- [X] [Link to relevant pull requests, original incomplete PR 429](https://github.com/jenkinsci/bitbucket-branch-source-plugin/pull/429)
- [ ] Did you provide a test-case? @MayaPetter tested the server case in her PR. I'm not currently able to install a server on my company computer. Changes for cloud version have not been tested either. Nonetheless, the changes made in this PR are an updated list from an Enum content and an additional case in a switch from an Enum content.
