### PR TITLE
fix: bitbucket service pull request build status from different source

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/impl/notifier/BitbucketBuildStatusNotifications.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/impl/notifier/BitbucketBuildStatusNotifications.java
@@ -225,22 +225,25 @@ public final class BitbucketBuildStatusNotifications {
             listener.getLogger().println("[Bitbucket] Notifying pull request build result");
             PullRequestSCMHead head = (PullRequestSCMHead) rev.getHead();
             key = getBuildKey(build, head.getOriginName(), shareBuildKeyBetweenBranchAndPR);
-            /*
-             * Poor documentation for bitbucket cloud at:
-             * https://community.atlassian.com/t5/Bitbucket-questions/Re-Builds-not-appearing-in-pull-requests/qaq-p/1805991/comment-id/65864#M65864
-             * that means refName null or valued with only head.getBranchName()
-             *
-             * For Bitbucket Server, refName should be "refs/heads/" + the name
-             * of the source branch of the pull request, and the build status
-             * should be posted to the repository that contains that branch.
-             * If refName is null, then Bitbucket Server does not show the
-             * build status in the list of pull requests, but still shows it
-             * on the web page of the individual pull request.
-             */
-            bitbucket = source.buildBitbucketClient(head);
-            if (BitbucketApiUtils.isCloud(bitbucket)) {
+            if (BitbucketApiUtils.isCloud(source.getServerUrl())) {
+                /*
+                 * Poor documentation for bitbucket cloud at:
+                 * https://community.atlassian.com/t5/Bitbucket-questions/Re-Builds-not-appearing-in-pull-requests/qaq-p/1805991/comment-id/65864#M65864
+                 * that means refName null or valued with only head.getBranchName()
+                 */
+                bitbucket = source.buildBitbucketClient(head);
                 refName = null;
             } else {
+                // For  Bitbucket Server, notify the target of the PR. Head may point to a forked source repo that the
+                // credentials don't have access to resulting in a 401 error.
+                bitbucket = source.buildBitbucketClient();
+                // For Bitbucket Server, refName should be "refs/heads/" + the name
+                // of the source branch of the pull request, and the build status
+                // should be posted to the repository of the pull request target.
+                // If refName is null, then Bitbucket Server shows the build status
+                // for all pull requests for the commit id. When refName is provided
+                // the build status is only shown for the pull request that matches
+                // the refName and commit id.
                 refName = "refs/heads/" + head.getBranchName();
             }
         } else {


### PR DESCRIPTION
The commit 7ac886d switched to the newer repository commit build status api. This introduced a regression in the case the PR source repository is not the same as the target, for example a person fork. In this case the bitbucket api created from the PR head will point to the fork repo and may result in a 401 error if the credentials don't have the necessary permissions.

```
ERROR: Could not send notifications
com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketRequestException: HTTP request error.
Status: HTTP/1.1 401
Response: {"errors":[{"context":null,"message":"You are not permitted to access this resource","exceptionName":"com.atlassian.bitbucket.AuthorisationException"}]}
```

This change will force the bitbucket api instance to be the target repo which is the appropriate target for the notification. The old api was commit hash centric, not project centric, so the api client owner/repo didn't matter.

This change also reverts some changes introduced by #954 to the refName parameter. While local testing has shown that by changing the bitbucket client to point to the target repo, setting the refName to null works in all cases, this change has been restricted to only cases when the source repo is the same as the target.

No changes were made to the Bitbucket Cloud code path.


### Your checklist for this pull request

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Did you provide a test-case? That demonstrates feature works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled the information below
Describe your pull request below
-->
