### PR TITLE
Revert "Cleanup deprecated/unused code"

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketGitSCMBuilder.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketGitSCMBuilder.java
@@ -24,6 +24,7 @@
 package com.cloudbees.jenkins.plugins.bitbucket;
 
 import com.cloudbees.jenkins.plugins.bitbucket.BitbucketSCMSource.DescriptorImpl;
+import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketAuthenticator;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketHref;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketRepository;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketRepositoryProtocol;
@@ -41,7 +42,6 @@ import hudson.plugins.git.GitSCM;
 import hudson.plugins.git.browser.BitbucketWeb;
 import java.util.List;
 import jenkins.plugins.git.GitSCMBuilder;
-import jenkins.plugins.git.MergeWithGitSCMExtension;
 import jenkins.scm.api.SCMHead;
 import jenkins.scm.api.SCMRevision;
 import jenkins.scm.api.SCMSource;
@@ -311,6 +311,13 @@ public class BitbucketGitSCMBuilder extends GitSCMBuilder<BitbucketGitSCMBuilder
         return cloneLinks.stream()
             .filter(link -> protocol.matches(link.getName()))
             .findAny()
+            .map(bitbucketHref -> {
+                BitbucketAuthenticator authenticator = scmSource().authenticator();
+                if (authenticator == null) {
+                    return bitbucketHref;
+                }
+                return authenticator.addAuthToken(bitbucketHref);
+            })
             .orElseThrow(() -> new IllegalStateException("Can't find clone link for protocol " + protocol))
             .getHref();
     }

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource.java
@@ -34,6 +34,7 @@ import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketMirroredRepository;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketMirroredRepositoryDescriptor;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketPullRequest;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketRepository;
+import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketRepositoryType;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketRequestException;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketTeam;
 import com.cloudbees.jenkins.plugins.bitbucket.client.BitbucketCloudApiClient;
@@ -116,6 +117,7 @@ import jenkins.scm.impl.trait.Discovery;
 import jenkins.scm.impl.trait.Selection;
 import jenkins.scm.impl.trait.WildcardSCMHeadFilterTrait;
 import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang.WordUtils;
 import org.eclipse.jgit.lib.Constants;
 import org.jenkinsci.Symbol;
 import org.kohsuke.accmod.Restricted;
@@ -229,6 +231,12 @@ public class BitbucketSCMSource extends SCMSource {
     private transient String bitbucketServerUrl;
 
     /**
+     * The cache of the repository type.
+     */
+    @CheckForNull
+    private transient BitbucketRepositoryType repositoryType;
+
+    /**
      * The cache of pull request titles for each open PR.
      */
     @CheckForNull
@@ -288,6 +296,7 @@ public class BitbucketSCMSource extends SCMSource {
      * @return {@code this}
      * @throws ObjectStreamException if things go wrong.
      */
+    @SuppressWarnings({"ConstantConditions", "deprecation"})
     @SuppressFBWarnings(value = "RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE",
                         justification = "Only non-null after we set them here!")
     private Object readResolve() throws ObjectStreamException {
@@ -520,6 +529,18 @@ public class BitbucketSCMSource extends SCMSource {
         return true;
     }
 
+    public BitbucketRepositoryType getRepositoryType() throws IOException, InterruptedException {
+        if (repositoryType == null) {
+            BitbucketRepository r = buildBitbucketClient().getRepository();
+            repositoryType = BitbucketRepositoryType.fromString(r.getScm());
+            Map<String, List<BitbucketHref>> links = r.getLinks();
+            if (links != null && links.containsKey("clone")) {
+                setPrimaryCloneLinks(links.get("clone"));
+            }
+        }
+        return repositoryType;
+    }
+
     public BitbucketApi buildBitbucketClient() {
         return buildBitbucketClient(repoOwner, repository);
     }
@@ -530,6 +551,17 @@ public class BitbucketSCMSource extends SCMSource {
 
     public BitbucketApi buildBitbucketClient(String repoOwner, String repository) {
         return BitbucketApiFactory.newInstance(getServerUrl(), authenticator(), repoOwner, null, repository);
+    }
+
+    @Override
+    public void afterSave() {
+        try {
+            getRepositoryType();
+        } catch (InterruptedException | IOException e) {
+            LOGGER.log(Level.FINE,
+                    "Could not determine repository type of " + getRepoOwner() + "/" + getRepository() + " on "
+                            + getServerUrl() + " for " + getOwner(), e);
+        }
     }
 
     @Override
@@ -546,6 +578,9 @@ public class BitbucketSCMSource extends SCMSource {
                 listener.getLogger().format("Connecting to %s using %s%n", getServerUrl(),
                         CredentialsNameProvider.name(scanCredentials));
             }
+            // this has the side effect of ensuring that repository type is always populated.
+            final BitbucketRepositoryType repositoryType = getRepositoryType();
+            listener.getLogger().format("Repository type: %s%n", WordUtils.capitalizeFully(repositoryType != null ? repositoryType.name() : "Unknown"));
 
             // populate the request with its data sources
             if (request.isFetchPRs()) {

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketTagSCMHead.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketTagSCMHead.java
@@ -23,6 +23,8 @@
  */
 package com.cloudbees.jenkins.plugins.bitbucket;
 
+import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketRepositoryType;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import jenkins.plugins.git.GitTagSCMHead;
 import jenkins.scm.api.SCMHead;
@@ -38,6 +40,15 @@ public class BitbucketTagSCMHead extends GitTagSCMHead implements TagSCMHead {
     private static final long serialVersionUID = 1L;
 
     /**
+     * Cache of the repository type.
+     *
+     * @since 2.2.11
+     */
+    // The repository type should be immutable for any SCMSource.
+    @CheckForNull
+    private final BitbucketRepositoryType repositoryType;
+
+    /**
      * Constructor.
      *
      * @param tagName        the tag name
@@ -45,6 +56,16 @@ public class BitbucketTagSCMHead extends GitTagSCMHead implements TagSCMHead {
      */
     public BitbucketTagSCMHead(@NonNull String tagName, long timestamp) {
         super(tagName, timestamp);
+        this.repositoryType = BitbucketRepositoryType.GIT;
+    }
+
+    /**
+     * Gets the repository type.
+     * @return the repository type or {@code null}
+     */
+    @CheckForNull
+    public BitbucketRepositoryType getRepositoryType() {
+        return repositoryType;
     }
 
     /**

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/MergeWithGitSCMExtension.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/MergeWithGitSCMExtension.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright (c) 2016, CloudBees, Inc.
+ * Copyright (c) 2017, CloudBees, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -23,52 +23,28 @@
  */
 package com.cloudbees.jenkins.plugins.bitbucket;
 
-import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketRepositoryType;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
-import jenkins.scm.api.SCMHead;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.io.ObjectStreamException;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.DoNotUse;
 
 /**
- * {@link SCMHead} for a Bitbucket branch.
+ * Retained for data migration.
  *
- * @since 2.0.0
+ * @deprecated use {@link jenkins.plugins.git.MergeWithGitSCMExtension}
  */
-public class BranchSCMHead extends SCMHead {
+@Deprecated
+@Restricted(DoNotUse.class)
+@SuppressFBWarnings("NM_SAME_SIMPLE_NAME_AS_SUPERCLASS")
+public class MergeWithGitSCMExtension extends jenkins.plugins.git.MergeWithGitSCMExtension {
 
-    private static final long serialVersionUID = 1L;
-
-    /**
-     * Cache of the repository type. Will only be {@code null} for data loaded from pre-2.1.0 releases
-     *
-     * @since 2.1.0
-     */
-    // The repository type should be immutable for any SCMSource.
-    @CheckForNull
-    private final BitbucketRepositoryType repositoryType;
-
-    /**
-     * Constructor.
-     *
-     * @param branchName the branch name
-     */
-    public BranchSCMHead(String branchName) {
-        super(branchName);
-        this.repositoryType = BitbucketRepositoryType.GIT;
+    MergeWithGitSCMExtension(@NonNull String baseName, @CheckForNull String baseHash) {
+        super(baseName, baseHash);
     }
 
-    /**
-     * Gets the repository type.
-     * @return the repository type or {@code null} if this is a legacy branch instance.
-     */
-    @CheckForNull
-    public BitbucketRepositoryType getRepositoryType() {
-        return repositoryType;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public String getPronoun() {
-        return Messages.BranchSCMHead_Pronoun();
+    private Object readResolve() throws ObjectStreamException {
+        return new jenkins.plugins.git.MergeWithGitSCMExtension(getBaseName(), getBaseHash());
     }
 }

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/PullRequestSCMHead.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/PullRequestSCMHead.java
@@ -24,6 +24,7 @@
 package com.cloudbees.jenkins.plugins.bitbucket;
 
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketPullRequest;
+import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketRepositoryType;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
@@ -162,6 +163,10 @@ public class PullRequestSCMHead extends SCMHead implements ChangeRequestSCMHead2
 
     public String getBranchName() {
         return branchName;
+    }
+
+    public BitbucketRepositoryType getRepositoryType() {
+        return target.getRepositoryType();
     }
 
     @NonNull

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/BitbucketAuthenticator.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/BitbucketAuthenticator.java
@@ -70,7 +70,7 @@ public abstract class BitbucketAuthenticator {
      *
      * @param credentials credentials instance this authenticator will use
      */
-    protected BitbucketAuthenticator(StandardCredentials credentials) {
+    public BitbucketAuthenticator(StandardCredentials credentials) {
         id = credentials.getId();
     }
 
@@ -116,6 +116,16 @@ public abstract class BitbucketAuthenticator {
      */
     public StandardUsernameCredentials getCredentialsForSCM() {
         return null;
+    }
+
+    /**
+     * Add authentication token to clone link if
+     * authentication method requires it
+     *
+     * @return updated clone link
+     */
+    public BitbucketHref addAuthToken(BitbucketHref bitbucketHref) {
+        return bitbucketHref;
     }
 
     /**

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/BitbucketRepositoryType.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/BitbucketRepositoryType.java
@@ -21,54 +21,38 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package com.cloudbees.jenkins.plugins.bitbucket;
+package com.cloudbees.jenkins.plugins.bitbucket.api;
 
-import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketRepositoryType;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
-import jenkins.scm.api.SCMHead;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
- * {@link SCMHead} for a Bitbucket branch.
- *
- * @since 2.0.0
+ * @deprecated No longer a choice.
  */
-public class BranchSCMHead extends SCMHead {
-
-    private static final long serialVersionUID = 1L;
-
-    /**
-     * Cache of the repository type. Will only be {@code null} for data loaded from pre-2.1.0 releases
-     *
-     * @since 2.1.0
-     */
-    // The repository type should be immutable for any SCMSource.
-    @CheckForNull
-    private final BitbucketRepositoryType repositoryType;
+@Deprecated
+public enum BitbucketRepositoryType {
 
     /**
-     * Constructor.
-     *
-     * @param branchName the branch name
+     * Git repository.
      */
-    public BranchSCMHead(String branchName) {
-        super(branchName);
-        this.repositoryType = BitbucketRepositoryType.GIT;
+    GIT("git");
+
+    private final String type;
+
+    BitbucketRepositoryType(@NonNull String type) {
+        this.type = type;
     }
 
-    /**
-     * Gets the repository type.
-     * @return the repository type or {@code null} if this is a legacy branch instance.
-     */
-    @CheckForNull
-    public BitbucketRepositoryType getRepositoryType() {
-        return repositoryType;
+    public String getType() {
+        return type;
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public String getPronoun() {
-        return Messages.BranchSCMHead_Pronoun();
+    @CheckForNull
+    public static BitbucketRepositoryType fromString(String type) {
+        if (GIT.type.equals(type)) {
+            return GIT;
+        } else {
+            return null;
+        }
     }
 }


### PR DESCRIPTION
Whereas #898 broke a downstream test as described in https://github.com/jenkinsci/bitbucket-branch-source-plugin/pull/898#issuecomment-2460769141; whereas that downstream test has not been fixed a week after the issue was reported, blocking https://github.com/jenkinsci/bom/pull/3920; whereas #898 did not update unit tests to match production code as described in https://github.com/jenkinsci/bitbucket-branch-source-plugin/pull/898#issuecomment-2474278089; and whereas #898 causes [JENKINS-74848](https://issues.jenkins.io/browse/JENKINS-74848), a failure to load job definitions that include `com.cloudbees.jenkins.plugins.bitbucket.MergeWithGitSCMExtension` as described in https://github.com/jenkinsci/bitbucket-branch-source-plugin/pull/898#issuecomment-2474293564; now, therefore, be it proposed to revert #898, acknowledging that #898 can be reintegrated once the above issues are resolved.

### Testing done

`mvn clean verify`