### PR TITLE
[JENKINS-75157] Bitbucket client fail to retrieve resource with HTTP 404 for bitbucket server

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/filesystem/BitbucketSCMFile.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/filesystem/BitbucketSCMFile.java
@@ -28,6 +28,7 @@ import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketApi;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Collections;
 import jenkins.scm.api.SCMFile;
 
 public class BitbucketSCMFile  extends SCMFile {
@@ -45,13 +46,13 @@ public class BitbucketSCMFile  extends SCMFile {
     }
 
     @Deprecated
-    public BitbucketSCMFile(BitbucketSCMFileSystem bitBucketSCMFileSystem,
+    public BitbucketSCMFile(BitbucketSCMFileSystem bitbucketSCMFileSystem,
                             BitbucketApi api,
                             String ref) {
-        this(bitBucketSCMFileSystem, api, ref, null);
+        this(bitbucketSCMFileSystem, api, ref, null);
     }
 
-    public BitbucketSCMFile(BitbucketSCMFileSystem bitBucketSCMFileSystem,
+    public BitbucketSCMFile(BitbucketSCMFileSystem bitbucketSCMFileSystem,
                             BitbucketApi api,
                             String ref, String hash) {
         super();
@@ -85,7 +86,8 @@ public class BitbucketSCMFile  extends SCMFile {
         if (this.isDirectory()) {
             return api.getDirectoryContent(this);
         } else {
-            throw new IOException("Cannot get children from a regular file");
+            // respect the interface javadoc
+            return Collections.emptyList();
         }
     }
 
@@ -108,7 +110,7 @@ public class BitbucketSCMFile  extends SCMFile {
     @Override
     @NonNull
     protected SCMFile newChild(String name, boolean assumeIsDirectory) {
-        return new BitbucketSCMFile(this, name, assumeIsDirectory?Type.DIRECTORY:Type.REGULAR_FILE, hash);
+        return new BitbucketSCMFile(this, name, assumeIsDirectory ? Type.DIRECTORY : Type.REGULAR_FILE, hash);
     }
 
     @Override

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/filesystem/BitbucketSCMFileSystem.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/filesystem/BitbucketSCMFileSystem.java
@@ -45,7 +45,6 @@ import hudson.Extension;
 import hudson.Util;
 import hudson.model.Item;
 import hudson.model.Queue;
-import hudson.model.queue.Tasks;
 import hudson.scm.SCM;
 import hudson.scm.SCMDescriptor;
 import hudson.security.ACL;
@@ -118,22 +117,24 @@ public class BitbucketSCMFileSystem extends SCMFileSystem {
         }
 
         private static StandardCredentials lookupScanCredentials(@CheckForNull Item context,
-                @CheckForNull String scanCredentialsId, String serverUrl) {
-            if (Util.fixEmpty(scanCredentialsId) == null) {
+                                                                 @CheckForNull String scanCredentialsId,
+                                                                 String serverURL) {
+            scanCredentialsId = Util.fixEmpty(scanCredentialsId);
+            if (scanCredentialsId == null) {
                 return null;
             } else {
                 return CredentialsMatchers.firstOrNull(
-                        CredentialsProvider.lookupCredentials(
+                        CredentialsProvider.lookupCredentialsInItem(
                                 StandardCredentials.class,
                                 context,
-                                context instanceof Queue.Task
-                                        ? Tasks.getDefaultAuthenticationOf((Queue.Task) context)
-                                        : ACL.SYSTEM,
-                                URIRequirementBuilder.fromUri(serverUrl).build()
+                                context instanceof Queue.Task task
+                                        ? task.getDefaultAuthentication2()
+                                        : ACL.SYSTEM2,
+                                URIRequirementBuilder.fromUri(serverURL).build()
                         ),
                         CredentialsMatchers.allOf(
                                 CredentialsMatchers.withId(scanCredentialsId),
-                                AuthenticationTokens.matcher(BitbucketAuthenticator.authenticationContext(serverUrl))
+                                AuthenticationTokens.matcher(BitbucketAuthenticator.authenticationContext(serverURL))
                         )
                 );
             }

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/BitbucketServerAPIClient.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/BitbucketServerAPIClient.java
@@ -952,7 +952,7 @@ public class BitbucketServerAPIClient extends AbstractBitbucketApi implements Bi
     protected HttpHost getHost() {
         String url = baseURL;
         try {
-            // it's really needed?
+            // it's needed because the serverURL can contains a context root different than '/' and the HttpHost must contains only schema, host and port
             URL tmp = new URL(baseURL);
             String schema = tmp.getProtocol() == null ? "http" : tmp.getProtocol();
             return new HttpHost(tmp.getHost(), tmp.getPort(), schema);

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/filesystem/BitbucketSCMFileTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/filesystem/BitbucketSCMFileTest.java
@@ -1,0 +1,27 @@
+package com.cloudbees.jenkins.plugins.bitbucket.filesystem;
+
+import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketApi;
+import com.cloudbees.jenkins.plugins.bitbucket.client.BitbucketIntegrationClientFactory;
+import java.io.FileNotFoundException;
+import jenkins.scm.api.SCMFile.Type;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+
+class BitbucketSCMFileTest {
+
+    @WithJenkins
+    @Issue("JENKINS-75157")
+    @Test
+    void test(JenkinsRule r) {
+        BitbucketApi client = BitbucketIntegrationClientFactory.getApiMockClient("https://acme.bitbucket.com");
+
+        BitbucketSCMFile parent = new BitbucketSCMFile(mock(BitbucketSCMFileSystem.class), client, "ref", "hash");
+        BitbucketSCMFile file = new BitbucketSCMFile(parent, "pipeline_config.groovy", Type.REGULAR_FILE, "046d9a3c1532acf4cf08fe93235c00e4d673c1d2");
+        assertThatThrownBy(file::content).isInstanceOf(FileNotFoundException.class);
+    }
+}


### PR DESCRIPTION
Remove the HttpHost parameter when calling in Apache client as it seems to cause a 404 error in the response while in previous version the call worked.