### PR TITLE
[JENKINS-55927] Hook event should not trigger Branch Indexing

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/HookProcessor.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/HookProcessor.java
@@ -39,8 +39,7 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
  * Abstract hook processor.
  *
  * Add new hook processors by extending this class and implement {@link #process(HookEventType, String, BitbucketType, String)},
- * extract owner and repository name from the hook payload and then call {@link #scmSourceReIndex(String, String)}
- * to launch a branch/PR reindexing on the matching SCMSource.
+ * extract details from the hook payload and then fire an {@link jenkins.scm.api.SCMEvent#} to dispatch it to the SCM API.
  */
 public abstract class HookProcessor {
 
@@ -86,6 +85,7 @@ public abstract class HookProcessor {
     /**
      * To be called by implementations once the owner and the repository have been extracted from the payload.
      *
+     * @deprecated SCM Event should not trigger Branch Indexing
      * @param owner the repository owner as configured in the SCMSource
      * @param repository the repository name as configured in the SCMSource
      */

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/NativeServerPushHookProcessor.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/NativeServerPushHookProcessor.java
@@ -102,15 +102,6 @@ public class NativeServerPushHookProcessor extends HookProcessor {
             return;
         }
 
-        if (changes.isEmpty()) {
-            final String owner = repository.getOwnerName();
-            final String repositoryName = repository.getRepositoryName();
-            LOGGER.log(Level.INFO, "Received hook from Bitbucket. Processing push event on {0}/{1}",
-                new Object[] { owner, repositoryName });
-            scmSourceReIndex(owner, repositoryName);
-            return;
-        }
-
         final Multimap<SCMEvent.Type, NativeServerChange> events = HashMultimap.create();
         for (final NativeServerChange change : changes) {
             final String type = change.getType();

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/PushHookProcessor.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/PushHookProcessor.java
@@ -46,7 +46,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 import jenkins.plugins.git.AbstractGitSCMSource;
 import jenkins.scm.api.SCMEvent;
@@ -71,13 +70,6 @@ public class PushHookProcessor extends HookProcessor {
                 push = BitbucketCloudWebhookPayload.pushEventFromPayload(payload);
             }
             if (push != null) {
-                String owner = push.getRepository().getOwnerName();
-                final String repository = push.getRepository().getRepositoryName();
-                if (push.getChanges().isEmpty()) {
-                    LOGGER.log(Level.INFO, "Received hook from Bitbucket. Processing push event on {0}/{1}",
-                            new Object[]{owner, repository});
-                    scmSourceReIndex(owner, repository);
-                } else {
                     SCMHeadEvent.Type type = null;
                     for (BitbucketPushEvent.Change change: push.getChanges()) {
                         if ((type == null || type == SCMEvent.Type.CREATED) && change.isCreated()) {
@@ -203,7 +195,6 @@ public class PushHookProcessor extends HookProcessor {
                             return false;
                         }
                     }, BitbucketSCMSource.getEventDelaySeconds(), TimeUnit.SECONDS);
-                }
             }
         }
     }


### PR DESCRIPTION
[JENKINS-55927](https://issues.jenkins.io/browse/JENKINS-55927)

Noticed this issue while troubleshooting an environment where Bitbucket event were triggering branch indexing. Haven't yet identified exactly what kind of push events has empty `changes`. Though per my understanding of the design of the Branch API / SCM API and Pipeline Multibranch, SCM events should not trigger branch indexing ? And this is rather unexpected. Unless I am missing something ?

cc @jenkinsci/bitbucket-branch-source-plugin-developers 

### Your checklist for this pull request

- [ ] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Did you provide a test-case? That demonstrates feature works or fixes the issue.