### PR TITLE
[JENKINS-75160] NO_PROXY configuration seems to be ignored

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/impl/client/AbstractBitbucketApi.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/impl/client/AbstractBitbucketApi.java
@@ -164,17 +164,17 @@ public abstract class AbstractBitbucketApi implements AutoCloseable {
             context = HttpClientContext.create();
             authenticator.configureContext(context, getHost());
         }
-        setClientProxyParams(host, httpClientBuilder);
+        setClientProxyParams(httpClientBuilder);
         return httpClientBuilder;
     }
 
-    private void setClientProxyParams(String host, HttpClientBuilder builder) {
+    protected void setClientProxyParams(HttpClientBuilder builder) {
         Jenkins jenkins = Jenkins.getInstanceOrNull(); // because unit test
         ProxyConfiguration proxyConfig = jenkins != null ? jenkins.proxy : null;
 
         final Proxy proxy;
         if (proxyConfig != null) {
-            proxy = proxyConfig.createProxy(host);
+            proxy = proxyConfig.createProxy(getHost().getHostName());
         } else {
             proxy = Proxy.NO_PROXY;
         }


### PR DESCRIPTION
Fix proxy configuration to be used in the Apache client created from the ProxyConfiguration class using only the hostname instead passing the configured serverURL. The NO_PROXY configuration matches only hostname, that means if the given hostname contains also scheme or port match fails.