### PR TITLE
[JENKINS-75157] Bitbucket client fail to retrieve resource with HTTP 404 for bitbucket server

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,8 +90,6 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>git</artifactId>
-      <!-- TODO: remove when in bom -->
-      <version>5.7.0</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/BitbucketApi.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/BitbucketApi.java
@@ -302,17 +302,30 @@ public interface BitbucketApi extends AutoCloseable {
      * @throws IOException if there was a network communications error.
      * @throws InterruptedException if interrupted while waiting on remote communications.
      */
+    @NonNull
     @Restricted(NoExternalUse.class)
     Iterable<SCMFile> getDirectoryContent(BitbucketSCMFile parent) throws IOException, InterruptedException;
 
     /**
      * Return an input stream for the given file.
      *
-     * @param file and instance of SCM file
+     * @param file an instance of SCM file
      * @return the stream of the given {@link SCMFile}
      * @throws IOException if there was a network communications error.
      * @throws InterruptedException if interrupted while waiting on remote communications.
      */
     @Restricted(NoExternalUse.class)
     InputStream getFileContent(BitbucketSCMFile file) throws IOException, InterruptedException;
+
+    /**
+     * Return the metadata for the given file.
+     *
+     * @param file an instance of SCM file
+     * @return a {@link SCMFile} file with updated the metadata
+     * @throws IOException if there was a network communications error.
+     * @throws InterruptedException if interrupted while waiting on remote communications.
+     */
+    @NonNull
+    @Restricted(NoExternalUse.class)
+    SCMFile getFile(@NonNull BitbucketSCMFile file) throws IOException, InterruptedException;
 }

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/repository/BitbucketRepositorySource.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/repository/BitbucketRepositorySource.java
@@ -28,6 +28,7 @@ import com.cloudbees.jenkins.plugins.bitbucket.filesystem.BitbucketSCMFile;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.List;
 import java.util.Map;
 import jenkins.scm.api.SCMFile;
@@ -68,23 +69,25 @@ public class BitbucketRepositorySource {
 
     @JsonIgnore
     public boolean isDirectory() {
-        return type.equals("commit_directory");
+        return "commit_directory".equals(type);
     }
 
-    public BitbucketSCMFile toBitbucketScmFile(BitbucketSCMFile parent){
+    @NonNull
+    public BitbucketSCMFile toBitbucketSCMFile(BitbucketSCMFile parent) {
         SCMFile.Type fileType;
-        if(isDirectory()){
+        if (isDirectory()) {
             fileType = SCMFile.Type.DIRECTORY;
         } else {
             fileType = SCMFile.Type.REGULAR_FILE;
-            for(String attribute: getAttributes()){
-                if(attribute.equals("link")){
+            for (String attribute : getAttributes()) {
+                if ("link".equals(attribute)) {
                     fileType = SCMFile.Type.LINK;
-                } else if(attribute.equals("subrepository")){
+                } else if ("subrepository".equals(attribute)) {
                     fileType = SCMFile.Type.OTHER; // sub-module or sub-repo
                 }
             }
         }
         return new BitbucketSCMFile(parent, path, fileType, hash);
     }
+
 }

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/filesystem/BitbucketSCMFileTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/filesystem/BitbucketSCMFileTest.java
@@ -1,0 +1,70 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2025, Nikolas Falco
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.cloudbees.jenkins.plugins.bitbucket.filesystem;
+
+import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketApi;
+import com.cloudbees.jenkins.plugins.bitbucket.client.BitbucketIntegrationClientFactory;
+import java.io.FileNotFoundException;
+import jenkins.scm.api.SCMFile;
+import jenkins.scm.api.SCMFile.Type;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@WithJenkins
+class BitbucketSCMFileTest {
+
+    @SuppressWarnings("unused")
+    private static JenkinsRule j;
+
+    @BeforeAll
+    static void init(JenkinsRule rule) {
+        j = rule;
+    }
+
+    @Issue("JENKINS-75157")
+    @Test
+    void verify_content_throws_FileNotFoundException_when_file_does_not_exists() {
+        BitbucketApi client = BitbucketIntegrationClientFactory.getApiMockClient("https://acme.bitbucket.com");
+
+        BitbucketSCMFile parent = new BitbucketSCMFile(client, "master", "hash");
+        BitbucketSCMFile file = new BitbucketSCMFile(parent, "pipeline_config.groovy", Type.REGULAR_FILE, "046d9a3c1532acf4cf08fe93235c00e4d673c1d2");
+        assertThatThrownBy(file::content).isInstanceOf(FileNotFoundException.class);
+    }
+
+    @Issue("JENKINS-75157")
+    @Test
+    void test_SCMBinder_behavior_when_discover_the_Jenkinsfile_for_a_given_branch_on_cloud() throws Exception {
+        BitbucketApi client = BitbucketIntegrationClientFactory.getApiMockClient("https://bitbucket.org");
+
+        BitbucketSCMFile root = new BitbucketSCMFile(client, "feature/BB1", "fb522a6f08c7c7df337312e4e65ec1b57710672e");
+        SCMFile jenkinsfile = root.child("script.bat");
+        assertThat(jenkinsfile.content()).hasContent("@echo off\necho \"Hello world\"");
+    }
+}

--- a/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/client/payload/2.0-repositories-amuniz-test-repos-src-fb522a6f08c7c7df337312e4e65ec1b57710672e-script.bat_at_feature_2FBB1.json
+++ b/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/client/payload/2.0-repositories-amuniz-test-repos-src-fb522a6f08c7c7df337312e4e65ec1b57710672e-script.bat_at_feature_2FBB1.json
@@ -1,0 +1,2 @@
+@echo off
+echo "Hello world"

--- a/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/client/payload/2.0-repositories-amuniz-test-repos-src-fb522a6f08c7c7df337312e4e65ec1b57710672e-script.bat_format_meta.json
+++ b/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/client/payload/2.0-repositories-amuniz-test-repos-src-fb522a6f08c7c7df337312e4e65ec1b57710672e-script.bat_format_meta.json
@@ -1,0 +1,31 @@
+{
+    "path": "script.bat",
+    "commit": {
+        "hash": "fb522a6f08c7c7df337312e4e65ec1b57710672e",
+        "links": {
+            "self": {
+                "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/commit/fb522a6f08c7c7df337312e4e65ec1b57710672e"
+            },
+            "html": {
+                "href": "https://bitbucket.org/amuniz/test-repos/commits/fb522a6f08c7c7df337312e4e65ec1b57710672e"
+            }
+        },
+        "type": "commit"
+    },
+    "type": "commit_file",
+    "attributes": [],
+    "escaped_path": "script.bat",
+    "size": 28,
+    "mimetype": "application/x-msdos-program",
+    "links": {
+        "self": {
+            "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/src/fb522a6f08c7c7df337312e4e65ec1b57710672e/script.bat"
+        },
+        "meta": {
+            "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/src/fb522a6f08c7c7df337312e4e65ec1b57710672e/script.bat?format=meta"
+        },
+        "history": {
+            "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/filehistory/fb522a6f08c7c7df337312e4e65ec1b57710672e/script.bat"
+        }
+    }
+}


### PR DESCRIPTION
Remove the HttpHost parameter when calling in Apache client as the request could be different than the host configured in jenkins, for example in Bitbucket Server request using mirror link.
Rethrow the FileNotFoundException in executeMethod instead of encapsulate into other exception to respect the SCMFile interface. Rewrote the BitbucketSCMFile logic to not assume the SCMFile.type but resolve at runtime when needed.