### PR TITLE
Use tagNameFormat to include correct tag in released pom file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,7 @@
     <hpi.compatibleSinceVersion>2.0</hpi.compatibleSinceVersion>
     <!-- Jenkins.MANAGE is still in Beta -->
     <useBeta>true</useBeta>
+    <tagNameFormat>@{project.version}</tagNameFormat>
   </properties>
 
   <developers>


### PR DESCRIPTION
## Use tagNameFormat to include correct tag in released pom file

The [933.0.1 pom file](https://repo.jenkins-ci.org/artifactory/releases/org/jenkins-ci/plugins/cloudbees-bitbucket-branch-source/933.0.1/cloudbees-bitbucket-branch-source-933.0.1.pom) stored in the Jenkins artifact repository includes an invalid scm.tag value because the tagNameFormat property was removed on the 933.x branch.

[Apache Maven release plugin documentation](https://maven.apache.org/maven-release/maven-release-plugin/prepare-mojo.html#tagNameFormat) says the default tagNameFormat is '@{project.artifactId}-@{project.version}'.  That matches with the value that is in the pom file, 'cloudbees-bitbucket-branch-source-933.0.1'.  It does not match the value written to the git repository.

The 933.0.1 release cannot be included in the Jenkins plugin BOM because of that invalid scm.tag.  A 933.0.2 release is needed after this change is merged so that the released pom file includes the tag value that matches the tag written to the repository by the Apache Maven release plugin.

Refer to the failing plugin BOM pull request:

* https://github.com/jenkinsci/bom/pull/4091

### Your checklist for this pull request

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Did you provide a test-case? That demonstrates feature works or fixes the issue.
