### PR TITLE
Fix the API build notification state when the sent payload contains a longer than allowed attribute value.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ work
 
 # VSCode
 .factorypath
+META-INF/

--- a/pom.xml
+++ b/pom.xml
@@ -128,6 +128,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>net.javacrumbs.json-unit</groupId>
+      <artifactId>json-unit-assertj</artifactId>
+      <version>4.0.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>git</artifactId>
       <classifier>tests</classifier>

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketBuildStatusNotifications.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketBuildStatusNotifications.java
@@ -172,7 +172,7 @@ public class BitbucketBuildStatusNotifications {
 
     private static @CheckForNull BitbucketSCMSource findBitbucketSCMSource(Run<?, ?> build) {
         SCMSource s = SCMSource.SourceByItem.findSource(build.getParent());
-        return s instanceof BitbucketSCMSource ? (BitbucketSCMSource) s : null;
+        return s instanceof BitbucketSCMSource scm ? scm : null;
     }
 
     private static void sendNotifications(BitbucketSCMSource source, Run<?, ?> build, TaskListener listener)
@@ -211,12 +211,11 @@ public class BitbucketBuildStatusNotifications {
 
     @CheckForNull
     private static String getHash(@CheckForNull SCMRevision revision) {
-        if (revision instanceof PullRequestSCMRevision) {
-            // unwrap
-            revision = ((PullRequestSCMRevision) revision).getPull();
+        if (revision instanceof PullRequestSCMRevision prRevision) {
+            revision = prRevision.getPull();
         }
-        if (revision instanceof AbstractGitSCMSource.SCMRevisionImpl) {
-            return ((AbstractGitSCMSource.SCMRevisionImpl) revision).getHash();
+        if (revision instanceof AbstractGitSCMSource.SCMRevisionImpl scmRevision) {
+            return scmRevision.getHash();
         }
         return null;
     }

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/BitbucketBuildStatus.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/BitbucketBuildStatus.java
@@ -24,6 +24,7 @@
 package com.cloudbees.jenkins.plugins.bitbucket.api;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.DoNotUse;
@@ -97,6 +98,20 @@ public class BitbucketBuildStatus {
         this.url = url;
         this.key = DigestUtils.md5Hex(key);
         this.name = name;
+    }
+
+    /**
+     * Copy constructor.
+     *
+     * @param other from copy to.
+     */
+    public BitbucketBuildStatus(@NonNull BitbucketBuildStatus other) {
+        this.hash = other.hash;
+        this.description = other.description;
+        this.state = other.state;
+        this.url = other.url;
+        this.key = other.key;
+        this.name = other.name;
     }
 
     public String getHash() {

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/BitbucketCloudApiClient.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/BitbucketCloudApiClient.java
@@ -657,12 +657,15 @@ public class BitbucketCloudApiClient extends AbstractBitbucketApi implements Bit
      */
     @Override
     public void postBuildStatus(@NonNull BitbucketBuildStatus status) throws IOException, InterruptedException {
+        BitbucketBuildStatus newStatus = new BitbucketBuildStatus(status);
+        newStatus.setName(truncateMiddle(newStatus.getName(), 255));
+
         String url = UriTemplate.fromTemplate(REPO_URL_TEMPLATE + "/commit/{hash}/statuses/build")
                 .set("owner", owner)
                 .set("repo", repositoryName)
-                .set("hash", status.getHash())
+                .set("hash", newStatus.getHash())
                 .expand();
-        postRequest(url, JsonParser.toJson(status));
+        postRequest(url, JsonParser.toJson(newStatus));
     }
 
     /**

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/internal/api/AbstractBitbucketApi.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/internal/api/AbstractBitbucketApi.java
@@ -24,6 +24,7 @@
 package com.cloudbees.jenkins.plugins.bitbucket.internal.api;
 
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketRequestException;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import hudson.ProxyConfiguration;
 import java.io.IOException;
 import java.io.InputStream;
@@ -50,12 +51,21 @@ import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.ProtectedExternally;
 
 @Restricted(ProtectedExternally.class)
-public class AbstractBitbucketApi {
+public abstract class AbstractBitbucketApi {
     protected static final int API_RATE_LIMIT_STATUS_CODE = 429;
 
     protected final Logger logger = Logger.getLogger(this.getClass().getName());
     protected HttpClientContext context;
 
+    protected String truncateMiddle(@CheckForNull String value, int maxLength) {
+        int length = StringUtils.length(value);
+        if (length > maxLength) {
+            int halfLength = (maxLength - 3) / 2;
+            return StringUtils.left(value, halfLength) + "..." + StringUtils.substring(value, -halfLength);
+        } else {
+            return value;
+        }
+    }
 
     protected BitbucketRequestException buildResponseException(CloseableHttpResponse response, String errorMessage) {
         String headers = StringUtils.join(response.getAllHeaders(), "\n");

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/BitbucketServerAPIClient.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/BitbucketServerAPIClient.java
@@ -509,13 +509,13 @@ public class BitbucketServerAPIClient extends AbstractBitbucketApi implements Bi
      */
     @Override
     public void postBuildStatus(@NonNull BitbucketBuildStatus status) throws IOException, InterruptedException {
-        postRequest(
-            UriTemplate
-                .fromTemplate(API_COMMIT_STATUS_PATH)
-                .set("hash", status.getHash())
-                .expand(),
-            JsonParser.toJson(status)
-        );
+        BitbucketBuildStatus newStatus = new BitbucketBuildStatus(status);
+        newStatus.setName(truncateMiddle(newStatus.getName(), 255));
+
+        String url = UriTemplate.fromTemplate(API_COMMIT_STATUS_PATH)
+                .set("hash", newStatus.getHash())
+                .expand();
+        postRequest(url, JsonParser.toJson(newStatus));
     }
 
     /**

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/client/BitbucketIntegrationClientFactory.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/client/BitbucketIntegrationClientFactory.java
@@ -46,7 +46,7 @@ import static org.mockito.Mockito.when;
 public class BitbucketIntegrationClientFactory {
 
     public interface IRequestAudit {
-        default void request(String url) {
+        default void request(HttpRequestBase request) {
             // mockito audit
         }
 
@@ -118,10 +118,12 @@ public class BitbucketIntegrationClientFactory {
                 return createRateLimitResponse();
             }
             String path = httpMethod.getURI().toString();
-            path = path.substring(path.indexOf("/rest/api/"));
-            audit.request(path);
+            audit.request(httpMethod);
 
-            String payloadPath = path.replace("/rest/api/", "").replace('/', '-').replaceAll("[=%&?]", "_");
+            String payloadPath = path.substring(path.indexOf("/rest/"))
+                    .replace("/rest/api/", "")
+                    .replace("/rest/", "")
+                    .replace('/', '-').replaceAll("[=%&?]", "_");
             payloadPath = payloadRootPath + payloadPath + ".json";
 
             return loadResponseFromResources(getClass(), path, payloadPath);
@@ -160,7 +162,7 @@ public class BitbucketIntegrationClientFactory {
         @Override
         protected CloseableHttpResponse executeMethod(HttpHost host, HttpRequestBase httpMethod) throws InterruptedException, IOException {
             String path = httpMethod.getURI().toString();
-            audit.request(path);
+            audit.request(httpMethod);
 
             String payloadPath = path.replace(API_ENDPOINT, "").replace('/', '-').replaceAll("[=%&?]", "_");
             payloadPath = payloadRootPath + payloadPath + ".json";

--- a/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/client/payload/2.0-repositories-amuniz-test-repos-commit-046d9a3c1532acf4cf08fe93235c00e4d673c1d3-statuses-build.json
+++ b/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/client/payload/2.0-repositories-amuniz-test-repos-commit-046d9a3c1532acf4cf08fe93235c00e4d673c1d3-statuses-build.json
@@ -1,0 +1,48 @@
+{
+    "key": "fe7e71305b004dd8dd5a124e1dae4c33",
+    "type": "build",
+    "state": "FAILED",
+    "name": "test » feature/test #36",
+    "refname": null,
+    "commit": {
+        "hash": "046d9a3c1532acf4cf08fe93235c00e4d673c1d2",
+        "links": {
+            "self": {
+                "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/commit/046d9a3c1532acf4cf08fe93235c00e4d673c1d2"
+            },
+            "html": {
+                "href": "https://bitbucket.org/amuniz/test-repos/commits/046d9a3c1532acf4cf08fe93235c00e4d673c1d2"
+            }
+        },
+        "type": "commit"
+    },
+    "url": "https://jenkins.dev.opensoftware.it/job/test/job/feature%252Ftest/36/display/redirect",
+    "repository": {
+        "type": "repository",
+        "full_name": "amuniz/test-repos",
+        "links": {
+            "self": {
+                "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos"
+            },
+            "html": {
+                "href": "https://bitbucket.org/amuniz/test-repos"
+            },
+            "avatar": {
+                "href": "https://bytebucket.org/ravatar/%7Bf991126e-6825-40ea-a1c2-e72c336ae41e%7D?ts=java"
+            }
+        },
+        "name": "test-repos",
+        "uuid": "{f991126e-6825-40ea-a1c2-e72c336ae41e}"
+    },
+    "description": "There was a failure building this commit.",
+    "created_on": "2024-11-22T10:23:20.512180+00:00",
+    "updated_on": "2024-11-27T16:21:27.750703+00:00",
+    "links": {
+        "self": {
+            "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/commit/046d9a3c1532acf4cf08fe93235c00e4d673c1d2/statuses/build/fe7e71305b004dd8dd5a124e1dae4c33"
+        },
+        "commit": {
+            "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/commit/046d9a3c1532acf4cf08fe93235c00e4d673c1d2"
+        }
+    }
+}

--- a/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/server/payload/build-status-1.0-commits-046d9a3c1532acf4cf08fe93235c00e4d673c1d3.json
+++ b/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/server/payload/build-status-1.0-commits-046d9a3c1532acf4cf08fe93235c00e4d673c1d3.json
@@ -1,0 +1,48 @@
+{
+    "key": "fe7e71305b004dd8dd5a124e1dae4c33",
+    "type": "build",
+    "state": "FAILED",
+    "name": "test » feature/test #36",
+    "refname": null,
+    "commit": {
+        "hash": "046d9a3c1532acf4cf08fe93235c00e4d673c1d2",
+        "links": {
+            "self": {
+                "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/commit/046d9a3c1532acf4cf08fe93235c00e4d673c1d2"
+            },
+            "html": {
+                "href": "https://bitbucket.org/amuniz/test-repos/commits/046d9a3c1532acf4cf08fe93235c00e4d673c1d2"
+            }
+        },
+        "type": "commit"
+    },
+    "url": "https://jenkins.dev.opensoftware.it/job/test/job/feature%252Ftest/36/display/redirect",
+    "repository": {
+        "type": "repository",
+        "full_name": "amuniz/test-repos",
+        "links": {
+            "self": {
+                "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos"
+            },
+            "html": {
+                "href": "https://bitbucket.org/amuniz/test-repos"
+            },
+            "avatar": {
+                "href": "https://bytebucket.org/ravatar/%7Bf991126e-6825-40ea-a1c2-e72c336ae41e%7D?ts=java"
+            }
+        },
+        "name": "test-repos",
+        "uuid": "{f991126e-6825-40ea-a1c2-e72c336ae41e}"
+    },
+    "description": "There was a failure building this commit.",
+    "created_on": "2024-11-22T10:23:20.512180+00:00",
+    "updated_on": "2024-11-27T16:21:27.750703+00:00",
+    "links": {
+        "self": {
+            "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/commit/046d9a3c1532acf4cf08fe93235c00e4d673c1d2/statuses/build/fe7e71305b004dd8dd5a124e1dae4c33"
+        },
+        "commit": {
+            "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/commit/046d9a3c1532acf4cf08fe93235c00e4d673c1d2"
+        }
+    }
+}


### PR DESCRIPTION
For bitbucket Server and Cloud:
* name must be less than 255 characters;
* URL must be less than 450 characters, in this case we can not trim otherwise the URL is invalid.