### PR TITLE
[JENKINS-75410] extends AbstractGitSCMSource for BitbucketSCMSource 

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketGitSCMHelper.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketGitSCMHelper.java
@@ -1,0 +1,78 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016-2017, CloudBees, Inc., Nikolas Falco
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.cloudbees.jenkins.plugins.bitbucket;
+
+import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketHref;
+import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketRepositoryProtocol;
+import com.cloudbees.jenkins.plugins.bitbucket.impl.util.BitbucketCredentials;
+import com.cloudbees.jenkins.plugins.sshcredentials.SSHUserPrivateKey;
+import com.cloudbees.plugins.credentials.common.StandardCredentials;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Util;
+import java.util.List;
+import org.apache.commons.lang.StringUtils;
+
+public class BitbucketGitSCMHelper {
+    protected static String getCloneLink(@NonNull BitbucketSCMSource scmSource,
+                                         @CheckForNull List<BitbucketHref> primaryCloneLinks,
+                                         @CheckForNull List<BitbucketHref> mirrorCloneLinks) {
+        if (primaryCloneLinks == null) {
+            throw new IllegalArgumentException("Primary clone links shouldn't be null");
+        }
+        mirrorCloneLinks = Util.fixNull(mirrorCloneLinks);
+        if (mirrorCloneLinks.isEmpty()) {
+            return getCloneLink(scmSource, mirrorCloneLinks);
+        }
+        return getCloneLink(scmSource, primaryCloneLinks);
+    }
+
+    private static String getCloneLink(BitbucketSCMSource scmSource, List<BitbucketHref> cloneLinks) {
+        BitbucketRepositoryProtocol protocol = getProtocol(scmSource);
+        return cloneLinks.stream()
+                .filter(link -> protocol.matches(link.getName()))
+                .findAny()
+                .orElseThrow(
+                        () -> new IllegalStateException("Can't find clone link for protocol " + protocol))
+                .getHref();
+    }
+
+    private static BitbucketRepositoryProtocol getProtocol(BitbucketSCMSource scmSource) {
+        String credentialsId = scmSource.getCredentialsId();
+        if (StringUtils.isNotBlank(credentialsId)) {
+            StandardCredentials credentials = BitbucketCredentials.lookupCredentials(
+                    scmSource.getServerUrl(),
+                    scmSource.getOwner(),
+                    BitbucketSCMSource.DescriptorImpl.SAME.equals(
+                            scmSource.getCheckoutCredentialsId()) ? credentialsId :
+                            scmSource.getCheckoutCredentialsId(),
+                    StandardCredentials.class
+            );
+            if (credentials instanceof SSHUserPrivateKey) {
+                return BitbucketRepositoryProtocol.SSH;
+            }
+        }
+        return BitbucketRepositoryProtocol.HTTP;
+    }
+}

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource.java
@@ -96,6 +96,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import jenkins.authentication.tokens.api.AuthenticationTokens;
 import jenkins.model.Jenkins;
+import jenkins.plugins.git.AbstractGitSCMSource;
 import jenkins.plugins.git.GitTagSCMHead;
 import jenkins.plugins.git.traits.GitBrowserSCMSourceTrait;
 import jenkins.scm.api.SCMHead;
@@ -104,7 +105,6 @@ import jenkins.scm.api.SCMHeadEvent;
 import jenkins.scm.api.SCMHeadObserver;
 import jenkins.scm.api.SCMHeadOrigin;
 import jenkins.scm.api.SCMRevision;
-import jenkins.scm.api.SCMSource;
 import jenkins.scm.api.SCMSourceCriteria;
 import jenkins.scm.api.SCMSourceCriteria.Probe;
 import jenkins.scm.api.SCMSourceDescriptor;
@@ -145,7 +145,7 @@ import static com.cloudbees.jenkins.plugins.bitbucket.impl.util.BitbucketApiUtil
  * It provides a way to discover/retrieve branches and pull requests through the Bitbucket REST API
  * which is much faster than the plain Git SCM source implementation.
  */
-public class BitbucketSCMSource extends SCMSource {
+public class BitbucketSCMSource extends AbstractGitSCMSource {
 
     private static final Logger LOGGER = Logger.getLogger(BitbucketSCMSource.class.getName());
     private static final String CLOUD_REPO_TEMPLATE = "{/owner,repo}";
@@ -333,6 +333,12 @@ public class BitbucketSCMSource extends SCMSource {
     @CheckForNull
     public String getCredentialsId() {
         return credentialsId;
+    }
+
+    @Override
+    public String getRemote() {
+        initCloneLinks();
+        return BitbucketGitSCMHelper.getCloneLink(this,  primaryCloneLinks, mirrorCloneLinks);
     }
 
     @DataBoundSetter


### PR DESCRIPTION
Change BitbucketSCMSource extended class to AbstractGitSCMSource to be fully compatible with Pipeline: Multibranch build strategy extension.
Otherwise the srategy extension plugin throws an exception when trying to get the changeset to apply the strategy defined in the job.

### Your checklist for this pull request

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Did you provide a test-case? That demonstrates feature works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled the information below
Describe your pull request below
-->
