### PR TITLE
CQI Improve error logging from the bitbucket client

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource.java
@@ -66,7 +66,6 @@ import hudson.model.Item;
 import hudson.model.Items;
 import hudson.model.TaskListener;
 import hudson.plugins.git.GitSCM;
-import hudson.plugins.git.extensions.GitSCMExtension;
 import hudson.scm.SCM;
 import hudson.security.AccessControlled;
 import hudson.util.FormFillFailure;
@@ -1006,7 +1005,7 @@ public class BitbucketSCMSource extends SCMSource {
 
         BitbucketAuthenticator authenticator = authenticator();
         return new BitbucketGitSCMBuilder(this, head, revision, null)
-                .withExtension(authenticator == null || sshAuth ? null : new GitClientAuthenticatorExtension(authenticator.getCredentialsForSCM()))
+                .withExtension(new GitClientAuthenticatorExtension(authenticator == null || sshAuth ? null : authenticator.getCredentialsForSCM()))
                 .withCloneLinks(primaryCloneLinks, mirrorCloneLinks)
                 .withTraits(traits)
                 .build();

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/SSHCheckoutTrait.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/SSHCheckoutTrait.java
@@ -42,7 +42,6 @@ import hudson.security.ACL;
 import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
 import jenkins.model.Jenkins;
-import jenkins.plugins.git.GitSCMBuilder;
 import jenkins.scm.api.SCMSource;
 import jenkins.scm.api.trait.SCMBuilder;
 import jenkins.scm.api.trait.SCMSourceContext;
@@ -103,9 +102,8 @@ public class SSHCheckoutTrait extends SCMSourceTrait {
      */
     @Override
     protected void decorateBuilder(SCMBuilder<?, ?> builder) {
-        if (builder instanceof GitSCMBuilder) {
-            ((BitbucketGitSCMBuilder) builder)
-                .withCredentials(credentialsId, BitbucketRepositoryProtocol.SSH);
+        if (builder instanceof BitbucketGitSCMBuilder gitBuilder) {
+            gitBuilder.withCredentials(credentialsId, BitbucketRepositoryProtocol.SSH);
         }
     }
 

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/ClosingConnectionInputStream.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/ClosingConnectionInputStream.java
@@ -4,7 +4,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpRequestBase;
-import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
+import org.apache.http.conn.HttpClientConnectionManager;
 import org.apache.http.util.EntityUtils;
 
 public class ClosingConnectionInputStream extends InputStream {
@@ -13,16 +13,16 @@ public class ClosingConnectionInputStream extends InputStream {
 
     private final HttpRequestBase method;
 
-    private final PoolingHttpClientConnectionManager connectionManager;
+    private final HttpClientConnectionManager connectionManager;
 
     private final InputStream delegate;
 
     public ClosingConnectionInputStream(final CloseableHttpResponse response, final HttpRequestBase method,
-            final PoolingHttpClientConnectionManager connectionManager)
+            final HttpClientConnectionManager connectionmanager)
             throws UnsupportedOperationException, IOException {
         this.response = response;
         this.method = method;
-        this.connectionManager = connectionManager;
+        this.connectionManager = connectionmanager;
         this.delegate = response.getEntity().getContent();
     }
 

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/internal/api/AbstractBitbucketApi.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/internal/api/AbstractBitbucketApi.java
@@ -1,0 +1,142 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.cloudbees.jenkins.plugins.bitbucket.internal.api;
+
+import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketRequestException;
+import hudson.ProxyConfiguration;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+import java.nio.charset.StandardCharsets;
+import java.util.logging.Logger;
+import jenkins.model.Jenkins;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang.StringUtils;
+import org.apache.http.Header;
+import org.apache.http.HttpHost;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.AuthCache;
+import org.apache.http.client.CredentialsProvider;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.protocol.HttpClientContext;
+import org.apache.http.impl.auth.BasicScheme;
+import org.apache.http.impl.client.BasicAuthCache;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.ProtectedExternally;
+
+@Restricted(ProtectedExternally.class)
+public class AbstractBitbucketApi {
+    protected static final int API_RATE_LIMIT_STATUS_CODE = 429;
+
+    protected final Logger logger = Logger.getLogger(this.getClass().getName());
+    protected HttpClientContext context;
+
+
+    protected BitbucketRequestException buildResponseException(CloseableHttpResponse response, String errorMessage) {
+        String headers = StringUtils.join(response.getAllHeaders(), "\n");
+        String message = String.format("HTTP request error.%nStatus: %s%nResponse: %s%n%s", response.getStatusLine(), errorMessage, headers);
+        return new BitbucketRequestException(response.getStatusLine().getStatusCode(), message);
+    }
+
+    protected String getResponseContent(CloseableHttpResponse response) throws IOException {
+        String content;
+        long len = response.getEntity().getContentLength();
+        if (len < 0) {
+            len = getLenghtFromHeader(response);
+        }
+        if (len == 0) {
+            content = "";
+        } else {
+            try (InputStream is = response.getEntity().getContent()) {
+                content = IOUtils.toString(is, StandardCharsets.UTF_8);
+            }
+        }
+        return content;
+    }
+
+    private long getLenghtFromHeader(CloseableHttpResponse response) {
+        long len = -1L;
+        Header[] headers = response.getHeaders("Content-Length");
+        if (headers != null && headers.length > 0) {
+            int i = headers.length - 1;
+            len = -1L;
+            while (i >= 0) {
+                Header header = headers[i];
+                try {
+                    len = Long.parseLong(header.getValue());
+                    break;
+                } catch (NumberFormatException var5) {
+                    --i;
+                }
+            }
+        }
+        return len;
+    }
+
+    protected void setClientProxyParams(String host, HttpClientBuilder builder) {
+        Jenkins jenkins = Jenkins.getInstanceOrNull(); // because unit test
+        ProxyConfiguration proxyConfig = jenkins != null ? jenkins.proxy : null;
+
+        final Proxy proxy;
+        if (proxyConfig != null) {
+            proxy = proxyConfig.createProxy(host);
+        } else {
+            proxy = Proxy.NO_PROXY;
+        }
+
+        if (proxy != Proxy.NO_PROXY && proxy.type() != Proxy.Type.DIRECT) {
+            final InetSocketAddress proxyAddress = (InetSocketAddress) proxy.address();
+            logger.fine("Jenkins proxy: " + proxy.address());
+            HttpHost proxyHttpHost = new HttpHost(proxyAddress.getHostName(), proxyAddress.getPort());
+            builder.setProxy(proxyHttpHost);
+            String username = proxyConfig.getUserName();
+            String password = proxyConfig.getSecretPassword().getPlainText();
+            if (StringUtils.isNotBlank(username)) {
+                logger.fine("Using proxy authentication (user=" + username + ")");
+                if (context == null) {
+                    // may have been already set in com.cloudbees.jenkins.plugins.bitbucket.api.credentials.BitbucketUsernamePasswordAuthenticator.configureContext(HttpClientContext, HttpHost)
+                    context = HttpClientContext.create();
+                }
+                CredentialsProvider credentialsProvider = context.getCredentialsProvider();
+                if (credentialsProvider == null) {
+                    credentialsProvider = new BasicCredentialsProvider();
+                    // may have been already set in com.cloudbees.jenkins.plugins.bitbucket.api.credentials.BitbucketUsernamePasswordAuthenticator.configureContext(HttpClientContext, HttpHost)
+                    context.setCredentialsProvider(credentialsProvider);
+                }
+                credentialsProvider.setCredentials(new AuthScope(proxyHttpHost), new UsernamePasswordCredentials(username, password));
+                AuthCache authCache = context.getAuthCache();
+                if (authCache == null) {
+                    authCache = new BasicAuthCache();
+                    context.setAuthCache(authCache);
+                }
+                authCache.put(proxyHttpHost, new BasicScheme());
+            }
+        }
+    }
+
+}

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/client/BitbucketCloudApiClientTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/client/BitbucketCloudApiClientTest.java
@@ -36,7 +36,6 @@ import java.util.Optional;
 import org.apache.commons.io.IOUtils;
 import org.hamcrest.CoreMatchers;
 import org.junit.Test;
-import org.mockito.Mockito;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertNotNull;
@@ -64,12 +63,14 @@ public class BitbucketCloudApiClientTest {
     public void verifyUpdateWebhookURL() throws Exception {
         BitbucketApi client = BitbucketIntegrationClientFactory.getApiMockClient(BitbucketCloudEndpoint.SERVER_URL);
         IRequestAudit audit = ((IRequestAudit) client).getAudit();
-        Optional<? extends BitbucketWebHook> webHook = client.getWebHooks().stream().filter(h -> h.getDescription().contains("Jenkins")).findFirst();
+        Optional<? extends BitbucketWebHook> webHook = client.getWebHooks().stream()
+                .filter(h -> h.getDescription().contains("Jenkins"))
+                .findFirst();
         assertTrue(webHook.isPresent());
 
         reset(audit);
         client.updateCommitWebHook(webHook.get());
-        verify(audit).request(Mockito.eq("https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/hooks/%7B202cf34e-7ccf-44b7-ba6b-8827a14d5324%7D"));
+        verify(audit).request("https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/hooks/%7B202cf34e-7ccf-44b7-ba6b-8827a14d5324%7D");
     }
 
 }

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/client/BitbucketIntegrationClientFactory.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/client/BitbucketIntegrationClientFactory.java
@@ -48,7 +48,7 @@ public class BitbucketIntegrationClientFactory {
     public interface IRequestAudit {
         default void request(String url) {
             // mockito audit
-        };
+        }
 
         IRequestAudit getAudit();
 
@@ -58,7 +58,7 @@ public class BitbucketIntegrationClientFactory {
                     throw new IllegalStateException("Payload for the REST path " + path + " could not be found: " + payloadPath);
                 }
                 HttpEntity entity = mock(HttpEntity.class);
-                String jsonString = IOUtils.toString(json);
+                String jsonString = IOUtils.toString(json, StandardCharsets.UTF_8);
                 when(entity.getContentLength()).thenReturn((long)jsonString.getBytes(StandardCharsets.UTF_8).length);
                 when(entity.getContent()).thenReturn(new StringInputStream(jsonString));
 

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/BitbucketServerAPIClientTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/BitbucketServerAPIClientTest.java
@@ -8,7 +8,6 @@ import com.damnhandy.uri.template.UriTemplate;
 import com.damnhandy.uri.template.impl.Operator;
 import java.util.List;
 import java.util.logging.Level;
-import java.util.stream.Collectors;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.junit.Assert;
@@ -36,7 +35,7 @@ public class BitbucketServerAPIClientTest {
     @Rule
     public JenkinsRule r = new JenkinsRule();
     @Rule
-    public LoggerRule logger = new LoggerRule().record(BitbucketServerAPIClient.class, Level.FINE);
+    public LoggerRule logger = new LoggerRule().record(BitbucketServerIntegrationClient.class, Level.FINE);
 
     @Test
     @WithoutJenkins
@@ -74,18 +73,18 @@ public class BitbucketServerAPIClientTest {
 
     @Test
     public void filterArchivedRepositories() throws Exception {
-        BitbucketApi client = BitbucketIntegrationClientFactory.getClient("localhost", "foo", "test-repos");;
+        BitbucketApi client = BitbucketIntegrationClientFactory.getClient("localhost", "foo", "test-repos");
         List<? extends BitbucketRepository> repos = client.getRepositories();
-        List<String> names = repos.stream().map(BitbucketRepository::getRepositoryName).collect(Collectors.toList());
+        List<String> names = repos.stream().map(BitbucketRepository::getRepositoryName).toList();
         assertThat(names, not(hasItem("bar-archived")));
         assertThat(names, is(List.of("bar-active")));
     }
 
     @Test
     public void sortRepositoriesByName() throws Exception {
-        BitbucketApi client = BitbucketIntegrationClientFactory.getClient("localhost", "amuniz", "test-repos");;
+        BitbucketApi client = BitbucketIntegrationClientFactory.getClient("localhost", "amuniz", "test-repos");
         List<? extends BitbucketRepository> repos = client.getRepositories();
-        List<String> names = repos.stream().map(BitbucketRepository::getRepositoryName).collect(Collectors.toList());
+        List<String> names = repos.stream().map(BitbucketRepository::getRepositoryName).toList();
         assertThat(names, is(List.of("another-repo", "dogs-repo", "test-repos")));
     }
 


### PR DESCRIPTION
Improve error logging from the bitbucket client. This helps to understand what is going wrong (e.g. HTTP 403).
Reduce duplicate code by sharing Apache HTTP client management between bitbucket server and cloud clients