### PR TITLE
[JENKINS-75208] Checkout on bitbucket server fail with IllegalArgumentException "Name cannot contain '/'"

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/repository/BitbucketRepositorySource.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/repository/BitbucketRepositorySource.java
@@ -87,7 +87,7 @@ public class BitbucketRepositorySource {
                 }
             }
         }
-        return new BitbucketSCMFile(parent, path, fileType, hash);
+        return parent.child(path, fileType);
     }
 
 }

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/filesystem/BitbucketSCMFile.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/filesystem/BitbucketSCMFile.java
@@ -31,6 +31,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Collections;
 import jenkins.scm.api.SCMFile;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 public class BitbucketSCMFile extends SCMFile {
 
@@ -69,6 +71,11 @@ public class BitbucketSCMFile extends SCMFile {
         return hash;
     }
 
+    @Restricted(NoExternalUse.class)
+    public void setType(Type type) {
+        type(type);
+    }
+
     @Override
     @NonNull
     public Iterable<SCMFile> children() throws IOException, InterruptedException {
@@ -99,6 +106,14 @@ public class BitbucketSCMFile extends SCMFile {
     @NonNull
     protected SCMFile newChild(String name, boolean assumeIsDirectory) {
         return new BitbucketSCMFile(this, name, null, hash);
+    }
+
+    @NonNull
+    public BitbucketSCMFile child(@NonNull String path, @NonNull Type type) {
+        BitbucketSCMFile scmFile = (BitbucketSCMFile) super.child(path);
+        scmFile.type(type);
+        scmFile.resolved = true;
+        return scmFile;
     }
 
     @Override

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/filesystem/BitbucketSCMFileTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/filesystem/BitbucketSCMFileTest.java
@@ -77,6 +77,17 @@ class BitbucketSCMFileTest {
                 });
     }
 
+    @Issue("JENKINS-75208")
+    @Test
+    void test_SCMFile_when_client_return_path_attribute_with_folder_separator_on_cloud() throws Exception {
+        BitbucketApi client = BitbucketIntegrationClientFactory.getApiMockClient("https://bitbucket.org");
+
+        BitbucketSCMFile root = new BitbucketSCMFile(client, "master", null);
+        SCMFile file = root.child("folder/file.properties");
+        String content = file.contentAsString();
+        assertThat(content).isEqualTo("message=This is a test for metadata");
+    }
+
     @Issue("JENKINS-75157")
     @Test
     void test_SCMBinder_behavior_when_discover_the_Jenkinsfile_for_a_given_branch_on_cloud() throws Exception {

--- a/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/client/payload/2.0-repositories-amuniz-test-repos-src-folder_2Ffile.properties_at_master.json
+++ b/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/client/payload/2.0-repositories-amuniz-test-repos-src-folder_2Ffile.properties_at_master.json
@@ -1,0 +1,1 @@
+message=This is a test for metadata

--- a/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/client/payload/2.0-repositories-amuniz-test-repos-src-master-folder_2Ffile.properties_format_meta.json
+++ b/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/client/payload/2.0-repositories-amuniz-test-repos-src-master-folder_2Ffile.properties_format_meta.json
@@ -1,0 +1,31 @@
+{
+    "path": "folder/file.properties",
+    "commit": {
+        "hash": "e43fdffe2def75053da30efa8204d0317a0b932a",
+        "links": {
+            "self": {
+                "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/commit/e43fdffe2def75053da30efa8204d0317a0b932a"
+            },
+            "html": {
+                "href": "https://bitbucket.org/amuniz/test-repos/commits/e43fdffe2def75053da30efa8204d0317a0b932a"
+            }
+        },
+        "type": "commit"
+    },
+    "type": "commit_file",
+    "attributes": [],
+    "escaped_path": "folder/file.properties",
+    "size": 35,
+    "mimetype": null,
+    "links": {
+        "self": {
+            "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/src/e43fdffe2def75053da30efa8204d0317a0b932a/folder/file.properties"
+        },
+        "meta": {
+            "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/src/e43fdffe2def75053da30efa8204d0317a0b932a/folder/file.properties?format=meta"
+        },
+        "history": {
+            "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/filehistory/e43fdffe2def75053da30efa8204d0317a0b932a/folder/file.properties"
+        }
+    }
+}


### PR DESCRIPTION
Fix cloud client when file metadata return a path attribute that contains '/', for example 'scripts/Jenkinsfile'