### PR TITLE
[JENKINS-73250] The GIT_URL environmente variable contains user name after update

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketGitSCMBuilder.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketGitSCMBuilder.java
@@ -192,8 +192,8 @@ public class BitbucketGitSCMBuilder extends GitSCMBuilder<BitbucketGitSCMBuilder
     public BitbucketGitSCMBuilder withBitbucketRemote() {
         SCMHead head = head();
         String headName = head.getName();
-        if (head instanceof PullRequestSCMHead) {
-            withPullRequestRemote((PullRequestSCMHead) head, headName);
+        if (head instanceof PullRequestSCMHead prHead) {
+            withPullRequestRemote(prHead, headName);
         } else if (head instanceof TagSCMHead) {
             withTagRemote(headName);
         } else {
@@ -322,19 +322,19 @@ public class BitbucketGitSCMBuilder extends GitSCMBuilder<BitbucketGitSCMBuilder
     @Override
     public GitSCM build() {
         withBitbucketRemote();
-        SCMHead h = head();
-        SCMRevision r = revision();
+        SCMHead head = head();
+        SCMRevision rev = revision();
         try {
-            if (h instanceof PullRequestSCMHead) {
-                withHead(new SCMHead(((PullRequestSCMHead) h).getBranchName()));
-                if (r instanceof PullRequestSCMRevision) {
-                    withRevision(((PullRequestSCMRevision) r).getPull());
+            if (head instanceof PullRequestSCMHead prHead) {
+                withHead(new SCMHead(prHead.getBranchName()));
+                if (rev instanceof PullRequestSCMRevision prRev) {
+                    withRevision(prRev.getPull());
                 }
             }
             return super.build();
         } finally {
-            withHead(h);
-            withRevision(r);
+            withHead(head);
+            withRevision(rev);
         }
     }
 }

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketGitSCMRevision.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketGitSCMRevision.java
@@ -67,7 +67,7 @@ public class BitbucketGitSCMRevision extends SCMRevisionImpl {
     /**
      * Returns the author of this revision in GIT format.
      *
-     * @return commit author in the following format &gt;name&lt; &gt;email&lt;
+     * @return commit author in the following format &lt;name&gt; &lt;email&gt;
      */
     public String getAuthor() {
         return author;

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSourceTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSourceTest.java
@@ -1,10 +1,15 @@
 package com.cloudbees.jenkins.plugins.bitbucket;
 
+import com.cloudbees.jenkins.plugins.bitbucket.client.BitbucketIntegrationClientFactory;
+import com.cloudbees.jenkins.plugins.bitbucket.client.pullrequest.BitbucketPullRequestCommit;
 import com.cloudbees.jenkins.plugins.bitbucket.endpoints.AbstractBitbucketEndpoint;
 import com.cloudbees.jenkins.plugins.bitbucket.endpoints.BitbucketEndpointConfiguration;
+import hudson.plugins.git.GitSCM;
+import hudson.scm.SCM;
 import java.net.URL;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Date;
 import jenkins.model.Jenkins;
 import jenkins.model.JenkinsLocationConfiguration;
 import jenkins.scm.api.trait.SCMSourceTrait;
@@ -25,6 +30,7 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 public class BitbucketSCMSourceTest {
@@ -421,6 +427,21 @@ public class BitbucketSCMSourceTest {
         assertThat(instance.getIncludes(), is("*"));
         assertThat(instance.getExcludes(), is(""));
         assertThat(instance.isAutoRegisterHook(), is(false));
+    }
+
+    @Test
+    public void test_that_clone_url_does_not_contains_username() {
+        BranchSCMHead head = new BranchSCMHead("master");
+        BitbucketPullRequestCommit commit = new BitbucketPullRequestCommit();
+        commit.setHash("046d9a3c1532acf4cf08fe93235c00e4d673c1d2");
+        commit.setDate(new Date());
+
+        BitbucketSCMSource instance = new BitbucketSCMSource("amuniz", "test-repo");
+        BitbucketMockApiFactory.add(instance.getServerUrl(), BitbucketIntegrationClientFactory.getApiMockClient(instance.getServerUrl()));
+        SCM scm = instance.build(head, new BitbucketGitSCMRevision(head, commit));
+        assertInstanceOf(GitSCM.class, scm);
+        GitSCM gitSCM = (GitSCM) scm;
+        assertThat(gitSCM.getUserRemoteConfigs().get(0).getUrl(), is("https://bitbucket.org/amuniz/test-repos.git"));
     }
 
     @Test


### PR DESCRIPTION
Revert to the behavior before the clone link feature from version 866. The remote URL must not contain the user or it may not work when using username/password authentication. This is because the username belonging to the credential provided to perform the git operation may not be the same as the URL. The clone URL comes from the links that bitbucket sends with the repository information. The link sent contains the user associated with the credentials used to call the REST APIs.