### PR TITLE
Use CANCELLED build state in Bitbucket Data Center and Server 8.0 (#606)

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketBuildStatusNotificationsTrait.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketBuildStatusNotificationsTrait.java
@@ -41,12 +41,17 @@ import org.kohsuke.stapler.DataBoundSetter;
 public class BitbucketBuildStatusNotificationsTrait extends SCMSourceTrait {
 
     /**
-     * Should unstable builds be communicated as success to Bitbucket
+     * Should unstable builds be communicated as success to Bitbucket.
      */
     private boolean sendSuccessNotificationForUnstableBuild;
 
     /**
-     * Should not build jobs be communicated to Bitbucket
+     * Aborted jobs must be communicated as stopped to Bitbucket.
+     */
+    private boolean sendStoppedNotificationForAbortBuild;
+
+    /**
+     * Should not build jobs be communicated to Bitbucket.
      */
     private boolean disableNotificationForNotBuildJobs;
 
@@ -73,6 +78,27 @@ public class BitbucketBuildStatusNotificationsTrait extends SCMSourceTrait {
         return this.sendSuccessNotificationForUnstableBuild;
     }
 
+    /**
+     * Set if aborted builds will be communicated as stopped.
+     *
+     * @param sendStop comunicate Stop/Cancelled build status to Bitbucket for
+     *        aborted build.
+     */
+    @DataBoundSetter
+    public void setSendStoppedNotificationForAbortBuild(boolean sendStop) {
+        sendStoppedNotificationForAbortBuild = sendStop;
+    }
+
+    /**
+     * Return if aborted builds will be communicated as stopped.
+     *
+     * @return true will be comunicate to Bitbucket as Stopped/Cancelled build
+     *         failed otherwise.
+     */
+    public boolean getSendStoppedNotificationForAbortBuild() {
+        return this.sendStoppedNotificationForAbortBuild;
+    }
+
     @DataBoundSetter
     public void setDisableNotificationForNotBuildJobs(boolean isNotificationDisabled) {
         disableNotificationForNotBuildJobs = isNotificationDisabled;
@@ -92,6 +118,7 @@ public class BitbucketBuildStatusNotificationsTrait extends SCMSourceTrait {
     protected void decorateContext(SCMSourceContext<?, ?> context) {
         ((BitbucketSCMSourceContext) context).withDisableNotificationForNotBuildJobs(getDisableNotificationForNotBuildJobs());
         ((BitbucketSCMSourceContext) context).withSendSuccessNotificationForUnstableBuild(getSendSuccessNotificationForUnstableBuild());
+        ((BitbucketSCMSourceContext) context).withSendStoppedNotificationForAbortBuild(getSendStoppedNotificationForAbortBuild());
     }
 
     /**

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSourceContext.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSourceContext.java
@@ -81,6 +81,7 @@ public class BitbucketSCMSourceContext extends SCMSourceContext<BitbucketSCMSour
      */
     @NonNull
     private WebhookConfiguration webhookConfiguration = new WebhookConfiguration();
+
     /**
      * {@code true} if notifications should be disabled in this context.
      */
@@ -92,7 +93,12 @@ public class BitbucketSCMSourceContext extends SCMSourceContext<BitbucketSCMSour
     private boolean sendSuccessNotificationForUnstableBuild;
 
     /**
-     * {@code false} if not build jobs should be send to Bitbucket.
+     * {@code true} if aborted builds will be communicated as stopped/cancelled.
+     */
+    private boolean sendStoppedNotificationForAbortBuild;
+
+    /**
+     * {@code false} if not built jobs should be send to Bitbucket.
      */
     private boolean disableNotificationForNotBuildJobs;
 
@@ -208,7 +214,15 @@ public class BitbucketSCMSourceContext extends SCMSourceContext<BitbucketSCMSour
      */
     public final boolean notificationsDisabled() {
         return notificationsDisabled;
+    }
 
+    /**
+     * Returns if aborted builds should be passed as stopped/cancelled to Bitbucket.
+     *
+     * @return {@code true} if aborted builds should be passed as stopped/cancelled to Bitbucket.
+     */
+    public final boolean sendStopNotificationForAbortBuild() {
+        return sendStoppedNotificationForAbortBuild;
     }
 
     /**
@@ -363,6 +377,18 @@ public class BitbucketSCMSourceContext extends SCMSourceContext<BitbucketSCMSour
     @NonNull
     public final BitbucketSCMSourceContext withSendSuccessNotificationForUnstableBuild(boolean isUnstableBuildSuccess) {
         this.sendSuccessNotificationForUnstableBuild = isUnstableBuildSuccess;
+        return this;
+    }
+
+    /**
+     * Defines behaviour of unstable builds in Bitbucket.
+     *
+     * @param sendStopped {@code true} to consider aborted builds as stopped when notifying Bitbucket.
+     * @return {@code this} for method chaining.
+     */
+    @NonNull
+    public final BitbucketSCMSourceContext withSendStoppedNotificationForAbortBuild(boolean sendStopped) {
+        this.sendStoppedNotificationForAbortBuild = sendStopped;
         return this;
     }
 

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/BitbucketBuildStatus.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/BitbucketBuildStatus.java
@@ -36,7 +36,10 @@ public class BitbucketBuildStatus {
     public enum Status {
         INPROGRESS("INPROGRESS"),
         FAILED("FAILED"),
+        // available only in Cloud
         STOPPED("STOPPED"),
+        // available only in Data Center
+        CANCELLED("CANCELLED"),
         SUCCESSFUL("SUCCESSFUL");
 
         private final String status;

--- a/src/main/resources/com/cloudbees/jenkins/plugins/bitbucket/BitbucketBuildStatusNotificationsTrait/config.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/bitbucket/BitbucketBuildStatusNotificationsTrait/config.jelly
@@ -3,7 +3,10 @@
   <f:entry title="${%Communicate unstable builds to Bitbucket as successful}" field="sendSuccessNotificationForUnstableBuild">
     <f:checkbox/>
   </f:entry>
-  <f:entry title="${%Do not communicate not-built jobs to Bitbucket}" field="disableNotificationForNotBuildJobs">
+  <f:entry title="${%Communicate not-built jobs to Bitbucket as stopped}" field="disableNotificationForNotBuildJobs">
+    <f:checkbox/>
+  </f:entry>
+  <f:entry title="${%Communicate abort build to Bitbucket as stopped}" field="sendStoppedNotificationForAbortBuild">
     <f:checkbox/>
   </f:entry>
 </j:jelly>

--- a/src/main/resources/com/cloudbees/jenkins/plugins/bitbucket/BitbucketBuildStatusNotificationsTrait/help-disableNotificationForNotBuildJobs.html
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/bitbucket/BitbucketBuildStatusNotificationsTrait/help-disableNotificationForNotBuildJobs.html
@@ -1,0 +1,4 @@
+<div>
+    Not-built result by default is notificated as FAILED status to Bitbucket.
+    If this option is enabled than not-built result is notified as STOPPED for Bitbucket Cloud or as CANCELLED for Bitbucket Data Center.
+</div>

--- a/src/main/resources/com/cloudbees/jenkins/plugins/bitbucket/BitbucketBuildStatusNotificationsTrait/help-sendStoppedNotificationForAbortBuild.html
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/bitbucket/BitbucketBuildStatusNotificationsTrait/help-sendStoppedNotificationForAbortBuild.html
@@ -1,0 +1,4 @@
+<div>
+    Aborted build by default is notificated as FAILED status to Bitbucket.
+    If this option is enabled than aborted build is notified as STOPPED for Bitbucket Cloud or as CANCELLED for Bitbucket Data Center.
+</div>

--- a/src/main/resources/com/cloudbees/jenkins/plugins/bitbucket/BitbucketBuildStatusNotificationsTrait/help-sendSuccessNotificationForUnstableBuild.html
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/bitbucket/BitbucketBuildStatusNotificationsTrait/help-sendSuccessNotificationForUnstableBuild.html
@@ -1,0 +1,4 @@
+<div>
+    Unstable build by default is notificated as FAILED status to Bitbucket.
+    If this option is enabled than unstable build is notified as SUCCESS to Bitbucket.
+</div>

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketBuildStatusNotifications2Test.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketBuildStatusNotifications2Test.java
@@ -1,0 +1,182 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2024 Nikolas Falco
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.cloudbees.jenkins.plugins.bitbucket;
+
+import com.cloudbees.jenkins.plugins.bitbucket.BitbucketBuildStatusNotifications.JobCheckoutListener;
+import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketApi;
+import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketBuildStatus;
+import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketBuildStatus.Status;
+import com.cloudbees.jenkins.plugins.bitbucket.client.BitbucketCloudApiClient;
+import com.cloudbees.jenkins.plugins.bitbucket.endpoints.BitbucketCloudEndpoint;
+import com.cloudbees.jenkins.plugins.bitbucket.server.client.BitbucketServerAPIClient;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.FilePath;
+import hudson.model.Result;
+import hudson.model.StreamBuildListener;
+import hudson.scm.SCM;
+import hudson.scm.SCMRevisionState;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.UnaryOperator;
+import jenkins.branch.Branch;
+import jenkins.branch.BranchProjectFactory;
+import jenkins.branch.BranchSource;
+import jenkins.plugins.git.AbstractGitSCMSource.SCMRevisionImpl;
+import jenkins.scm.api.SCMHead;
+import jenkins.scm.api.SCMRevision;
+import jenkins.scm.api.SCMRevisionAction;
+import jenkins.scm.api.trait.SCMSourceTrait;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProject;
+import org.junit.After;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.mockito.ArgumentCaptor;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(Parameterized.class)
+public class BitbucketBuildStatusNotifications2Test {
+
+    @ClassRule
+    public static JenkinsRule r = new JenkinsRule() {
+        @Override
+        public URL getURL() throws IOException {
+            return new URL("http://example.com:" + localPort + contextPath + "/");
+        }
+    };
+
+    private static UnaryOperator<BitbucketBuildStatusNotificationsTrait> notifyAbortAsCancelled = t -> {
+        t.setSendStoppedNotificationForAbortBuild(true);
+        return t;
+    };
+
+    private static UnaryOperator<BitbucketBuildStatusNotificationsTrait> notifyNotBuiltAsCancelled = t -> {
+        t.setDisableNotificationForNotBuildJobs(true);
+        return t;
+    };
+
+    @Parameterized.Parameters(name = "When build result is {1} expect to notify status {2}")
+    public static Collection<Object[]> input() {
+        return Arrays.asList(new Object[][] {
+                                              { UnaryOperator.identity(), Result.ABORTED, Status.FAILED, mock(BitbucketCloudApiClient.class) },
+                                              { UnaryOperator.identity(), Result.ABORTED, Status.FAILED, mock(BitbucketServerAPIClient.class) },
+                                              { notifyAbortAsCancelled, Result.ABORTED, Status.STOPPED, mock(BitbucketCloudApiClient.class) },
+                                              { notifyAbortAsCancelled, Result.ABORTED, Status.CANCELLED, mock(BitbucketServerAPIClient.class) },
+                                              { UnaryOperator.identity(), Result.NOT_BUILT, Status.FAILED, mock(BitbucketCloudApiClient.class) },
+                                              { UnaryOperator.identity(), Result.NOT_BUILT, Status.FAILED, mock(BitbucketServerAPIClient.class) },
+                                              { notifyNotBuiltAsCancelled, Result.NOT_BUILT, Status.STOPPED, mock(BitbucketCloudApiClient.class) },
+                                              { notifyNotBuiltAsCancelled, Result.NOT_BUILT, Status.CANCELLED, mock(BitbucketServerAPIClient.class) },
+        });
+    }
+
+    private BitbucketBuildStatusNotificationsTrait trait;
+    private Result buildResult;
+    private Status expectedStatus;
+    private BitbucketApi apiClient;
+
+    public BitbucketBuildStatusNotifications2Test(UnaryOperator<BitbucketBuildStatusNotificationsTrait> traitCustomizer,
+                                                  Result buildResult,
+                                                  Status expectedStatus,
+                                                  BitbucketApi apiClient) {
+        this.trait = traitCustomizer.apply(new BitbucketBuildStatusNotificationsTrait());
+        this.buildResult = buildResult;
+        this.expectedStatus = expectedStatus;
+        this.apiClient = apiClient;
+    }
+
+    @After
+    public void cleanUp() {
+        r.jenkins.getAllItems().forEach(item -> {
+            try {
+                item.delete();
+            } catch (IOException | InterruptedException e) {
+            }
+        });
+    }
+
+    @Test
+    public void test_status_notification_for_given_build_result() throws Exception {
+        StreamBuildListener taskListener = new StreamBuildListener(System.out, StandardCharsets.UTF_8);
+
+        WorkflowRun build = prepareBuildForNotification(List.of(trait));
+        doReturn(buildResult).when(build).getResult();
+
+        FilePath workspace = r.jenkins.getWorkspaceFor(build.getParent());
+
+        BitbucketMockApiFactory.add(BitbucketCloudEndpoint.SERVER_URL, apiClient);
+
+        JobCheckoutListener listener = new JobCheckoutListener();
+        listener.onCheckout(build, null, workspace, taskListener, null, SCMRevisionState.NONE);
+
+        ArgumentCaptor<BitbucketBuildStatus> captor = ArgumentCaptor.forClass(BitbucketBuildStatus.class);
+        verify(apiClient).postBuildStatus(captor.capture());
+        assertThat(captor.getValue().getState(), is(expectedStatus.name()));
+    }
+
+    private WorkflowRun prepareBuildForNotification(@NonNull List<SCMSourceTrait> traits) throws Exception {
+        BitbucketSCMSource scmSource = new BitbucketSCMSource("repoOwner", "repository");
+        scmSource.setTraits(traits);
+
+        WorkflowMultiBranchProject project = r.jenkins.createProject(WorkflowMultiBranchProject.class, "p");
+        project.setSourcesList(List.of(new BranchSource(scmSource)));
+        scmSource.setOwner(project);
+
+        WorkflowJob job = new WorkflowJob(project, "branch-job");
+
+        SCMHead scmHead = new BranchSCMHead("master");
+        SCMRevision scmRevision = new SCMRevisionImpl(scmHead, "c341232342311");
+        SCM scm = mock(SCM.class);
+
+        WorkflowRun build = mock(WorkflowRun.class);
+        doReturn(List.of(new SCMRevisionAction(scmSource, scmRevision))).when(build).getActions(SCMRevisionAction.class);
+        doReturn(job).when(build).getParent();
+        doReturn("builds/1/").when(build).getUrl();
+        @SuppressWarnings("unchecked")
+        BranchProjectFactory<WorkflowJob, WorkflowRun> projectFactory = mock(BranchProjectFactory.class);
+        when(projectFactory.isProject(job)).thenReturn(true);
+        when(projectFactory.asProject(job)).thenReturn(job);
+        Branch branch = new Branch(scmSource.getId(), scmHead, scm, Collections.emptyList());
+        when(projectFactory.getBranch(job)).thenReturn(branch);
+        project.setProjectFactory(projectFactory);
+
+        return build;
+    }
+
+}


### PR DESCRIPTION
Adds an option to the Status Notification Trait to guide what notification to send to Bitbucket when the Jenkins build result is ABORTED.

This PR restores the default behavior for the NOT_BUILT notification from SUCCESS to FAILED (configurable to STOPPED) for Bitbucket Cloud; the SUCCESS state was incorrectly introduced in 2022 as the default instead of STOPPED when the disableNotificationForNotBuildJob configuration option was added (the name can be misinterpreted).

Adds missing guidance description for each configurable option in the Build Status Notification Trait.

Status Notification Summary

| Jenkins | Bitbucket Cloud | Bitbucket Data Center and Server |
| --- | --- | --- |
| [SUCCESS](https://javadoc.jenkins.io/hudson/model/Result.html#SUCCESS) | SUCCESSFUL | SUCCESSFUL |
| [UNSTABLE](https://javadoc.jenkins.io/hudson/model/Result.html#UNSTABLE) | configurable SUCCESSFUL or FAILED | configurable SUCCESSFUL or FAILED |
| [FAILURE](https://javadoc.jenkins.io/hudson/model/Result.html#FAILURE) | FAILED | FAILED |
| [NOT_BUILT](https://javadoc.jenkins.io/hudson/model/Result.html#NOT_BUILT) | configurable FAILED or STOPPED | configurable FAILED or CANCELLED |
| [ABORTED](https://javadoc.jenkins.io/hudson/model/Result.html#ABORTED) | configurable FAILED or STOPPED | configurable FAILED or CANCELLED |
| null | INPROGRESS | INPROGRESS |

The STOPPED status prevents merge checks on Cloud
CANCELLED status should prevents merge checks on Data Center