### PR TITLE
Fix git clone of repository using OAuth2 authenticator.

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource.java
@@ -36,6 +36,7 @@ import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketPullRequest;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketRepository;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketRequestException;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketTeam;
+import com.cloudbees.jenkins.plugins.bitbucket.api.credentials.BitbucketUsernamePasswordAuthenticator;
 import com.cloudbees.jenkins.plugins.bitbucket.client.BitbucketCloudApiClient;
 import com.cloudbees.jenkins.plugins.bitbucket.client.repository.UserRoleInRepository;
 import com.cloudbees.jenkins.plugins.bitbucket.endpoints.AbstractBitbucketEndpoint;
@@ -48,7 +49,6 @@ import com.cloudbees.jenkins.plugins.bitbucket.server.client.BitbucketServerAPIC
 import com.cloudbees.jenkins.plugins.bitbucket.server.client.repository.BitbucketServerRepository;
 import com.cloudbees.plugins.credentials.CredentialsNameProvider;
 import com.cloudbees.plugins.credentials.common.StandardCredentials;
-import com.cloudbees.plugins.credentials.common.StandardUsernameCredentials;
 import com.damnhandy.uri.template.UriTemplate;
 import com.fasterxml.jackson.databind.util.StdDateFormat;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
@@ -1015,14 +1015,13 @@ public class BitbucketSCMSource extends SCMSource {
                 // trait will do the magic
                 scmCredentialsId = null;
                 scmExtension = new GitClientAuthenticatorExtension(null);
+            } else if (authenticator instanceof BitbucketUsernamePasswordAuthenticator) {
+                scmExtension = new GitClientAuthenticatorExtension(null);
             } else {
-                StandardUsernameCredentials scmCredentials = authenticator.getCredentialsForSCM();
                 // extension overrides the configured credentialsId with a custom StandardUsernameCredentials provided by the Authenticator
-                scmExtension = new GitClientAuthenticatorExtension(scmCredentials);
-                if (scmCredentials != null) {
-                    // will be overridden by git extension
-                    scmCredentialsId = null;
-                }
+                scmExtension = new GitClientAuthenticatorExtension(authenticator.getCredentialsForSCM());
+                // will be overridden by git extension
+                scmCredentialsId = null;
             }
         } else {
             scmExtension = new GitClientAuthenticatorExtension(null);

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/credentials/BitbucketOAuthAuthenticator.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/credentials/BitbucketOAuthAuthenticator.java
@@ -15,7 +15,6 @@ import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 import jenkins.authentication.tokens.api.AuthenticationTokenException;
 import jenkins.util.SetContextClassLoader;
-import org.apache.commons.lang.StringUtils;
 import org.apache.http.HttpRequest;
 
 public class BitbucketOAuthAuthenticator extends BitbucketAuthenticator {
@@ -54,7 +53,7 @@ public class BitbucketOAuthAuthenticator extends BitbucketAuthenticator {
     public StandardUsernameCredentials getCredentialsForSCM() {
         try {
             return new UsernamePasswordCredentialsImpl(
-                    CredentialsScope.GLOBAL, getId(), null, StringUtils.EMPTY, token.getAccessToken());
+                    CredentialsScope.GLOBAL, getId(), null, "x-token-auth", token.getAccessToken());
         } catch (FormException e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
This issue is caused by removing user from clone link. Using "x-token-auth" as user tells bitbucket that the specified password is an OAuth2 credential token.