### PR TITLE
[JENKINS-75225] When configure job the list of credentials returns HTTP 504

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/impl/credentials/BitbucketAccessTokenAuthenticatorSource.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/impl/credentials/BitbucketAccessTokenAuthenticatorSource.java
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
 package com.cloudbees.jenkins.plugins.bitbucket.impl.credentials;
 
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketAuthenticator;

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/impl/credentials/BitbucketAuthenticatorUtils.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/impl/credentials/BitbucketAuthenticatorUtils.java
@@ -1,0 +1,52 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2025, Nikolas Falco
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.cloudbees.jenkins.plugins.bitbucket.impl.credentials;
+
+import com.cloudbees.plugins.credentials.common.UsernamePasswordCredentials;
+import com.google.common.util.concurrent.SimpleTimeLimiter;
+import com.google.common.util.concurrent.TimeLimiter;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.util.Secret;
+import java.time.Duration;
+import java.util.concurrent.Executors;
+
+final class BitbucketAuthenticatorUtils {
+
+    private BitbucketAuthenticatorUtils() {
+    }
+
+    public static String getPassword(@NonNull UsernamePasswordCredentials credentials) throws InterruptedException {
+        TimeLimiter timeLimiter = SimpleTimeLimiter.create(Executors.newSingleThreadExecutor());
+
+        try {
+            // JENKINS-75225
+            return timeLimiter.callWithTimeout(() -> Secret.toString(credentials.getPassword()), Duration.ofMillis(100));
+        } catch (InterruptedException e) {
+            // takes long maybe credentials are not stored in Jenkins and requires some rest call than will fail
+            throw e;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/impl/credentials/BitbucketOAuthCredentialMatcher.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/impl/credentials/BitbucketOAuthCredentialMatcher.java
@@ -27,7 +27,6 @@ package com.cloudbees.jenkins.plugins.bitbucket.impl.credentials;
 import com.cloudbees.plugins.credentials.Credentials;
 import com.cloudbees.plugins.credentials.CredentialsMatcher;
 import com.cloudbees.plugins.credentials.common.UsernamePasswordCredentials;
-import hudson.util.Secret;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -62,7 +61,7 @@ public class BitbucketOAuthCredentialMatcher implements CredentialsMatcher {
             String username = usernamePasswordCredential.getUsername();
             String password;
             try {
-                password = Secret.toString(usernamePasswordCredential.getPassword());
+                password = BitbucketAuthenticatorUtils.getPassword(usernamePasswordCredential);
             } catch (Exception e) {
                 // JENKINS-75184
                 return false;

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/impl/credentials/BitbucketUsernamePasswordCredentialMatcher.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/impl/credentials/BitbucketUsernamePasswordCredentialMatcher.java
@@ -26,7 +26,6 @@ package com.cloudbees.jenkins.plugins.bitbucket.impl.credentials;
 import com.cloudbees.plugins.credentials.Credentials;
 import com.cloudbees.plugins.credentials.CredentialsMatcher;
 import com.cloudbees.plugins.credentials.common.UsernamePasswordCredentials;
-import hudson.util.Secret;
 import org.apache.commons.lang.StringUtils;
 
 // Although the CredentialsMatcher documentation says that the best practice
@@ -53,7 +52,7 @@ public class BitbucketUsernamePasswordCredentialMatcher implements CredentialsMa
         String username = usernamePasswordCredential.getUsername();
         String password;
         try {
-            password = Secret.toString(usernamePasswordCredential.getPassword());
+            password = BitbucketAuthenticatorUtils.getPassword(usernamePasswordCredential);
         } catch (Exception e) {
             // JENKINS-75184
             return false;

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/impl/credentials/BitbucketOAuthCredentialMatcherTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/impl/credentials/BitbucketOAuthCredentialMatcherTest.java
@@ -53,6 +53,12 @@ class BitbucketOAuthCredentialMatcherTest {
         assertThat(sut.matches(new ExceptionalCredentials())).isFalse();
     }
 
+    @Test
+    @Issue("JENKINS-75225")
+    void matches_returns_false_when_getting_password_takes_longer() {
+        assertThat(sut.matches(new TakeLongCredentials())).isFalse();
+    }
+
     @SuppressWarnings("serial")
     private static class ExceptionalCredentials implements UsernamePasswordCredentials {
 
@@ -60,6 +66,38 @@ class BitbucketOAuthCredentialMatcherTest {
         @Override
         public Secret getPassword() {
             throw new IllegalArgumentException("Failed authentication");
+        }
+
+        @NonNull
+        @Override
+        public String getUsername() {
+            return "dummy-username";
+        }
+
+        @Override
+        public CredentialsScope getScope() {
+            return null;
+        }
+
+        @NonNull
+        @Override
+        public CredentialsDescriptor getDescriptor() {
+            return null;
+        }
+    }
+
+    @SuppressWarnings("serial")
+    private static class TakeLongCredentials implements UsernamePasswordCredentials {
+
+        @NonNull
+        @Override
+        public Secret getPassword() {
+            try {
+                Thread.sleep(1000);
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+            return Secret.fromString("password");
         }
 
         @NonNull


### PR DESCRIPTION
Limit the amount of time required to decryipt a password in case of com.cloudbees.jenkins.plugins.amazonecr.AmazonECSRegistryCredential credentials that takes long because perform rest operation to return password from the amazon vault.