### PR TITLE
[JENKINS-75184] CredentialsMatcher fail with ECR Security Token

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/impl/credentials/BitbucketUsernamePasswordCredentialMatcher.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/impl/credentials/BitbucketUsernamePasswordCredentialMatcher.java
@@ -51,7 +51,13 @@ public class BitbucketUsernamePasswordCredentialMatcher implements CredentialsMa
 
         UsernamePasswordCredentials usernamePasswordCredential = ((UsernamePasswordCredentials) item);
         String username = usernamePasswordCredential.getUsername();
-        String password = Secret.toString(usernamePasswordCredential.getPassword());
+        String password;
+        try {
+            password = Secret.toString(usernamePasswordCredential.getPassword());
+        } catch (Exception e) {
+            // JENKINS-75184
+            return false;
+        }
         return StringUtils.isNotBlank(username) && StringUtils.isNotBlank(password);
     }
 }


### PR DESCRIPTION
Add a try catch block in CredentialsMatcher implementation when invoke UsernamePasswordCredentials#getPassword method to handle those implementations that perform some operations, like an HTTP call, for which throw an exception.