### PR TITLE
[JENKINS-75082] Include test results in build status notification

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,6 +102,11 @@
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>display-url-api</artifactId>
         </dependency>
+      <dependency>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>junit</artifactId>
+        <optional>true</optional>
+      </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>branch-api</artifactId>

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/BitbucketBuildStatus.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/BitbucketBuildStatus.java
@@ -56,6 +56,50 @@ public class BitbucketBuildStatus {
     }
 
     /**
+     * A summary of the passed, failed and skipped tests
+     */
+    public static class TestResults {
+
+        private int successful;
+        private int failed;
+        private int skipped;
+
+        @Restricted(DoNotUse.class)
+        public TestResults() {
+        }
+
+        public TestResults(int successful, int failed, int skipped) {
+            this.successful = successful;
+            this.failed = failed;
+            this.skipped = skipped;
+        }
+
+        public int getSuccessful() {
+            return successful;
+        }
+
+        public void setSuccessful(int successful) {
+            this.successful = successful;
+        }
+
+        public int getFailed() {
+            return failed;
+        }
+
+        public void setFailed(int failed) {
+            this.failed = failed;
+        }
+
+        public int getSkipped() {
+            return skipped;
+        }
+
+        public void setSkipped(int skipped) {
+            this.skipped = skipped;
+        }
+    }
+
+    /**
      * The commit hash to set the status on
      */
     @JsonIgnore
@@ -107,6 +151,11 @@ public class BitbucketBuildStatus {
      */
     private int buildNumber;
 
+    /**
+     * A summary of the test results.
+     */
+    private TestResults testResults;
+
     // Used for marshalling/unmarshalling
     @Restricted(DoNotUse.class)
     public BitbucketBuildStatus() {}
@@ -142,6 +191,9 @@ public class BitbucketBuildStatus {
         this.refname = other.refname;
         this.buildDuration = other.buildDuration;
         this.parent = other.parent;
+        if(other.testResults != null) {
+            this.testResults = new TestResults(other.testResults.failed, other.testResults.successful, other.testResults.skipped);
+        }
     }
 
     public String getHash() {
@@ -222,5 +274,13 @@ public class BitbucketBuildStatus {
 
     public String getParent() {
         return parent;
+    }
+
+    public TestResults getTestResults() {
+        return testResults;
+    }
+
+    public void setTestResults(TestResults testResults) {
+        this.testResults = testResults;
     }
 }

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/impl/notifier/BitbucketBuildStatusNotifications.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/impl/notifier/BitbucketBuildStatusNotifications.java
@@ -186,7 +186,9 @@ public final class BitbucketBuildStatusNotifications {
             buildStatus.setBuildDuration(build.getDuration());
             buildStatus.setBuildNumber(build.getNumber());
             buildStatus.setParent(notificationParentKey);
-            // TODO testResults should be provided by an extension point that integrates JUnit or anything else plugin
+            if(!isCloud) {
+                buildStatus.setTestResults(TestResultsAdapter.getTestResults(build));
+            }
             notifier.notifyBuildStatus(buildStatus);
             if (result != null) {
                 listener.getLogger().println("[Bitbucket] Build result notified");

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/impl/notifier/TestResultsAdapter.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/impl/notifier/TestResultsAdapter.java
@@ -1,0 +1,84 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2025, ugrave.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.cloudbees.jenkins.plugins.bitbucket.impl.notifier;
+
+import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketBuildStatus.TestResults;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import hudson.model.Run;
+import hudson.tasks.test.AbstractTestResultAction;
+import java.util.List;
+
+class TestResultsAdapter {
+
+    private static final boolean JUNIT_PLUGIN_INSTALLED = isJUnitPluginInstalled();
+
+    static @Nullable TestResults getTestResults(@NonNull Run<?, ?> build) {
+        return JUNIT_PLUGIN_INSTALLED ? getTestResultsFromBuildAction(build) : null;
+    }
+
+    private static @Nullable TestResults getTestResultsFromBuildAction(@NonNull Run<?, ?> build) {
+        List<AbstractTestResultAction> testResultActions = build.getActions(AbstractTestResultAction.class);
+        if (testResultActions.isEmpty()) {
+            return null;
+        }
+        return testResultActions.stream()
+            .collect(TestResultSummary::new, TestResultSummary::accept, TestResultSummary::combine)
+            .getTestResults();
+    }
+
+    private static boolean isJUnitPluginInstalled() {
+        try {
+            Class.forName("hudson.tasks.test.AbstractTestResultAction");
+            return true;
+        } catch (ClassNotFoundException e) {
+            return false;
+        }
+    }
+
+    private static class TestResultSummary {
+
+        private int totalCount;
+        private int failCount;
+        private int skipCount;
+
+        void accept(@NonNull AbstractTestResultAction<?> value) {
+            totalCount += value.getTotalCount();
+            failCount += value.getFailCount();
+            skipCount += value.getSkipCount();
+        }
+
+        void combine(@NonNull TestResultSummary other) {
+            totalCount += other.totalCount;
+            failCount += other.failCount;
+            skipCount += other.skipCount;
+        }
+
+        @NonNull
+        TestResults getTestResults() {
+            return new TestResults( totalCount - failCount - skipCount, failCount, skipCount);
+        }
+    }
+
+}

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/impl/notifier/TestResultsAdapterTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/impl/notifier/TestResultsAdapterTest.java
@@ -1,0 +1,96 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2025, ugrave.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.cloudbees.jenkins.plugins.bitbucket.impl.notifier;
+
+import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketBuildStatus.TestResults;
+import hudson.model.Run;
+import hudson.tasks.test.AbstractTestResultAction;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TestResultsAdapterTest {
+
+    @Test
+    void shouldReturnNullIfNoTestResultAvailable() {
+        Run<?, ?> build = Mockito.mock(Run.class);
+
+        TestResults result = TestResultsAdapter.getTestResults(build);
+
+        assertThat(result).isNull();
+        Mockito.verify(build).getActions(AbstractTestResultAction.class);
+    }
+
+    @Test
+    void shouldSummariesTestResult() {
+        Run<?, ?> build = Mockito.mock(Run.class);
+        Mockito.when(build.getActions(Mockito.any())).thenReturn(
+            List.of(
+                new MockTestResultAction(4, 2, 1),
+                new MockTestResultAction(2, 1, 1)
+            )
+        );
+
+        TestResults result = TestResultsAdapter.getTestResults(build);
+
+        assertThat(result)
+            .extracting(TestResults::getSuccessful, TestResults::getFailed, TestResults::getSkipped)
+            .containsExactly(1, 3, 2);
+    }
+
+    private static class MockTestResultAction extends AbstractTestResultAction<MockTestResultAction> {
+
+        private final int totalCount;
+        private final int failCount;
+        private final int skipCount;
+
+        private MockTestResultAction(int totalCount, int failCount, int skipCount) {
+            this.totalCount = totalCount;
+            this.failCount = failCount;
+            this.skipCount = skipCount;
+        }
+
+        @Override
+        public int getFailCount() {
+            return failCount;
+        }
+
+        @Override
+        public int getTotalCount() {
+            return totalCount;
+        }
+
+        @Override
+        public int getSkipCount() {
+            return skipCount;
+        }
+
+        @Override
+        public Object getResult() {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
Include test result in build status notification.

The results are summaries from all available AbstractTestResultAction`s.
To post test result to junit plugin must be installed. If the junit plugin is not installed not test results are included into the build status notification.

The junit plugin is added as optional dependency.  

Publishing of test results is not only limited to junit plugin. Ex the [TestNG ](https://github.com/jenkinsci/testng-plugin-plugin/blob/master/src/main/java/hudson/plugins/testng/TestNGTestResultBuildAction.java) plugin is also extending the AbstractTestResultAction.

Publishing of test result is not supported by bitbucket cloud.

Fixes https://issues.jenkins.io/browse/JENKINS-75082

### Your checklist for this pull request

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Did you provide a test-case? That demonstrates feature works or fixes the issue.
