### PR TITLE
[JENKINS-64418] Add exponential backoff to BitBucket rate limit retry loop

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -167,6 +167,18 @@
       <artifactId>scribejava-core</artifactId>
       <version>8.3.3</version>
     </dependency>
+    <dependency>
+      <groupId>org.mock-server</groupId>
+      <artifactId>mockserver-junit-jupiter</artifactId>
+      <version>5.15.0</version>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>javax.servlet</groupId>
+          <artifactId>javax.servlet-api</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
   </dependencies>
 
   <repositories>

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketDefaultBranch.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketDefaultBranch.java
@@ -33,7 +33,8 @@ import java.util.Objects;
  * Represents the default branch of a specific repository
  */
 public class BitbucketDefaultBranch extends InvisibleAction implements Serializable {
-    private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = 1826270778226063782L;
+
     @NonNull
     private final String repoOwner;
     @NonNull

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketGitSCMBuilder.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketGitSCMBuilder.java
@@ -214,8 +214,8 @@ public class BitbucketGitSCMBuilder extends GitSCMBuilder<BitbucketGitSCMBuilder
         String scmSourceRepository = scmSource.getRepository();
         String pullRequestRepoOwner = head.getRepoOwner();
         String pullRequestRepository = head.getRepository();
-        boolean prFromTargetRepository = pullRequestRepoOwner.equals(scmSourceRepoOwner)
-            && pullRequestRepository.equals(scmSourceRepository);
+        boolean prFromTargetRepository = pullRequestRepoOwner.equalsIgnoreCase(scmSourceRepoOwner)
+            && pullRequestRepository.equalsIgnoreCase(scmSourceRepository);
         SCMRevision revision = revision();
         ChangeRequestCheckoutStrategy checkoutStrategy = head.getCheckoutStrategy();
         // PullRequestSCMHead should be refactored to add references to target and source commit hashes.

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/BitbucketProject.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/BitbucketProject.java
@@ -1,8 +1,5 @@
 package com.cloudbees.jenkins.plugins.bitbucket.api;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class BitbucketProject {
 
     private String key;

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/impl/client/ExponentialBackOffServiceUnavailableRetryStrategy.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/impl/client/ExponentialBackOffServiceUnavailableRetryStrategy.java
@@ -1,0 +1,114 @@
+package com.cloudbees.jenkins.plugins.bitbucket.impl.client;
+
+import java.util.concurrent.TimeUnit;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
+import org.apache.http.annotation.Contract;
+import org.apache.http.annotation.ThreadingBehavior;
+import org.apache.http.client.ServiceUnavailableRetryStrategy;
+import org.apache.http.impl.client.cache.AsynchronousValidationRequest;
+import org.apache.http.protocol.HttpContext;
+import org.apache.http.util.Args;
+
+/**
+ * An implementation that backs off exponentially based on the number of
+ * consecutive failed attempts. It uses the following defaults:
+ * <pre>
+ *         no delay in case it was never tried or didn't fail so far
+ *     6 secs delay for one failed attempt (= {@link #getInitialExpiryInMillis()})
+ *    60 secs delay for two failed attempts
+ *    10 mins delay for three failed attempts
+ *   100 mins delay for four failed attempts
+ *  ~16 hours delay for five failed attempts
+ *   24 hours delay for six or more failed attempts (= {@link #getMaxExpiryInMillis()})
+ * </pre>
+ *
+ * The following equation is used to calculate the delay for a specific revalidation request:
+ * <pre>
+ *     delay = {@link #getInitialExpiryInMillis()} * Math.pow({@link #getBackOffRate()},
+ *     {@link AsynchronousValidationRequest#getConsecutiveFailedAttempts()} - 1))
+ * </pre>
+ * The resulting delay won't exceed {@link #getMaxExpiryInMillis()}.
+ */
+@Contract(threading = ThreadingBehavior.SAFE)
+public class ExponentialBackOffServiceUnavailableRetryStrategy implements ServiceUnavailableRetryStrategy {
+
+    public static final long DEFAULT_BACK_OFF_RATE = 10;
+    public static final long DEFAULT_INITIAL_EXPIRY_IN_MILLIS = TimeUnit.SECONDS.toMillis(6);
+    public static final long DEFAULT_MAX_EXPIRY_IN_MILLIS = TimeUnit.SECONDS.toMillis(86400);
+
+    private final long backOffRate;
+    private final long initialExpiryInMillis;
+    private final long maxExpiryInMillis;
+    private ThreadLocal<Integer> consecutiveFailedAttempts; // TODO call ThreadLocal#remove method is not possible using the lifecycle of apache client 4.x. Move to http client 5.x ASAP
+
+    /**
+     * Create a new strategy using a fixed pool of worker threads.
+     */
+    public ExponentialBackOffServiceUnavailableRetryStrategy() {
+        this(DEFAULT_BACK_OFF_RATE,
+             DEFAULT_INITIAL_EXPIRY_IN_MILLIS,
+             DEFAULT_MAX_EXPIRY_IN_MILLIS);
+    }
+
+    /**
+     * Create a new strategy by using a fixed pool of worker threads and the
+     * given parameters to calculated the delay.
+     *
+     * @param backOffRate the back off rate to be used; not negative
+     * @param initialExpiryInMillis the initial expiry in milli seconds; not negative
+     * @param maxExpiryInMillis the upper limit of the delay in milli seconds; not negative
+     */
+    public ExponentialBackOffServiceUnavailableRetryStrategy(
+            final long backOffRate,
+            final long initialExpiryInMillis,
+            final long maxExpiryInMillis) {
+        this.backOffRate = Args.notNegative(backOffRate, "BackOffRate");
+        this.initialExpiryInMillis = Args.notNegative(initialExpiryInMillis, "InitialExpiryInMillis");
+        this.maxExpiryInMillis = Args.notNegative(maxExpiryInMillis, "MaxExpiryInMillis");
+        this.consecutiveFailedAttempts = new ThreadLocal<>();
+    }
+
+    public long getBackOffRate() {
+        return backOffRate;
+    }
+
+    public long getInitialExpiryInMillis() {
+        return initialExpiryInMillis;
+    }
+
+    public long getMaxExpiryInMillis() {
+        return maxExpiryInMillis;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean retryRequest(HttpResponse response, int executionCount, HttpContext context) {
+        int statusCode = response.getStatusLine().getStatusCode();
+        consecutiveFailedAttempts.set(executionCount);
+        return getRetryInterval(executionCount) < maxExpiryInMillis
+                && (statusCode == HttpStatus.SC_TOO_MANY_REQUESTS
+                || statusCode == HttpStatus.SC_SERVICE_UNAVAILABLE);
+    }
+
+    private long getRetryInterval(int failedAttempts) {
+        if (failedAttempts > 0) {
+            final long delayInSeconds = (long) (initialExpiryInMillis * Math.pow(backOffRate, failedAttempts - 1));
+            return Math.min(delayInSeconds, maxExpiryInMillis);
+        } else {
+            return 0;
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public long getRetryInterval() {
+        Integer attempts = consecutiveFailedAttempts.get();
+        return getRetryInterval(attempts == null ? 0 : attempts.intValue());
+    }
+
+}

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/WebhookConfigurationTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/WebhookConfigurationTest.java
@@ -1,3 +1,26 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2020, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package com.cloudbees.jenkins.plugins.bitbucket.hooks;
 
 import com.cloudbees.jenkins.plugins.bitbucket.BitbucketSCMSource;

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/impl/client/ExponentialBackOffServiceUnavailableRetryStrategyTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/impl/client/ExponentialBackOffServiceUnavailableRetryStrategyTest.java
@@ -1,0 +1,96 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2024, Nikolas Falco
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.cloudbees.jenkins.plugins.bitbucket.impl.client;
+
+import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketApi;
+import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketAuthenticator;
+import com.cloudbees.jenkins.plugins.bitbucket.server.BitbucketServerWebhookImplementation;
+import com.cloudbees.jenkins.plugins.bitbucket.server.client.BitbucketServerAPIClient;
+import java.io.IOException;
+import org.apache.http.HttpException;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpResponseInterceptor;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.protocol.HttpContext;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockserver.integration.ClientAndServer;
+import org.mockserver.junit.jupiter.MockServerExtension;
+import org.mockserver.model.HttpRequest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIOException;
+import static org.mockito.Mockito.mock;
+import static org.mockserver.model.HttpRequest.request;
+import static org.mockserver.model.HttpResponse.response;
+
+@ExtendWith(MockServerExtension.class)
+class ExponentialBackOffServiceUnavailableRetryStrategyTest {
+
+    @Test
+    void test_retry(ClientAndServer mockServer) throws Exception {
+        HttpRequest request = request() //
+                .withMethod("GET") //
+                .withPath("/rest/api/1.0/projects/test/repos/testRepos/tags");
+        mockServer.when(request)
+            .respond( //
+                response() //
+                        .withStatusCode(429) //
+        );
+
+        final RetryInterceptor counterInterceptor = new RetryInterceptor();
+        BitbucketApi client = new BitbucketServerAPIClient("http://localhost:" + mockServer.getPort(),
+                "test",
+                "testRepos",
+                (BitbucketAuthenticator) null,
+                false,
+                mock(BitbucketServerWebhookImplementation.class)) {
+            @Override
+            protected HttpClientBuilder setupClientBuilder(String host) {
+                return super.setupClientBuilder(host)
+                        .disableAutomaticRetries()
+                        .setServiceUnavailableRetryStrategy(new ExponentialBackOffServiceUnavailableRetryStrategy(2, 5, 100))
+                        .addInterceptorFirst(counterInterceptor);
+            }
+        };
+
+        assertThatIOException().isThrownBy(() -> client.getTags());
+        assertThat(counterInterceptor.getRetry()).isEqualTo(6); // retry after 5ms, 10ms, 20ms, 40ms, 80ms, 100ms
+    }
+
+    private static class RetryInterceptor implements HttpResponseInterceptor {
+        private int retry = 0;
+
+        @Override
+        public void process(HttpResponse response, HttpContext context) throws HttpException, IOException {
+            if (response.getStatusLine().getStatusCode() == 429) {
+                retry += 1;
+            }
+        }
+
+        public int getRetry() {
+            return retry;
+        }
+    }
+}

--- a/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/server/payload/1.0-projects-amuniz-repos-test-repos-browse-Jenkinsfile_at_feature_2Fpipeline.json
+++ b/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/server/payload/1.0-projects-amuniz-repos-test-repos-browse-Jenkinsfile_at_feature_2Fpipeline.json
@@ -1,0 +1,3 @@
+node() {
+    echo "ciao"
+}

--- a/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/server/payload/1.0-projects-amuniz-repos-test-repos-browse-folder-Jenkinsfile_at_feature_2Fpipeline.json
+++ b/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/server/payload/1.0-projects-amuniz-repos-test-repos-browse-folder-Jenkinsfile_at_feature_2Fpipeline.json
@@ -1,0 +1,3 @@
+node() {
+    echo "ciao"
+}


### PR DESCRIPTION
Refactory both server/cloud client to share the client management.
Use apache http client configuration to retry on HTTP 429 (too many connection) response.