### PR TITLE
Fix basic authentication for BitbucketUsernamePasswordAuthenticator

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/ClosingConnectionInputStream.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/ClosingConnectionInputStream.java
@@ -26,7 +26,6 @@ package com.cloudbees.jenkins.plugins.bitbucket.client;
 import java.io.IOException;
 import java.io.InputStream;
 import org.apache.hc.client5.http.classic.methods.HttpUriRequest;
-import org.apache.hc.client5.http.io.HttpClientConnectionManager;
 import org.apache.hc.core5.http.ClassicHttpResponse;
 import org.apache.hc.core5.http.io.entity.EntityUtils;
 
@@ -36,16 +35,12 @@ public class ClosingConnectionInputStream extends InputStream {
 
     private final HttpUriRequest method;
 
-    private final HttpClientConnectionManager connectionManager;
-
     private final InputStream delegate;
 
     public ClosingConnectionInputStream(final ClassicHttpResponse response,
-                                        final HttpUriRequest method,
-                                        final HttpClientConnectionManager connectionmanager) throws IOException {
+                                        final HttpUriRequest method) throws IOException {
         this.response = response;
         this.method = method;
-        this.connectionManager = connectionmanager;
         this.delegate = response.getEntity().getContent();
     }
 
@@ -58,8 +53,7 @@ public class ClosingConnectionInputStream extends InputStream {
     public void close() throws IOException {
         EntityUtils.consume(response.getEntity());
         delegate.close();
-//FIXME        method.releaseConnection();
-//FIXME        connectionManager.closeExpiredConnections();
+//        method.releaseConnection();
     }
 
     @Override

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/BitbucketServerAPIClient.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/BitbucketServerAPIClient.java
@@ -91,7 +91,6 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.hc.client5.http.classic.methods.HttpGet;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
-import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
 import org.apache.hc.client5.http.io.HttpClientConnectionManager;
 import org.apache.hc.core5.http.HttpHost;
 import org.apache.hc.core5.http.HttpStatus;
@@ -139,19 +138,7 @@ public class BitbucketServerAPIClient extends AbstractBitbucketApi implements Bi
     private static final String API_MIRRORS_PATH = "/rest/mirroring/1.0/mirrorServers";
     private static final Integer DEFAULT_PAGE_LIMIT = 200;
 
-    protected static final HttpClientConnectionManager connectionManager = connectionManager();
-
-    private static HttpClientConnectionManager connectionManager() {
-        try {
-            PoolingHttpClientConnectionManager connManager = new PoolingHttpClientConnectionManager(); // NOSONAR
-            connManager.setDefaultMaxPerRoute(20);
-            connManager.setMaxTotal(22);
-            return connManager;
-        } catch (Exception e) {
-            // in case of exception this avoids ClassNotFoundError which prevents the classloader from loading this class again
-            return null;
-        }
-    }
+    private static final HttpClientConnectionManager connectionManager = buildConnectionManager();
 
     /**
      * Repository owner.
@@ -190,7 +177,7 @@ public class BitbucketServerAPIClient extends AbstractBitbucketApi implements Bi
         this.repositoryName = repositoryName;
         this.baseURL = Util.removeTrailingSlash(baseURL);
         this.webhookImplementation = requireNonNull(webhookImplementation);
-        this.client = setupClientBuilder(baseURL).build();
+        this.client = setupClientBuilder().build();
     }
 
     /**

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/impl/client/ExponentialBackOffRetryStrategyTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/impl/client/ExponentialBackOffRetryStrategyTest.java
@@ -68,8 +68,8 @@ class ExponentialBackOffRetryStrategyTest {
                 false,
                 mock(BitbucketServerWebhookImplementation.class)) {
             @Override
-            protected HttpClientBuilder setupClientBuilder(String host) {
-                return super.setupClientBuilder(host)
+            protected HttpClientBuilder setupClientBuilder() {
+                return super.setupClientBuilder()
                         .setRetryStrategy(new ExponentialBackoffRetryStrategy(2, 5, 100))
                         .addResponseInterceptorFirst(counterInterceptor);
             }


### PR DESCRIPTION
Using a basic credentials provider with preemptive authentication does not work as expected.
Remove socket timeout configuration because it impact any socket connection not only the current request.