### PR TITLE
[JENKINS-75089] Getting clone URL using mirror returns HTTP 401

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/BitbucketServerAPIClient.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/BitbucketServerAPIClient.java
@@ -89,6 +89,7 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.http.HttpHost;
 import org.apache.http.HttpStatus;
+import org.apache.http.client.methods.HttpGet;
 import org.apache.http.conn.HttpClientConnectionManager;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
@@ -464,7 +465,8 @@ public class BitbucketServerAPIClient extends AbstractBitbucketApi implements Bi
      */
     @NonNull
     public BitbucketMirroredRepository getMirroredRepository(@NonNull String url) throws IOException, InterruptedException {
-        String response = getRequest(url);
+        HttpGet request = new HttpGet(url);
+        String response = doRequest(request, false);
         try {
             return JsonParser.toJava(response, BitbucketMirroredRepository.class);
         } catch (IOException e) {

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/client/BitbucketIntegrationClientFactory.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/client/BitbucketIntegrationClientFactory.java
@@ -104,7 +104,9 @@ public class BitbucketIntegrationClientFactory {
         }
 
         @Override
-        protected CloseableHttpResponse executeMethod(HttpHost host, HttpRequestBase httpMethod) throws IOException {
+        protected CloseableHttpResponse executeMethod(HttpHost host,
+                                                      HttpRequestBase httpMethod,
+                                                      boolean requireAuthentication) throws IOException {
             String path = httpMethod.getURI().toString();
             audit.request(httpMethod);
 
@@ -115,6 +117,11 @@ public class BitbucketIntegrationClientFactory {
             payloadPath = payloadRootPath + payloadPath + ".json";
 
             return loadResponseFromResources(getClass(), path, payloadPath);
+        }
+
+        @Override
+        public BitbucketAuthenticator getAuthenticator() {
+            return super.getAuthenticator();
         }
 
         @Override
@@ -131,7 +138,7 @@ public class BitbucketIntegrationClientFactory {
         private final IRequestAudit audit;
 
         private BitbucketClouldIntegrationClient(String payloadRootPath, String owner, String repositoryName) {
-            super(false, 0, 0, owner, null, repositoryName, (BitbucketAuthenticator) null);
+            super(false, 0, 0, owner, null, repositoryName, mock(BitbucketAuthenticator.class));
 
             if (payloadRootPath == null) {
                 this.payloadRootPath = PAYLOAD_RESOURCE_ROOTPATH;
@@ -148,7 +155,9 @@ public class BitbucketIntegrationClientFactory {
         }
 
         @Override
-        protected CloseableHttpResponse executeMethod(HttpHost host, HttpRequestBase httpMethod) throws IOException {
+        protected CloseableHttpResponse executeMethod(HttpHost host,
+                                                      HttpRequestBase httpMethod,
+                                                      boolean requireAuthentication) throws IOException {
             String path = httpMethod.getURI().toString();
             audit.request(httpMethod);
 
@@ -156,6 +165,11 @@ public class BitbucketIntegrationClientFactory {
             payloadPath = payloadRootPath + payloadPath + ".json";
 
             return loadResponseFromResources(getClass(), path, payloadPath);
+        }
+
+        @Override
+        public BitbucketAuthenticator getAuthenticator() {
+            return super.getAuthenticator();
         }
 
         @Override

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/BitbucketServerAPIClientTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/BitbucketServerAPIClientTest.java
@@ -1,20 +1,24 @@
 package com.cloudbees.jenkins.plugins.bitbucket.server.client;
 
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketApi;
+import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketAuthenticator;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketBuildStatus;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketBuildStatus.Status;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketRepository;
 import com.cloudbees.jenkins.plugins.bitbucket.client.BitbucketIntegrationClientFactory;
+import com.cloudbees.jenkins.plugins.bitbucket.client.BitbucketIntegrationClientFactory.BitbucketServerIntegrationClient;
 import com.cloudbees.jenkins.plugins.bitbucket.client.BitbucketIntegrationClientFactory.IRequestAudit;
 import io.jenkins.cli.shaded.org.apache.commons.lang.RandomStringUtils;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import org.apache.commons.io.IOUtils;
+import org.apache.http.HttpRequest;
 import org.apache.http.client.methods.HttpHead;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.http.impl.client.HttpClientBuilder;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
@@ -27,16 +31,25 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.RETURNS_SELF;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 @WithJenkins
 class BitbucketServerAPIClientTest {
 
+    private static JenkinsRule j;
+
+    @BeforeAll
+    static void init(JenkinsRule rule) {
+        j = rule;
+    }
+
     @Test
-    void verify_status_notitication_name_max_length(JenkinsRule j) throws Exception {
+    void verify_status_notitication_name_max_length() throws Exception {
         BitbucketApi client = BitbucketIntegrationClientFactory.getApiMockClient("https://acme.bitbucket.org");
         BitbucketBuildStatus status = new BitbucketBuildStatus();
         status.setName(RandomStringUtils.randomAlphanumeric(300));
@@ -63,8 +76,13 @@ class BitbucketServerAPIClientTest {
         return captor.getValue();
     }
 
+    private BitbucketAuthenticator extractAuthenticator(BitbucketApi client) {
+        assertThat(client).isInstanceOf(BitbucketServerIntegrationClient.class);
+        return ((BitbucketServerIntegrationClient) client).getAuthenticator();
+    }
+
     @Test
-    void verify_checkPathExists_given_a_path(JenkinsRule j) throws Exception {
+    void verify_checkPathExists_given_a_path() throws Exception {
         BitbucketApi client = BitbucketIntegrationClientFactory.getApiMockClient("https://acme.bitbucket.org");
         assertThat(client.checkPathExists("feature/pipeline", "folder/Jenkinsfile")).isTrue();
 
@@ -78,7 +96,7 @@ class BitbucketServerAPIClientTest {
     }
 
     @Test
-    void verify_checkPathExists_given_file(JenkinsRule j) throws Exception {
+    void verify_checkPathExists_given_file() throws Exception {
         BitbucketApi client = BitbucketIntegrationClientFactory.getApiMockClient("https://acme.bitbucket.org");
         assertThat(client.checkPathExists("feature/pipeline", "Jenkinsfile")).isTrue();
 
@@ -89,7 +107,7 @@ class BitbucketServerAPIClientTest {
     }
 
     @Test
-    void filterArchivedRepositories(JenkinsRule j) throws Exception {
+    void filterArchivedRepositories() throws Exception {
         BitbucketApi client = BitbucketIntegrationClientFactory.getClient("localhost", "foo", "test-repos");
         List<? extends BitbucketRepository> repos = client.getRepositories();
         List<String> names = repos.stream().map(BitbucketRepository::getRepositoryName).toList();
@@ -98,7 +116,7 @@ class BitbucketServerAPIClientTest {
     }
 
     @Test
-    void sortRepositoriesByName(JenkinsRule j) throws Exception {
+    void sortRepositoriesByName() throws Exception {
         BitbucketApi client = BitbucketIntegrationClientFactory.getClient("localhost", "amuniz", "test-repos");
         List<? extends BitbucketRepository> repos = client.getRepositories();
         List<String> names = repos.stream().map(BitbucketRepository::getRepositoryName).toList();
@@ -106,12 +124,22 @@ class BitbucketServerAPIClientTest {
     }
 
     @Test
-    void disableCookieManager(JenkinsRule j) throws Exception {
+    void disableCookieManager() throws Exception {
         try (MockedStatic<HttpClientBuilder> staticHttpClientBuilder = mockStatic(HttpClientBuilder.class)) {
             HttpClientBuilder httpClientBuilder = mock(HttpClientBuilder.class, RETURNS_SELF);
             staticHttpClientBuilder.when(HttpClientBuilder::create).thenReturn(httpClientBuilder);
             BitbucketIntegrationClientFactory.getClient("localhost", "amuniz", "test-repos");
             verify(httpClientBuilder).disableCookieManagement();
         }
+    }
+
+    @Test
+    void verify_mirroredRepository_does_not_authenticate_request() throws Exception {
+        BitbucketServerAPIClient client = (BitbucketServerAPIClient) BitbucketIntegrationClientFactory.getClient("localhost", "amuniz", "test-repos");
+
+        BitbucketAuthenticator authenticator = extractAuthenticator(client);
+        String url = "https://localhost/rest/mirroring/latest/upstreamServers/1/repos/1?jwt=TOKEN";
+        client.getMirroredRepository(url);
+        verify(authenticator, never()).configureRequest(any(HttpRequest.class));
     }
 }

--- a/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/server/payload/mirroring-latest-upstreamServers-1-repos-1_jwt_TOKEN.json
+++ b/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/server/payload/mirroring-latest-upstreamServers-1-repos-1_jwt_TOKEN.json
@@ -1,0 +1,19 @@
+{
+  "pushUrls": [
+    {
+      "name": "http",
+      "href": "https://bitbucket.example.com/scm/awesomeproject/awesomerepo.git"
+    }
+  ],
+  "cloneUrls": [
+    {
+      "name": "http",
+      "href": "https://bitbucket.example.com/scm/awesomeproject/awesomerepo.git"
+    }
+  ],
+  "mirrorName": "Saigon Mirror",
+  "lastUpdated": "<string>",
+  "available": true,
+  "status": "NOT_MIRRORED",
+  "repositoryId": "1"
+}


### PR DESCRIPTION
Fix the method to retrieve the list of mirror URLs without using authentication. A JWT token is already provided in the request URL as documented at https://developer.atlassian.com/server/bitbucket/rest/v803/api-group-mirroring/#api-mirroring-latest-repos-repoid-mirrors-get