### PR TITLE
[JENKINS-53535] Make Bitbucket Server, Owner and repository environment variables for Bitbucket Team/Project based jobs

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/impl/extension/BitbucketEnvVarExtension.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/impl/extension/BitbucketEnvVarExtension.java
@@ -3,9 +3,12 @@ package com.cloudbees.jenkins.plugins.bitbucket.impl.extension;
 import com.cloudbees.jenkins.plugins.bitbucket.impl.util.URLUtils;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
+import hudson.Extension;
 import hudson.plugins.git.GitSCM;
 import hudson.plugins.git.extensions.GitSCMExtension;
+import hudson.plugins.git.extensions.GitSCMExtensionDescriptor;
 import java.util.Map;
+import java.util.Objects;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 public class BitbucketEnvVarExtension extends GitSCMExtension {
@@ -33,9 +36,60 @@ public class BitbucketEnvVarExtension extends GitSCMExtension {
      */
     @Override
     public void populateEnvironmentVariables(GitSCM scm, Map<String, String> env) {
-        env.put("BITBUCKET_REPOSITORY", repository);
-        env.put("BITBUCKET_OWNER", owner);
-        env.put("BITBUCKET_PROJECT_KEY", projectKey);
-        env.put("BITBUCKET_SERVER_URL", serverURL);
+        env.put("BITBUCKET_REPOSITORY", getRepository());
+        env.put("BITBUCKET_OWNER", getOwner());
+        env.put("BITBUCKET_PROJECT_KEY", getProjectKey());
+        env.put("BITBUCKET_SERVER_URL", getServerURL());
+    }
+
+    public String getOwner() {
+        return owner;
+    }
+
+    public String getRepository() {
+        return repository;
+    }
+
+    public String getProjectKey() {
+        return projectKey;
+    }
+
+    public String getServerURL() {
+        return serverURL;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(owner, projectKey, repository, serverURL);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        BitbucketEnvVarExtension other = (BitbucketEnvVarExtension) obj;
+        return Objects.equals(owner, other.owner)
+                && Objects.equals(projectKey, other.projectKey)
+                && Objects.equals(repository, other.repository)
+                && Objects.equals(serverURL, other.serverURL);
+    }
+
+    @Extension
+    // No @Symbol because Pipeline users should not configure this in other ways than this plugin provides
+    public static class DescriptorImpl extends GitSCMExtensionDescriptor {
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public String getDisplayName() {
+            return "Contribute additional environment variables about the target branch.";
+        }
     }
 }

--- a/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/client/payload/2.0-repositories-amuniz-test-repos.json
+++ b/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/client/payload/2.0-repositories-amuniz-test-repos.json
@@ -76,10 +76,50 @@
     "type": "user",
     "uuid": "{644c7fc2-b15a-4445-9f89-35390694fac9}"
   },
+  "workspace": {
+    "type": "workspace",
+    "uuid": "{7d3a178a-a087-4756-b2da-2f9eadf50ba8}",
+    "name": "Albert Muniz",
+    "slug": "amunuz",
+    "links": {
+      "avatar": {
+        "href": "https://bitbucket.org/workspaces/amuniz/avatar/?ts=1644525365"
+      },
+      "html": {
+        "href": "https://bitbucket.org/amuniz/"
+      },
+      "self": {
+        "href": "https://api.bitbucket.org/2.0/workspaces/nfalco79"
+      }
+    }
+  },
+  "project": {
+    "type": "project",
+    "key": "PUB",
+    "uuid": "{ef731d07-06e0-46d2-9b56-2674649b0655}",
+    "name": "public",
+    "links": {
+      "self": {
+        "href": "https://api.bitbucket.org/2.0/workspaces/amuniz/projects/PUB"
+      },
+      "html": {
+        "href": "https://bitbucket.org/amuniz/workspace/projects/PUB"
+      },
+      "avatar": {
+        "href": "https://bitbucket.org/amuniz/workspace/projects/PUB/avatar/32?ts=1644525770"
+      }
+    }
+  },
   "updated_on": "2018-09-21T15:53:38.794718+00:00",
   "size": 84351,
   "type": "repository",
   "slug": "test-repos",
   "is_private": false,
-  "description": ""
+  "description": "",
+  "override_settings": {
+    "default_merge_strategy": false,
+    "branching_model": false
+  },
+  "parent": null,
+  "enforced_signed_commits": null
 }


### PR DESCRIPTION
Fix BitbucketEnvVarExtension to be compatible with @DataBoundConstructor annotation. Add getter methods, hashCode and equals method and a own GitSCMExtensionDescriptor.
Add test cases