### PR TITLE
[JENKINS-75083] Build statuses do not appear in list of pull requests in Bitbucket Server

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/impl/notifier/BitbucketBuildStatusNotifications.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/impl/notifier/BitbucketBuildStatusNotifications.java
@@ -223,10 +223,20 @@ public final class BitbucketBuildStatusNotifications {
              * Poor documentation for bitbucket cloud at:
              * https://community.atlassian.com/t5/Bitbucket-questions/Re-Builds-not-appearing-in-pull-requests/qaq-p/1805991/comment-id/65864#M65864
              * that means refName null or valued with only head.getBranchName()
-             * For bitbucket server refName set to null or ... (refs/heads/ + head.getBranchName()) ??
+             *
+             * For Bitbucket Server, refName should be "refs/heads/" + the name
+             * of the source branch of the pull request, and the build status
+             * should be posted to the repository that contains that branch.
+             * If refName is null, then Bitbucket Server does not show the
+             * build status in the list of pull requests, but still shows it
+             * on the web page of the individual pull request.
              */
-            refName = null;
             bitbucket = source.buildBitbucketClient(head);
+            if (BitbucketApiUtils.isCloud(bitbucket)) {
+                refName = null;
+            } else {
+                refName = "refs/heads/" + head.getBranchName();
+            }
         } else {
             listener.getLogger().println("[Bitbucket] Notifying commit build result");
             SCMHead head = rev.getHead();


### PR DESCRIPTION
When posting a build status from a pull-request job to Bitbucket Server or Data Center, set the "ref" property to match the source branch, e.g. "refs/heads/myfeature".  This fixes the problem that Bitbucket Server stopped showing build statuses in the list of pull requests when the plugin started using the newer build-status API in <https://github.com/jenkinsci/bitbucket-branch-source-plugin/pull/930>.

This PR does not change how the plugin posts a build status to Bitbucket Cloud.  That case will have `"ref": null` for pull-request jobs, like before.

Fix [JENKINS-75083](https://issues.jenkins.io/browse/JENKINS-75083).

<!--
To mark your pull request as work in progress please create it as a draft pull request
-->

### Your checklist for this pull request

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Did you provide a test-case? That demonstrates feature works or fixes the issue.\
  Manually tested with Bitbucket Server; see <https://github.com/jenkinsci/bitbucket-branch-source-plugin/pull/954#issuecomment-2571190504>.

<!--
Put an `x` into the [ ] to show you have filled the information below
Describe your pull request below
-->
