### PR TITLE
[JENKINS-74970] Log user name and repository if Bitbucket Server forbids posting a build status

### DIFF
--- a/src/main/resources/com/cloudbees/jenkins/plugins/bitbucket/Messages.properties
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/bitbucket/Messages.properties
@@ -65,3 +65,4 @@ BitbucketTagSCMHead.Pronoun=Tag
 TagDiscoveryTrait.authorityDisplayName=Trust origin tags
 BitbucketBuildStatusNotificationsTrait.displayName=Bitbucket build status notifications
 DiscardOldBranchTrait.displayName=Discard branch older than given days
+BitbucketServerAPIClient.adviceForBuildStatusError=Please verify that the Bitbucket user "{0}" is granted REPO_READ access on the repository "{1}/{2}".


### PR DESCRIPTION
If Bitbucket Server responds with HTTP status 401 (Unauthorized) or 403 (Forbidden) when this plugin posts a build status, and the HTTP response includes an "X-AUSERNAME" header field that shows Bitbucket Server authenticated the user, then add more information in the message of the BitbucketRequestException:

* The Bitbucket user name from the "X-AUSERNAME" response header field.
* The repository to which the request was sent.
* The project or user that owns the repository.

The behaviour is unchanged on Bitbucket Cloud, and on Bitbucket Server for operations other than posting a build status.

<!-- Please describe your pull request here. -->

<!--
To mark your pull request as work in progress please create it as a draft pull request
-->

### Your checklist for this pull request

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Did you provide a test-case? That demonstrates feature works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled the information below
Describe your pull request below
-->
