### PR TITLE
Fix removal of exception throwing in BitbucketCloudApiClient.java

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/BitbucketCloudApiClient.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/BitbucketCloudApiClient.java
@@ -548,7 +548,10 @@ public class BitbucketCloudApiClient implements BitbucketApi {
             } else {
                 return request.call();
             }
-        } catch (Exception ex) {
+        } catch (IOException | InterruptedException ex) {
+            throw ex;
+        }
+        catch (Exception ex) {
             return null;
         }
     }


### PR DESCRIPTION
Bug was introduced in https://github.com/jenkinsci/bitbucket-branch-source-plugin/pull/839, as discussed here https://github.com/jenkinsci/bitbucket-branch-source-plugin/pull/839#pullrequestreview-1976010981

In order to log the exceptions, they have to be thrown. In the previous PR, all exceptions were caught by a catch block, and null was returned. This is not the behavior from the before the PR.

### Your checklist for this pull request

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Did you provide a test-case? That demonstrates feature works or fixes the issue.

Fixes #850 