### PR TITLE
Remove CredentialsMatcher.CQL implementations

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/impl/credentials/BitbucketOAuthCredentialMatcher.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/impl/credentials/BitbucketOAuthCredentialMatcher.java
@@ -30,7 +30,15 @@ import com.cloudbees.plugins.credentials.common.UsernamePasswordCredentials;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-public class BitbucketOAuthCredentialMatcher implements CredentialsMatcher, CredentialsMatcher.CQL {
+// Although the CredentialsMatcher documentation says that the best practice
+// is to implement CredentialsMatcher.CQL too, this class does not implement
+// CredentialsMatcher.CQL, for the following reasons:
+//
+// * CQL supports neither method calls like username.contains(".")
+//   nor any regular-expression matching that could be used instead.
+// * There don't seem to be any public credential-provider plugins that
+//   would benefit from CQL.
+public class BitbucketOAuthCredentialMatcher implements CredentialsMatcher {
     private static int keyLength = 18;
     private static int secretLength = 32;
 
@@ -63,16 +71,4 @@ public class BitbucketOAuthCredentialMatcher implements CredentialsMatcher, Cred
             return false;
         }
     }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public String describe() {
-        return String.format(
-                "(username.lenght == %d && password.lenght == %d && !(username CONTAINS \".\" && username CONTAINS \"@\")",
-                keyLength, secretLength);
-    }
-
-
 }

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/impl/credentials/BitbucketUsernamePasswordCredentialMatcher.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/impl/credentials/BitbucketUsernamePasswordCredentialMatcher.java
@@ -29,7 +29,15 @@ import com.cloudbees.plugins.credentials.common.UsernamePasswordCredentials;
 import hudson.util.Secret;
 import org.apache.commons.lang.StringUtils;
 
-public class BitbucketUsernamePasswordCredentialMatcher implements CredentialsMatcher, CredentialsMatcher.CQL {
+// Although the CredentialsMatcher documentation says that the best practice
+// is to implement CredentialsMatcher.CQL too, this class does not implement
+// CredentialsMatcher.CQL, for the following reasons:
+//
+// * CQL supports neither method calls like StringUtils.isNotBlank(username)
+//   nor any regular-expression matching that could be used instead.
+// * There don't seem to be any public credential-provider plugins that
+//   would benefit from CQL.
+public class BitbucketUsernamePasswordCredentialMatcher implements CredentialsMatcher {
     private static final long serialVersionUID = -9196480589659636909L;
 
     /**
@@ -46,13 +54,4 @@ public class BitbucketUsernamePasswordCredentialMatcher implements CredentialsMa
         String password = Secret.toString(usernamePasswordCredential.getPassword());
         return StringUtils.isNotBlank(username) && StringUtils.isNotBlank(password);
     }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public String describe() {
-        return "username and password are not empty";
-    }
-
 }


### PR DESCRIPTION
Remove the CredentialsMatcher.CQL implementations that generated invalid Credentials Query Language (CQL) expressions.

CQL is a feature originally added in [JENKINS-35306](https://issues.jenkins.io/browse/JENKINS-35306) that lets a credential provider convert a CredentialMatcher to an expression tree and then check whether this expression matches a credential, without even loading the credential to the JVM.  For example, a credential provider that stores credentials in an SQL database could convert CQL to SQL and load only matching credentials from the database.  However, CQL does not support all the checks that BitbucketOAuthCredentialMatcher and BitbucketUsernamePasswordCredentialMatcher do.  Those classes generated invalid CQL that could not be parsed.  Although it might be possible to generate CQL for only some of the checks and let the Java code handle the rest, there don't seem to be credential providers that actually parse CQL, so it doesn't seem worth the trouble and it's easier to just remove CQL altogether.

Fixes [JENKINS-74972](https://issues.jenkins.io/browse/JENKINS-74972).

### Your checklist for this pull request

- [X] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Did you provide a test-case? That demonstrates feature works or fixes the issue.
