### PR TITLE
Change backoff strategy to exponential for BitbucketCloudApiClient when rate-limited

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/BitbucketCloudApiClient.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/BitbucketCloudApiClient.java
@@ -133,6 +133,7 @@ public class BitbucketCloudApiClient implements BitbucketApi {
     private static final int MAX_AVATAR_LENGTH = 16384;
     private static final int MAX_PAGE_LENGTH = 100;
     private static final PoolingHttpClientConnectionManager connectionManager = new PoolingHttpClientConnectionManager();
+    private static final int RETRY_DURATION_BASE_MILLIS = 5000;
     private CloseableHttpClient client;
     private HttpClientContext context;
     private final String owner;
@@ -911,8 +912,8 @@ public class BitbucketCloudApiClient implements BitbucketApi {
                 TODO: When bitbucket starts supporting rate limit expiration time, remove current wait strategy and put code
                       to wait till expiration time is over. It should also fix the wait for ever loop.
              */
-            long sleepTime = 5000 * (long)Math.pow(2, retryCount);
-            LOGGER.log(Level.FINE, "Bitbucket Cloud API rate limit reached for {0}, sleeping for {1} sec then retry...", new Object[]{httpMethod.getURI(), sleepTime});
+            long sleepTime = RETRY_DURATION_BASE_MILLIS * (long)Math.pow(2, retryCount);
+            LOGGER.log(Level.FINE, "Bitbucket Cloud API rate limit reached for {0}, sleeping for {1} sec then retry...", new Object[]{httpMethod.getURI(), sleepTime / 1000});
             Thread.sleep(sleepTime);
             retryCount++;
             LOGGER.log(Level.FINE, "Retrying Bitbucket Cloud API request for {0}, retryCount={1}", new Object[]{httpMethod.getURI(), retryCount});


### PR DESCRIPTION
Change backoff strategy to exponential for BitbucketCloudApiClient when rate-limited, as a fixed wait time of 5 seconds sends too many unnecessary requests that can be avoided.

<!-- Please describe your pull request here. -->

<!--
To mark your pull request as work in progress please create it as a draft pull request
-->

### Your checklist for this pull request

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Did you provide a test-case? That demonstrates feature works or fixes the issue.
    - no- as I am unsure how to test this 

<!--
Put an `x` into the [ ] to show you have filled the information below
Describe your pull request below
-->

Fixes #840
