### PR TITLE
[JENKINS-75073] Missing serverUrl in fillCredentialsIdItems cause some credentials missing in the initial configuration

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketGitSCMBuilder.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketGitSCMBuilder.java
@@ -104,10 +104,9 @@ public class BitbucketGitSCMBuilder extends GitSCMBuilder<BitbucketGitSCMBuilder
         this.scmSource = scmSource;
 
         String serverURL = scmSource.getServerUrl();
-        AbstractBitbucketEndpoint endpoint = BitbucketEndpointConfiguration.get().findEndpoint(serverURL);
-        if (endpoint == null) {
-            endpoint = new BitbucketServerEndpoint(null, serverURL, false, null);
-        }
+        AbstractBitbucketEndpoint endpoint = BitbucketEndpointConfiguration.get()
+                .findEndpoint(serverURL)
+                .orElse(new BitbucketServerEndpoint(null, serverURL, false, null));
 
         String repositoryURL = endpoint.getRepositoryUrl(scmSource.getRepoOwner(), scmSource.getRepository());
         if (BitbucketApiUtils.isCloud(endpoint.getServerUrl())) {

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSourceBuilder.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSourceBuilder.java
@@ -23,7 +23,6 @@
  */
 package com.cloudbees.jenkins.plugins.bitbucket;
 
-import com.cloudbees.jenkins.plugins.bitbucket.endpoints.BitbucketEndpointConfiguration;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import jenkins.scm.api.trait.SCMSourceBuilder;
@@ -74,7 +73,7 @@ public class BitbucketSCMSourceBuilder extends SCMSourceBuilder<BitbucketSCMSour
                                      @NonNull String repoName, @CheckForNull String mirrorId) {
         super(BitbucketSCMSource.class, repoName);
         this.id = id;
-        this.serverUrl = BitbucketEndpointConfiguration.normalizeServerUrl(serverUrl);
+        this.serverUrl = serverUrl;
         this.credentialsId = credentialsId;
         this.mirrorId = mirrorId;
         this.repoOwner = repoOwner;

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/BitbucketCloudApiFactory.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/BitbucketCloudApiFactory.java
@@ -22,14 +22,16 @@ public class BitbucketCloudApiFactory extends BitbucketApiFactory {
     @Override
     protected BitbucketApi create(@Nullable String serverUrl, @Nullable BitbucketAuthenticator authenticator,
                                   @NonNull String owner, @CheckForNull String projectKey, @CheckForNull String repository) {
-        AbstractBitbucketEndpoint endpoint = BitbucketEndpointConfiguration.get().findEndpoint(BitbucketCloudEndpoint.SERVER_URL);
+        AbstractBitbucketEndpoint endpoint = BitbucketEndpointConfiguration.get()
+                .findEndpoint(BitbucketCloudEndpoint.SERVER_URL)
+                .orElse(null);
         boolean enableCache = false;
         int teamCacheDuration = 0;
         int repositoriesCacheDuration = 0;
-        if (endpoint != null && endpoint instanceof BitbucketCloudEndpoint) {
-            enableCache = ((BitbucketCloudEndpoint) endpoint).isEnableCache();
-            teamCacheDuration = ((BitbucketCloudEndpoint) endpoint).getTeamCacheDuration();
-            repositoriesCacheDuration = ((BitbucketCloudEndpoint) endpoint).getRepositoriesCacheDuration();
+        if (endpoint instanceof BitbucketCloudEndpoint cloudEndpoint) {
+            enableCache = cloudEndpoint.isEnableCache();
+            teamCacheDuration = cloudEndpoint.getTeamCacheDuration();
+            repositoriesCacheDuration = cloudEndpoint.getRepositoriesCacheDuration();
         }
         return new BitbucketCloudApiClient(
                 enableCache, teamCacheDuration, repositoriesCacheDuration,

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/endpoints/AbstractBitbucketEndpoint.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/endpoints/AbstractBitbucketEndpoint.java
@@ -144,10 +144,11 @@ public abstract class AbstractBitbucketEndpoint extends AbstractDescribableImpl<
      */
     @NonNull
     public String getEndpointJenkinsRootUrl() {
-        if (StringUtils.isBlank(bitbucketJenkinsRootUrl))
+        if (StringUtils.isBlank(bitbucketJenkinsRootUrl)) {
             return ClassicDisplayURLProvider.get().getRoot();
-        else
+        } else {
             return bitbucketJenkinsRootUrl;
+        }
     }
 
     /**
@@ -172,7 +173,9 @@ public abstract class AbstractBitbucketEndpoint extends AbstractDescribableImpl<
         // Note: do not pre-initialize to the global value, so it can be
         // reconfigured on the fly.
 
-        AbstractBitbucketEndpoint endpoint = BitbucketEndpointConfiguration.get().findEndpoint(serverUrl);
+        AbstractBitbucketEndpoint endpoint = BitbucketEndpointConfiguration.get()
+                .findEndpoint(serverUrl)
+                .orElse(null);
         if (endpoint != null) {
             return endpoint.getEndpointJenkinsRootUrl();
         }

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/WebhookAutoRegisterListener.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/WebhookAutoRegisterListener.java
@@ -139,8 +139,9 @@ public class WebhookAutoRegisterListener extends ItemListener {
                     case DISABLE:
                         continue;
                     case SYSTEM:
-                        AbstractBitbucketEndpoint endpoint =
-                                BitbucketEndpointConfiguration.get().findEndpoint(source.getServerUrl());
+                        AbstractBitbucketEndpoint endpoint = BitbucketEndpointConfiguration.get()
+                            .findEndpoint(source.getServerUrl())
+                            .orElse(null);
                         if (endpoint == null || !endpoint.isManageHooks()) {
                             continue;
                         }
@@ -215,8 +216,9 @@ public class WebhookAutoRegisterListener extends ItemListener {
             case DISABLE:
                 return null;
             case SYSTEM:
-                AbstractBitbucketEndpoint endpoint =
-                        BitbucketEndpointConfiguration.get().findEndpoint(source.getServerUrl());
+                AbstractBitbucketEndpoint endpoint = BitbucketEndpointConfiguration.get()
+                    .findEndpoint(source.getServerUrl())
+                    .orElse(null);
                 return endpoint == null || !endpoint.isManageHooks()
                         ? null
                         : BitbucketApiFactory.newInstance(

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/WebhookConfiguration.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/WebhookConfiguration.java
@@ -26,7 +26,6 @@ package com.cloudbees.jenkins.plugins.bitbucket.hooks;
 import com.cloudbees.jenkins.plugins.bitbucket.BitbucketSCMSource;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketWebHook;
 import com.cloudbees.jenkins.plugins.bitbucket.client.repository.BitbucketRepositoryHook;
-import com.cloudbees.jenkins.plugins.bitbucket.endpoints.AbstractBitbucketEndpoint;
 import com.cloudbees.jenkins.plugins.bitbucket.endpoints.BitbucketCloudEndpoint;
 import com.cloudbees.jenkins.plugins.bitbucket.endpoints.BitbucketEndpointConfiguration;
 import com.cloudbees.jenkins.plugins.bitbucket.endpoints.BitbucketServerEndpoint;
@@ -213,9 +212,11 @@ public class WebhookConfiguration {
     }
 
     private static List<String> getNativeServerEvents(String serverUrl) {
-        AbstractBitbucketEndpoint endpoint = BitbucketEndpointConfiguration.get().findEndpoint(serverUrl);
-        if (endpoint instanceof BitbucketServerEndpoint) {
-            switch (((BitbucketServerEndpoint) endpoint).getServerVersion()) {
+        BitbucketServerEndpoint endpoint = BitbucketEndpointConfiguration.get()
+                .findEndpoint(serverUrl, BitbucketServerEndpoint.class)
+                .orElse(null);
+        if (endpoint != null) {
+            switch (endpoint.getServerVersion()) {
             case VERSION_5:
                 return NATIVE_SERVER_EVENTS_v5;
             case VERSION_5_10:

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/BitbucketServerAPIClient.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/BitbucketServerAPIClient.java
@@ -264,8 +264,9 @@ public class BitbucketServerAPIClient extends AbstractBitbucketApi implements Bi
 
         pullRequests.removeIf(this::shouldIgnore);
 
-        BitbucketServerEndpoint endpoint = (BitbucketServerEndpoint) BitbucketEndpointConfiguration.get().
-            findEndpoint(this.baseURL, BitbucketServerEndpoint.class).orElse(null);
+        BitbucketServerEndpoint endpoint = BitbucketEndpointConfiguration.get()
+                .findEndpoint(this.baseURL, BitbucketServerEndpoint.class)
+                .orElse(null);
 
         for (BitbucketServerPullRequest pullRequest : pullRequests) {
             setupPullRequest(pullRequest, endpoint);
@@ -395,8 +396,11 @@ public class BitbucketServerAPIClient extends AbstractBitbucketApi implements Bi
         try {
             BitbucketServerPullRequest pr = JsonParser.toJava(response, BitbucketServerPullRequest.class);
             setupClosureForPRBranch(pr);
-            setupPullRequest(pr, (BitbucketServerEndpoint) BitbucketEndpointConfiguration.get().
-                findEndpoint(this.baseURL, BitbucketServerEndpoint.class).orElse(null));
+
+            BitbucketServerEndpoint endpoint = BitbucketEndpointConfiguration.get()
+                    .findEndpoint(this.baseURL, BitbucketServerEndpoint.class)
+                    .orElse(null);
+            setupPullRequest(pr, endpoint);
             return pr;
         } catch (IOException e) {
             throw new IOException("I/O error when accessing URL: " + url, e);

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/client/BitbucketCloudApiClientTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/client/BitbucketCloudApiClientTest.java
@@ -69,7 +69,7 @@ class BitbucketCloudApiClientTest {
 
     @Test
     @WithJenkins
-    public void test_proxy_configurad_without_password(JenkinsRule r) throws Exception {
+    void test_proxy_configurad_without_password(JenkinsRule r) throws Exception {
         Proxy proxy = mock(Proxy.class);
         when(proxy.address()).thenReturn(new InetSocketAddress("proxy.lan", 8080));
         ProxyConfiguration proxyConfiguration = mock(ProxyConfiguration.class);


### PR DESCRIPTION
If the number of server instances is only one, when a new Jenkins project is created the server list combobox is not available. This causes, in the UI component that loads credentials, to pass the stapler parameter serverUrl as an empty string.
In this scenario, serverUrl must be taken from the first of configured endpoints so that it can properly filter the list of credentials.

Test why and the use case to normalizeServerUrl must be bitbucket cloud if server url is null