### PR TITLE
Add a new trait to discard all branches with head commits older than the configured days.

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketTeamMetadataAction.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketTeamMetadataAction.java
@@ -108,12 +108,12 @@ public class BitbucketTeamMetadataAction extends AvatarMetadataAction {
         }
 
         private StandardCredentials findCredentials() {
-            try (ACLContext ctx = ACL.as(ACL.SYSTEM)) {
+            try (ACLContext ctx = ACL.as2(ACL.SYSTEM2)) {
                 return CredentialsMatchers.firstOrNull(
-                        CredentialsProvider.lookupCredentials(
+                        CredentialsProvider.lookupCredentialsInItem(
                                 credentials.getClass(),
                                 (Item) null, // context
-                                ACL.SYSTEM,
+                                ACL.SYSTEM2,
                                 URIRequirementBuilder.fromUri(serverUrl).build()
                         ),
                         CredentialsMatchers.allOf(

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/ForkPullRequestDiscoveryTrait.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/ForkPullRequestDiscoveryTrait.java
@@ -234,7 +234,6 @@ public class ForkPullRequestDiscoveryTrait extends SCMSourceTrait {
      * <p>
      * This reduces generics in the databound constructor method signature as a workaround for JENKINS-26535
      */
-    @SuppressWarnings("rawtypes")
     public static abstract class BitbucketForkTrustPolicy extends SCMHeadAuthority<BitbucketSCMSourceRequest, PullRequestSCMHead, PullRequestSCMRevision> {
     }
 

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/AbstractBitbucketTeam.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/AbstractBitbucketTeam.java
@@ -23,8 +23,6 @@
  */
 package com.cloudbees.jenkins.plugins.bitbucket.api;
 
-import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketHref;
-import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketTeam;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/BitbucketBranch.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/BitbucketBranch.java
@@ -49,7 +49,6 @@ public interface BitbucketBranch {
      * Returns the head commit message for this branch.
      *
      * @return the head commit message of this branch
-     * @author Nikolas Falco
      * @since 2.2.14
      */
     String getMessage();
@@ -58,7 +57,6 @@ public interface BitbucketBranch {
      * Returns the head commit author for this branch.
      *
      * @return the head commit author of this branch
-     * @author Nikolas Falco
      * @since 2.2.14
      */
     String getAuthor();

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/BitbucketCommit.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/BitbucketCommit.java
@@ -32,7 +32,6 @@ public interface BitbucketCommit {
      * Returns the head commit author for this branch.
      *
      * @return the head commit author of this branch
-     * @author Nikolas Falco
      * @since 2.2.14
      */
     String getAuthor();

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/trait/DiscardOldBranchTrait.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/trait/DiscardOldBranchTrait.java
@@ -1,0 +1,128 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2025, Nikolas Falco
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.cloudbees.jenkins.plugins.bitbucket.trait;
+
+import com.cloudbees.jenkins.plugins.bitbucket.BitbucketGitSCMBuilder;
+import com.cloudbees.jenkins.plugins.bitbucket.BitbucketSCMSourceRequest;
+import com.cloudbees.jenkins.plugins.bitbucket.Messages;
+import com.cloudbees.jenkins.plugins.bitbucket.PullRequestSCMHead;
+import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketBranch;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Extension;
+import hudson.util.FormValidation;
+import java.io.IOException;
+import java.time.LocalDate;
+import jenkins.scm.api.SCMHead;
+import jenkins.scm.api.trait.SCMBuilder;
+import jenkins.scm.api.trait.SCMHeadFilter;
+import jenkins.scm.api.trait.SCMSourceContext;
+import jenkins.scm.api.trait.SCMSourceRequest;
+import jenkins.scm.api.trait.SCMSourceTrait;
+import jenkins.scm.api.trait.SCMSourceTraitDescriptor;
+import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.QueryParameter;
+
+/**
+ * Discard all branches with head commit older than the configured days.
+ *
+ * @author Nikolas Falco
+ * @since 933.3.0
+ * @see <a href="https://github.com/nfalco79/bitbucket-trait-plugin/blob/master/src/main/java/com/github/nfalco79/jenkins/plugins/bitbucket/trait/DiscardOldBranchTrait.java">Original source</a>
+ */
+public class DiscardOldBranchTrait extends SCMSourceTrait {
+
+    private int keepForDays = 1;
+
+    @DataBoundConstructor
+    public DiscardOldBranchTrait(@CheckForNull int keepForDays) {
+        this.keepForDays = keepForDays;
+    }
+
+    public int getKeepForDays() {
+        return keepForDays;
+    }
+
+    @Override
+    protected void decorateContext(SCMSourceContext<?, ?> context) {
+        context.withFilter(new ExcludeOldSCMHeadBranch());
+    }
+
+    public final class ExcludeOldSCMHeadBranch extends SCMHeadFilter {
+        @Override
+        public boolean isExcluded(SCMSourceRequest request, SCMHead head) throws IOException, InterruptedException {
+            if (keepForDays > 0) {
+                BitbucketSCMSourceRequest bbRequest = (BitbucketSCMSourceRequest) request;
+                String branchName = head.getName();
+                if (head instanceof PullRequestSCMHead prHead) {
+                    // getName return the PR-<id>, not the branch name
+                    branchName = prHead.getBranchName();
+                }
+
+                for (BitbucketBranch branch : bbRequest.getBranches()) {
+                    if (branchName.equals(branch.getName())) {
+                        LocalDate expiryDate = asLocalDate(branch.getDateMillis());
+                        return LocalDate.now().isAfter(expiryDate);
+                    }
+                }
+            }
+            return false;
+        }
+
+        @NonNull
+        private LocalDate asLocalDate(@NonNull long milliseconds) {
+            return new java.sql.Date(milliseconds).toLocalDate();
+        }
+    }
+
+    /**
+     * Our descriptor.
+     */
+    @Symbol("bitbucketDiscardOldBranch")
+    @Extension
+    public static class DescriptorImpl extends SCMSourceTraitDescriptor {
+
+        public FormValidation doCheckKeepForDays(@QueryParameter final int keepForDays) {
+            if (keepForDays <= 0) {
+                return FormValidation.error("Invalid value. Days must be greater than 0");
+            }
+            return FormValidation.ok();
+        }
+
+        @Override
+        public String getDisplayName() {
+            return Messages.DiscardOldBranchTrait_displayName();
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public boolean isApplicableToBuilder(@SuppressWarnings("rawtypes") @NonNull Class<? extends SCMBuilder> builderClass) {
+            return BitbucketGitSCMBuilder.class.isAssignableFrom(builderClass);
+        }
+    }
+
+}

--- a/src/main/resources/com/cloudbees/jenkins/plugins/bitbucket/Messages.properties
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/bitbucket/Messages.properties
@@ -64,3 +64,4 @@ BranchSCMHead.Pronoun=Branch
 BitbucketTagSCMHead.Pronoun=Tag
 TagDiscoveryTrait.authorityDisplayName=Trust origin tags
 BitbucketBuildStatusNotificationsTrait.displayName=Bitbucket build status notifications
+DiscardOldBranchTrait.displayName=Discard branch older than given days

--- a/src/main/resources/com/cloudbees/jenkins/plugins/bitbucket/trait/DiscardOldBranchTrait/config.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/bitbucket/trait/DiscardOldBranchTrait/config.jelly
@@ -1,0 +1,29 @@
+<!--
+ - The MIT License
+ -
+ - Copyright (c) 2025, Nikolas Falco
+ -
+ - Permission is hereby granted, free of charge, to any person obtaining a copy
+ - of this software and associated documentation files (the "Software"), to deal
+ - in the Software without restriction, including without limitation the rights
+ - to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ - copies of the Software, and to permit persons to whom the Software is
+ - furnished to do so, subject to the following conditions:
+ -
+ - The above copyright notice and this permission notice shall be included in
+ - all copies or substantial portions of the Software.
+ -
+ - THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ - IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ - FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ - AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ - LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ - OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ - THE SOFTWARE.
+ -->
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+    <f:entry title="${%Days to keep}" field="keepForDays">
+        <f:number default="1" />
+    </f:entry>
+</j:jelly>

--- a/src/main/resources/com/cloudbees/jenkins/plugins/bitbucket/trait/DiscardOldBranchTrait/help-keepForDays.html
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/bitbucket/trait/DiscardOldBranchTrait/help-keepForDays.html
@@ -1,0 +1,26 @@
+<!--
+ - The MIT License
+ -
+ - Copyright (c) 2025, Nikolas Falco
+ -
+ - Permission is hereby granted, free of charge, to any person obtaining a copy
+ - of this software and associated documentation files (the "Software"), to deal
+ - in the Software without restriction, including without limitation the rights
+ - to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ - copies of the Software, and to permit persons to whom the Software is
+ - furnished to do so, subject to the following conditions:
+ -
+ - The above copyright notice and this permission notice shall be included in
+ - all copies or substantial portions of the Software.
+ -
+ - THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ - IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ - FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ - AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ - LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ - OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ - THE SOFTWARE.
+ -->
+<div>
+    Number of days since the last commit in the branch before it is discarded.
+</div>

--- a/src/main/resources/com/cloudbees/jenkins/plugins/bitbucket/trait/DiscardOldBranchTrait/help.html
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/bitbucket/trait/DiscardOldBranchTrait/help.html
@@ -1,0 +1,26 @@
+<!--
+ - The MIT License
+ -
+ - Copyright (c) 2025, Nikolas Falco
+ -
+ - Permission is hereby granted, free of charge, to any person obtaining a copy
+ - of this software and associated documentation files (the "Software"), to deal
+ - in the Software without restriction, including without limitation the rights
+ - to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ - copies of the Software, and to permit persons to whom the Software is
+ - furnished to do so, subject to the following conditions:
+ -
+ - The above copyright notice and this permission notice shall be included in
+ - all copies or substantial portions of the Software.
+ -
+ - THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ - IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ - FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ - AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ - LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ - OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ - THE SOFTWARE.
+ -->
+<div>
+    Discard all branches with head commit older than the configured days.
+</div>

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/trait/DiscardOldBranchTraitTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/trait/DiscardOldBranchTraitTest.java
@@ -1,0 +1,102 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2025, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.cloudbees.jenkins.plugins.bitbucket.trait;
+
+import com.cloudbees.jenkins.plugins.bitbucket.BitbucketSCMSourceContext;
+import com.cloudbees.jenkins.plugins.bitbucket.BitbucketSCMSourceRequest;
+import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketBranch;
+import com.cloudbees.jenkins.plugins.bitbucket.trait.DiscardOldBranchTrait.ExcludeOldSCMHeadBranch;
+import java.util.Arrays;
+import java.util.Calendar;
+import java.util.Date;
+import jenkins.scm.api.SCMHead;
+import jenkins.scm.api.SCMHeadObserver;
+import jenkins.scm.api.trait.SCMHeadFilter;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class DiscardOldBranchTraitTest {
+
+    @Test
+    void verify_that_branch_is_not_excluded_if_has_recent_commits() throws Exception {
+        DiscardOldBranchTrait trait = new DiscardOldBranchTrait(10);
+        BitbucketSCMSourceContext ctx = new BitbucketSCMSourceContext(null, SCMHeadObserver.none());
+        trait.decorateContext(ctx);
+        assertThat(ctx.filters()).hasAtLeastOneElementOfType(ExcludeOldSCMHeadBranch.class);
+
+        long lastCommitDate = new Date().getTime();
+
+        SCMHead head = mock(SCMHead.class);
+        when(head.getName()).thenReturn("feature/release");
+
+        BitbucketBranch branch1 = mock(BitbucketBranch.class);
+        when(branch1.getName()).thenReturn("feature/xyz");
+        when(branch1.getDateMillis()).thenReturn(lastCommitDate);
+
+        BitbucketBranch branch2 = mock(BitbucketBranch.class);
+        when(branch2.getName()).thenReturn("feature/release");
+        when(branch2.getDateMillis()).thenReturn(lastCommitDate);
+
+        BitbucketSCMSourceRequest request = mock(BitbucketSCMSourceRequest.class);
+        when(request.getBranches()).thenReturn(Arrays.asList(branch1, branch2));
+
+        for (SCMHeadFilter filter : ctx.filters()) {
+            assertThat(filter.isExcluded(request, head)).isFalse();
+        }
+    }
+
+    @Test
+    void verify_that_branch_is_excluded_if_has_head_commit_older_than_specified() throws Exception {
+        DiscardOldBranchTrait trait = new DiscardOldBranchTrait(5);
+        BitbucketSCMSourceContext ctx = new BitbucketSCMSourceContext(null, SCMHeadObserver.none());
+        trait.decorateContext(ctx);
+        assertThat(ctx.filters()).hasAtLeastOneElementOfType(ExcludeOldSCMHeadBranch.class);
+
+        Calendar c = Calendar.getInstance();
+        c.add(Calendar.DAY_OF_MONTH, -100);
+        long lastCommitDate = c.getTimeInMillis();
+
+        SCMHead head = mock(SCMHead.class);
+        when(head.getName()).thenReturn("feature/release");
+
+        BitbucketBranch branch1 = mock(BitbucketBranch.class);
+        when(branch1.getName()).thenReturn("feature/xyz");
+        when(branch1.getDateMillis()).thenReturn(lastCommitDate);
+
+        BitbucketBranch branch2 = mock(BitbucketBranch.class);
+        when(branch2.getName()).thenReturn("feature/release");
+        when(branch2.getDateMillis()).thenReturn(lastCommitDate);
+
+        BitbucketSCMSourceRequest request = mock(BitbucketSCMSourceRequest.class);
+        when(request.getBranches()).thenReturn(Arrays.asList(branch1, branch2));
+
+        for (SCMHeadFilter filter : ctx.filters()) {
+            assertThat(filter.isExcluded(request, head)).isTrue();
+        }
+    }
+
+}


### PR DESCRIPTION
This trait is useful when you do not want to pollute the Jenkins instance with older work such as support, release or feature branches for which there will be no further work, for which without this trait the work will be kept there for weeks or years taking up resources. When a new commit is pushed to the discarded branch, a new Jenkins work will be recreated.