### PR TITLE
BitbucketTagSCMHead does not receive an annotated tag date

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketTagSCMHead.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketTagSCMHead.java
@@ -38,10 +38,10 @@ public class BitbucketTagSCMHead extends GitTagSCMHead implements TagSCMHead {
     private static final long serialVersionUID = 1L;
 
     /**
-     * Constructor.
+     * Default constructor.
      *
      * @param tagName        the tag name
-     * @param timestamp      the timestamp of tag
+     * @param timestamp      the timestamp of annotated tag or the commit is referring to
      */
     public BitbucketTagSCMHead(@NonNull String tagName, long timestamp) {
         super(tagName, timestamp);

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/filesystem/BitbucketSCMFileSystem.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/filesystem/BitbucketSCMFileSystem.java
@@ -145,8 +145,7 @@ public class BitbucketSCMFileSystem extends SCMFileSystem {
             String owner = src.getRepoOwner();
             String repository = src.getRepository();
             String serverUrl = src.getServerUrl();
-            StandardCredentials credentials;
-            credentials = lookupScanCredentials(src.getOwner(), credentialsId, serverUrl);
+            StandardCredentials credentials = lookupScanCredentials(src.getOwner(), credentialsId, serverUrl);
 
             BitbucketAuthenticator authenticator = AuthenticationTokens.convert(BitbucketAuthenticator.authenticationContext(serverUrl), credentials);
 

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/ServerPushEvent.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/ServerPushEvent.java
@@ -29,11 +29,17 @@ import com.cloudbees.jenkins.plugins.bitbucket.BitbucketTagSCMHead;
 import com.cloudbees.jenkins.plugins.bitbucket.BranchSCMHead;
 import com.cloudbees.jenkins.plugins.bitbucket.PullRequestSCMHead;
 import com.cloudbees.jenkins.plugins.bitbucket.PullRequestSCMRevision;
+import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketApi;
+import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketApiFactory;
+import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketAuthenticator;
+import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketCommit;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketPullRequest;
+import com.cloudbees.jenkins.plugins.bitbucket.impl.util.BitbucketCredentials;
 import com.cloudbees.jenkins.plugins.bitbucket.server.client.BitbucketServerAPIClient;
 import com.cloudbees.jenkins.plugins.bitbucket.server.client.pullrequest.BitbucketServerPullRequest;
 import com.cloudbees.jenkins.plugins.bitbucket.server.client.repository.BitbucketServerRepository;
 import com.cloudbees.jenkins.plugins.bitbucket.server.events.NativeServerChange;
+import com.cloudbees.plugins.credentials.common.StandardCredentials;
 import com.google.common.base.Ascii;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -48,6 +54,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import jenkins.authentication.tokens.api.AuthenticationTokens;
 import jenkins.plugins.git.AbstractGitSCMSource;
 import jenkins.scm.api.SCMEvent;
 import jenkins.scm.api.SCMHead;
@@ -138,7 +145,19 @@ final class ServerPushEvent extends AbstractNativeServerSCMHeadEvent<Collection<
                         : new AbstractGitSCMSource.SCMRevisionImpl(head, change.getToHash());
                 result.put(head, revision);
             } else if ("TAG".equals(refType)) {
-                SCMHead head = new BitbucketTagSCMHead(change.getRef().getDisplayId(), 0);
+                String tagName = change.getRef().getDisplayId();
+                // FIXME slow workaround until a real example of server tag payload has been provided
+                // I expect in the payload there is also the referred commit.
+                long tagTimestamp;
+                try (BitbucketApi client = getClient(src)) {
+//                    BitbucketBranch tag = client.getTag(tagName); // requires two API call and does not return the tag timestamp
+                    BitbucketCommit tag = client.resolveCommit(change.getFromHash());
+                    tagTimestamp = tag != null ? tag.getDateMillis() : 0;
+                } catch (InterruptedException | IOException e) {
+                    LOGGER.log(Level.SEVERE, "Fail to retrive the timestamp for tag event {0}", tagName);
+                    tagTimestamp = 0;
+                }
+                SCMHead head = new BitbucketTagSCMHead(tagName, tagTimestamp);
                 final SCMRevision revision = getType() == SCMEvent.Type.REMOVED ? null
                         : new AbstractGitSCMSource.SCMRevisionImpl(head, change.getToHash());
                 result.put(head, revision);
@@ -147,6 +166,19 @@ final class ServerPushEvent extends AbstractNativeServerSCMHeadEvent<Collection<
                         new Object[] { change.getRef().getType(), change.getRef().getDisplayId() });
             }
         }
+    }
+
+    protected BitbucketApi getClient(BitbucketSCMSource src) {
+        String serverURL = src.getServerUrl();
+
+        StandardCredentials credentials = BitbucketCredentials.lookupCredentials(
+            serverURL,
+            src.getOwner(),
+            src.getCredentialsId(),
+            StandardCredentials.class
+        );
+        BitbucketAuthenticator authenticator = AuthenticationTokens.convert(BitbucketAuthenticator.authenticationContext(serverURL), credentials);
+        return BitbucketApiFactory.newInstance(serverURL, authenticator, src.getRepoOwner(), null, src.getRepository());
     }
 
     private void addPullRequests(BitbucketSCMSource src, Map<SCMHead, SCMRevision> result) throws InterruptedException {

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/client/BitbucketIntegrationClientFactory.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/client/BitbucketIntegrationClientFactory.java
@@ -26,6 +26,7 @@ package com.cloudbees.jenkins.plugins.bitbucket.client;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketApi;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketAuthenticator;
 import com.cloudbees.jenkins.plugins.bitbucket.impl.util.BitbucketApiUtils;
+import com.cloudbees.jenkins.plugins.bitbucket.server.BitbucketServerWebhookImplementation;
 import com.cloudbees.jenkins.plugins.bitbucket.server.client.BitbucketServerAPIClient;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -91,7 +92,7 @@ public class BitbucketIntegrationClientFactory {
         private final IRequestAudit audit;
 
         private BitbucketServerIntegrationClient(String payloadRootPath, String baseURL, String owner, String repositoryName) {
-            super(baseURL, owner, repositoryName, mock(BitbucketAuthenticator.class), false);
+            super(baseURL, owner, repositoryName, mock(BitbucketAuthenticator.class), false, BitbucketServerWebhookImplementation.NATIVE);
 
             if (payloadRootPath == null) {
                 this.payloadRootPath = PAYLOAD_RESOURCE_ROOTPATH;

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/filesystem/BitbucketSCMFileTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/filesystem/BitbucketSCMFileTest.java
@@ -28,26 +28,18 @@ import com.cloudbees.jenkins.plugins.bitbucket.client.BitbucketIntegrationClient
 import java.io.FileNotFoundException;
 import jenkins.scm.api.SCMFile;
 import jenkins.scm.api.SCMFile.Type;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
-import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
-@WithJenkins
 class BitbucketSCMFileTest {
 
     @SuppressWarnings("unused")
     private static JenkinsRule j;
-
-    @BeforeAll
-    static void init(JenkinsRule rule) {
-        j = rule;
-    }
 
     @Issue("JENKINS-75157")
     @Test

--- a/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/hooks/native/tagPayload.json
+++ b/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/hooks/native/tagPayload.json
@@ -1,0 +1,126 @@
+{
+  "actor": {
+    "active": true,
+    "displayName": "Antonio Muniz",
+    "emailAddress": "amuniz@acme.com",
+    "id": 2,
+    "links": {
+      "self": [
+        {
+          "href": "http://localhost:7990/users/amuniz"
+        }
+      ]
+    },
+    "name": "amuniz",
+    "slug": "amuniz",
+    "type": "NORMAL"
+  },
+  "changes": [
+    {
+      "fromHash": "fb522a6f08c7c7df337312e4e65ec1b57710672e",
+      "ref": {
+        "displayId": "v0.0.0",
+        "id": "refs/tags/v0.0.0",
+        "type": "TAG"
+      },
+      "refId": "refs/heads/main",
+      "toHash": "ad64eb8f05364f825e8557a7a672cc576baffb9a",
+      "type": "ADD"
+    }
+  ],
+  "commits": [
+    {
+      "author": {
+        "active": true,
+        "displayName": "Antonio Muniz",
+        "emailAddress": "amuniz@acme.com",
+        "id": 2,
+        "links": {
+          "self": [
+            {
+              "href": "http://localhost:7990/users/amuniz"
+            }
+          ]
+        },
+        "name": "amuniz",
+        "slug": "amuniz",
+        "type": "NORMAL"
+      },
+      "authorTimestamp": 1537538991000,
+      "committer": {
+        "active": true,
+        "displayName": "Antonio Muniz",
+        "emailAddress": "amuniz@acme.com",
+        "id": 2,
+        "links": {
+          "self": [
+            {
+              "href": "http://localhost:7990/users/amuniz"
+            }
+          ]
+        },
+        "name": "amuniz",
+        "slug": "amuniz",
+        "type": "NORMAL"
+      },
+      "committerTimestamp": 1537538991000,
+      "displayId": "9fdd7b96d3f",
+      "id": "9fdd7b96d3f5c276d0b9e0bf38c879eb112d889a",
+      "message": "source-2: Wed 13 Nov 2024 21:54:36 AEST",
+      "parents": [
+        {
+          "displayId": "ae995d7a370",
+          "id": "ae995d7a37069d0988462a9c92828971e8a42b5d"
+        }
+      ]
+    }
+  ],
+  "date": "2024-11-27T01:34:45+0000",
+  "eventKey": "repo:refs_changed",
+  "repository": {
+    "archived": false,
+    "forkable": true,
+    "hierarchyId": "050ab73089457a2ae375",
+    "id": 1,
+    "links": {
+      "clone": [
+        {
+          "href": "ssh://git@localhost:7999/amuniz/test-repos.git",
+          "name": "ssh"
+        },
+        {
+          "href": "http://localhost:7990/scm/amuniz/test-repos.git",
+          "name": "http"
+        }
+      ],
+      "self": [
+        {
+          "href": "http://localhost:7990/projects/AMUNIZ/repos/test-repos/browse"
+        }
+      ]
+    },
+    "name": "test-repos",
+    "project": {
+      "id": 1,
+      "key": "AMUNIZ",
+      "links": {
+        "self": [
+          {
+            "href": "http://localhost:7990/projects/AMUNIZ"
+          }
+        ]
+      },
+      "name": "prj",
+      "public": false,
+      "type": "NORMAL"
+    },
+    "public": false,
+    "scmId": "git",
+    "slug": "test-repos",
+    "state": "AVAILABLE",
+    "statusMessage": "Available"
+  },
+  "toCommit": {
+    "_comment": "NOT real payload!"
+  }
+}


### PR DESCRIPTION
Fix the timestamp in BitbucketTagSCMHead valued with 0 in NativeServer webhook processor instead of the annotated tag timestamp or using the referred commit timestamp.

This is archived perforing a remote call to get missing details in the event payload, unfortunately there are no real example to implement a different strategy.

Fix #642 