### PR TITLE
[JENKINS-72780] The key value for the build notification is an UUID which couldn't be filter in required build feature of Bitbucket

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketBuildStatusNotificationsTrait.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketBuildStatusNotificationsTrait.java
@@ -44,6 +44,7 @@ public class BitbucketBuildStatusNotificationsTrait extends SCMSourceTrait {
     private boolean sendSuccessNotificationForUnstableBuild;
     private boolean sendStoppedNotificationForAbortBuild;
     private boolean disableNotificationForNotBuildJobs;
+    private boolean useReadableNotificationIds = false;
     // seems that this attribute as been moved out to plugin skip-notifications-trait-plugin
     @SuppressFBWarnings("UUF_UNUSED_FIELD")
     private transient boolean disableNotifications;
@@ -110,14 +111,30 @@ public class BitbucketBuildStatusNotificationsTrait extends SCMSourceTrait {
     }
 
     /**
+     * Use a readable id as key for the build notification status.
+     *
+     * @return if will not hash the generated key of the build notification
+     *         status.
+     */
+    public boolean getUseReadableNotificationIds() {
+        return useReadableNotificationIds;
+    }
+
+    @DataBoundSetter
+    public void setUseReadableNotificationIds(boolean useReadableNotificationIds) {
+        this.useReadableNotificationIds = useReadableNotificationIds;
+    }
+
+    /**
      * {@inheritDoc}
      */
     @Override
     protected void decorateContext(SCMSourceContext<?, ?> context) {
         if (context instanceof BitbucketSCMSourceContext scmContext) {
-            scmContext.withSendStopNotificationForNotBuildJobs(getDisableNotificationForNotBuildJobs());
-            scmContext.withSendSuccessNotificationForUnstableBuild(getSendSuccessNotificationForUnstableBuild());
-            scmContext.withSendStoppedNotificationForAbortBuild(getSendStoppedNotificationForAbortBuild());
+            scmContext.withSendStopNotificationForNotBuildJobs(getDisableNotificationForNotBuildJobs())
+                .withSendSuccessNotificationForUnstableBuild(getSendSuccessNotificationForUnstableBuild())
+                .withSendStoppedNotificationForAbortBuild(getSendStoppedNotificationForAbortBuild())
+                .withUseReadableNotificationIds(getUseReadableNotificationIds());
         }
     }
 

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSourceContext.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSourceContext.java
@@ -103,6 +103,11 @@ public class BitbucketSCMSourceContext extends SCMSourceContext<BitbucketSCMSour
     private boolean sendStopNotificationForNotBuildJobs;
 
     /**
+     * {@code false} will not hash the generated key of the build notification status.
+     */
+    private boolean useReadableNotificationIds;
+
+    /**
      * Constructor.
      *
      * @param criteria (optional) criteria.
@@ -241,6 +246,10 @@ public class BitbucketSCMSourceContext extends SCMSourceContext<BitbucketSCMSour
      */
     public boolean sendStopNotificationForNotBuildJobs() {
         return sendStopNotificationForNotBuildJobs;
+    }
+
+    public boolean useReadableNotificationIds() {
+        return useReadableNotificationIds;
     }
 
     /**
@@ -404,6 +413,11 @@ public class BitbucketSCMSourceContext extends SCMSourceContext<BitbucketSCMSour
         return this;
     }
 
+    public final BitbucketSCMSourceContext withUseReadableNotificationIds(boolean useReadableNotificationIds) {
+        this.useReadableNotificationIds = useReadableNotificationIds;
+        return this;
+    }
+
     /**
      * {@inheritDoc}
      */
@@ -412,4 +426,5 @@ public class BitbucketSCMSourceContext extends SCMSourceContext<BitbucketSCMSour
     public BitbucketSCMSourceRequest newRequest(@NonNull SCMSource scmSource, TaskListener taskListener) {
         return new BitbucketSCMSourceRequest((BitbucketSCMSource) scmSource, this, taskListener);
     }
+
 }

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/BitbucketBuildStatus.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/BitbucketBuildStatus.java
@@ -26,7 +26,6 @@ package com.cloudbees.jenkins.plugins.bitbucket.api;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
-import org.apache.commons.codec.digest.DigestUtils;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.DoNotUse;
 
@@ -118,7 +117,7 @@ public class BitbucketBuildStatus {
         this.description = description;
         this.state = state;
         this.url = url;
-        this.key = DigestUtils.md5Hex(key);
+        this.key = key;
         this.name = name;
         this.refname = refname;
     }
@@ -176,7 +175,7 @@ public class BitbucketBuildStatus {
     }
 
     public void setKey(String key) {
-        this.key = DigestUtils.md5Hex(key);
+        this.key = key;
     }
 
     public String getName() {

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/BitbucketCloudApiClient.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/BitbucketCloudApiClient.java
@@ -84,6 +84,7 @@ import org.apache.http.message.BasicNameValuePair;
 
 import static java.util.concurrent.TimeUnit.HOURS;
 import static java.util.concurrent.TimeUnit.MINUTES;
+import static org.apache.commons.lang.StringUtils.abbreviate;
 
 public class BitbucketCloudApiClient extends AbstractBitbucketApi implements BitbucketApi {
 
@@ -610,7 +611,7 @@ public class BitbucketCloudApiClient extends AbstractBitbucketApi implements Bit
     @Override
     public void postBuildStatus(@NonNull BitbucketBuildStatus status) throws IOException, InterruptedException {
         BitbucketBuildStatus newStatus = new BitbucketBuildStatus(status);
-        newStatus.setName(truncateMiddle(newStatus.getName(), 255));
+        newStatus.setName(abbreviate(newStatus.getName(), 255));
 
         String url = UriTemplate.fromTemplate(REPO_URL_TEMPLATE + "/commit/{hash}/statuses/build")
                 .set("owner", owner)

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/impl/client/AbstractBitbucketApi.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/impl/client/AbstractBitbucketApi.java
@@ -84,16 +84,6 @@ public abstract class AbstractBitbucketApi implements AutoCloseable {
         this.authenticator = authenticator;
     }
 
-    protected String truncateMiddle(@CheckForNull String value, int maxLength) {
-        int length = StringUtils.length(value);
-        if (length > maxLength) {
-            int halfLength = (maxLength - 3) / 2;
-            return StringUtils.left(value, halfLength) + "..." + StringUtils.substring(value, -halfLength);
-        } else {
-            return value;
-        }
-    }
-
     protected BitbucketRequestException buildResponseException(CloseableHttpResponse response, String errorMessage) {
         String headers = StringUtils.join(response.getAllHeaders(), "\n");
         String message = String.format("HTTP request error.%nStatus: %s%nResponse: %s%n%s", response.getStatusLine(), errorMessage, headers);

--- a/src/main/resources/com/cloudbees/jenkins/plugins/bitbucket/BitbucketBuildStatusNotificationsTrait/config.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/bitbucket/BitbucketBuildStatusNotificationsTrait/config.jelly
@@ -1,12 +1,15 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
-  <f:entry title="${%Communicate unstable builds to Bitbucket as successful}" field="sendSuccessNotificationForUnstableBuild">
-    <f:checkbox/>
-  </f:entry>
-  <f:entry title="${%Communicate not-built jobs to Bitbucket as stopped}" field="disableNotificationForNotBuildJobs">
-    <f:checkbox/>
-  </f:entry>
-  <f:entry title="${%Communicate abort build to Bitbucket as stopped}" field="sendStoppedNotificationForAbortBuild">
-    <f:checkbox/>
-  </f:entry>
+    <f:entry title="${%Communicate unstable builds to Bitbucket as successful}" field="sendSuccessNotificationForUnstableBuild">
+        <f:checkbox />
+    </f:entry>
+    <f:entry title="${%Communicate not-built jobs to Bitbucket as stopped}" field="disableNotificationForNotBuildJobs">
+        <f:checkbox />
+    </f:entry>
+    <f:entry title="${%Communicate abort build to Bitbucket as stopped}" field="sendStoppedNotificationForAbortBuild">
+        <f:checkbox />
+    </f:entry>
+    <f:entry title="${%Do not hash the build status notification key}" field="useReadableNotificationIds">
+        <f:checkbox />
+    </f:entry>
 </j:jelly>

--- a/src/main/resources/com/cloudbees/jenkins/plugins/bitbucket/BitbucketBuildStatusNotificationsTrait/help-useReadableNotificationIds.html
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/bitbucket/BitbucketBuildStatusNotificationsTrait/help-useReadableNotificationIds.html
@@ -1,0 +1,8 @@
+<div>
+    By enabling this feature, the key used to send a build notification status is not hashed. This allow filtering
+    in Bitbucket Data Center (only) for <a href="https://confluence.atlassian.com/bitbucketserver/checks-for-merging-pull-requests-776640039.html">
+    Required builds merge check</a>.
+    <p>
+    Please note that changing this value will cause all build-time commits (e.g. pull requests) to have a duplicate build notification status due to the key change.
+    </p>
+</div>

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/client/BitbucketCloudApiClientTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/client/BitbucketCloudApiClientTest.java
@@ -82,6 +82,7 @@ class BitbucketCloudApiClientTest {
         status.setName(RandomStringUtils.randomAlphanumeric(300));
         status.setState(Status.INPROGRESS);
         status.setHash("046d9a3c1532acf4cf08fe93235c00e4d673c1d3");
+        status.setKey("PRJ/REPO");
 
         client.postBuildStatus(status);
 


### PR DESCRIPTION
Add an option in the build status notifications trait to use as id of the notification an human readable format so it is possible configure a filter in the Bitbucket server as described in https://confluence.atlassian.com/bitbucketserver/checks-for-merging-pull-requests-776640039.html

[X] rename hashNotificationIds to useReadableIds
[X] add documentation in the help file (add a note when you change current setting that current notifications will be doubled)
[X] add test cases
[X] force notification id to be upper or lowercase so it not subject to the owner name cases
[X] verify the max key length and strategy to reduce it