### PR TITLE
Fix leaking of Apache HTTP client I/O Dispatcher threads

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -147,7 +147,7 @@
    </dependency>
    <dependency>
       <groupId>com.github.scribejava</groupId>
-      <artifactId>scribejava-httpclient-apache</artifactId>
+      <artifactId>scribejava-core</artifactId>
       <version>8.3.3</version>
     </dependency>
   </dependencies>

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/credentials/BitbucketOAuthAuthenticator.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/credentials/BitbucketOAuthAuthenticator.java
@@ -6,10 +6,10 @@ import com.cloudbees.plugins.credentials.common.StandardUsernameCredentials;
 import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
 import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl;
 import com.github.scribejava.core.builder.ServiceBuilder;
+import com.github.scribejava.core.httpclient.jdk.JDKHttpClientConfig;
 import com.github.scribejava.core.model.OAuth2AccessToken;
 import com.github.scribejava.core.model.OAuthConstants;
 import com.github.scribejava.core.oauth.OAuth20Service;
-import com.github.scribejava.httpclient.apache.ApacheHttpClientConfig;
 import hudson.model.Descriptor.FormException;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
@@ -31,11 +31,11 @@ public class BitbucketOAuthAuthenticator extends BitbucketAuthenticator {
     public BitbucketOAuthAuthenticator(StandardUsernamePasswordCredentials credentials) throws AuthenticationTokenException {
         super(credentials);
 
-        try (SetContextClassLoader cl = new SetContextClassLoader(this.getClass())) {
-            OAuth20Service service = new ServiceBuilder(credentials.getUsername())
-                .apiSecret(credentials.getPassword().getPlainText())
-                .httpClientConfig(ApacheHttpClientConfig.defaultConfig())
-                .build(BitbucketOAuth.instance());
+        try (SetContextClassLoader cl = new SetContextClassLoader(this.getClass());
+                OAuth20Service service = new ServiceBuilder(credentials.getUsername())
+                    .apiSecret(credentials.getPassword().getPlainText())
+                    .httpClientConfig(JDKHttpClientConfig.defaultConfig())
+                    .build(BitbucketOAuth.instance())) {
             token = service.getAccessTokenClientCredentialsGrant();
         } catch (IOException | InterruptedException | ExecutionException e) {
             throw new AuthenticationTokenException(e);


### PR DESCRIPTION
Change the configured http client provider in scribejava from Apache HTTP Client to JDK HTTP Client, as in the previous implementation with the scribe library. There is no gain in using a client with a pooled connection manager that is destroyed every time a new token is requested.

This commit fix the ClassNotFoundException issue of org.apache.logging.log4j.spi.LoggerAdapter (commons-logging is marked as a scope dependency in the pom-plugin) when scm is used in a scripted pipeline.