### PR TITLE
[JENKINS-75203] Include parent in build status notification

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/BitbucketBuildStatus.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/BitbucketBuildStatus.java
@@ -82,6 +82,11 @@ public class BitbucketBuildStatus {
     private String key;
 
     /**
+     * The parent key
+     */
+    private String parent;
+
+    /**
      * A short name, usually #job-name, #build-number (will be shown as link
      * text in BB UI)
      */
@@ -136,6 +141,7 @@ public class BitbucketBuildStatus {
         this.name = other.name;
         this.refname = other.refname;
         this.buildDuration = other.buildDuration;
+        this.parent = other.parent;
     }
 
     public String getHash() {
@@ -210,4 +216,11 @@ public class BitbucketBuildStatus {
         this.buildNumber = buildNumber;
     }
 
+    public void setParent(String parent) {
+        this.parent = parent;
+    }
+
+    public String getParent() {
+        return parent;
+    }
 }

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/impl/notifier/BitbucketBuildStatusNotifications.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/impl/notifier/BitbucketBuildStatusNotifications.java
@@ -177,12 +177,15 @@ public final class BitbucketBuildStatusNotifications {
         if (state != null) {
             BitbucketDefaulNotifier notifier = new BitbucketDefaulNotifier(client);
             String notificationKey = DigestUtils.md5Hex(key);
+            String notificationParentKey = null;
             if (context.useReadableNotificationIds() && !isCloud) {
                 notificationKey = key.replace(' ', '_').toUpperCase();
+                notificationParentKey = getBuildParentKey(build).replace(' ', '_').toUpperCase();
             }
             BitbucketBuildStatus buildStatus = new BitbucketBuildStatus(hash, statusDescription, state, url, notificationKey, name, refName);
             buildStatus.setBuildDuration(build.getDuration());
             buildStatus.setBuildNumber(build.getNumber());
+            buildStatus.setParent(notificationParentKey);
             // TODO testResults should be provided by an extension point that integrates JUnit or anything else plugin
             notifier.notifyBuildStatus(buildStatus);
             if (result != null) {
@@ -294,6 +297,10 @@ public final class BitbucketBuildStatusNotifications {
         }
 
         return key;
+    }
+
+    private static String getBuildParentKey(@NonNull Run<?, ?> build) {
+        return build.getParent().getParent().getFullName();
     }
 
     /**


### PR DESCRIPTION
Include parent key into build status notification to be abler to use the required build feature in bitbucket

The parent key is calculated from the parent of the build.

https://issues.jenkins.io/browse/JENKINS-75203

### Your checklist for this pull request

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Did you provide a test-case? That demonstrates feature works or fixes the issue.
