### PR TITLE
[JENKINS-] HTTP client fails with randomly with NoHttpResponseException

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/impl/client/AbstractBitbucketApi.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/impl/client/AbstractBitbucketApi.java
@@ -64,6 +64,7 @@ import org.apache.http.client.protocol.HttpClientContext;
 import org.apache.http.conn.HttpClientConnectionManager;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.NoConnectionReuseStrategy;
 import org.apache.http.impl.auth.BasicScheme;
 import org.apache.http.impl.client.BasicAuthCache;
 import org.apache.http.impl.client.BasicCredentialsProvider;
@@ -145,6 +146,9 @@ public abstract class AbstractBitbucketApi implements AutoCloseable {
                 .setServiceUnavailableRetryStrategy(serviceUnavailableStrategy)
                 .setRetryHandler(new StandardHttpRequestRetryHandler())
                 .setDefaultRequestConfig(config)
+                .evictExpiredConnections()
+                .evictIdleConnections(5, TimeUnit.SECONDS)
+                .setConnectionReuseStrategy(new NoConnectionReuseStrategy())
                 .disableCookieManagement();
 
         if (authenticator != null) {
@@ -255,6 +259,7 @@ public abstract class AbstractBitbucketApi implements AutoCloseable {
         HttpClientConnectionManager connectionManager = getConnectionManager();
         if (connectionManager != null) {
             connectionManager.closeExpiredConnections();
+            connectionManager.closeIdleConnections(5, TimeUnit.SECONDS);
         }
     }
 

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/impl/notifier/BitbucketBuildStatusNotifications.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/impl/notifier/BitbucketBuildStatusNotifications.java
@@ -268,7 +268,11 @@ public final class BitbucketBuildStatusNotifications {
                 }
             }
         }
-        createStatus(build, listener, bitbucket, key, hash, refName);
+        try {
+            createStatus(build, listener, bitbucket, key, hash, refName);
+        } finally {
+            bitbucket.close();
+        }
     }
 
     @CheckForNull

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/BitbucketServerAPIClient.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/BitbucketServerAPIClient.java
@@ -81,6 +81,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
 import java.util.logging.Level;
 import javax.imageio.ImageIO;
@@ -145,7 +146,7 @@ public class BitbucketServerAPIClient extends AbstractBitbucketApi implements Bi
 
     private static HttpClientConnectionManager connectionManager() {
         try {
-            PoolingHttpClientConnectionManager connManager = new PoolingHttpClientConnectionManager(); // NOSONAR
+            PoolingHttpClientConnectionManager connManager = new PoolingHttpClientConnectionManager(1, TimeUnit.SECONDS); // NOSONAR
             connManager.setDefaultMaxPerRoute(20);
             connManager.setMaxTotal(22);
             return connManager;


### PR DESCRIPTION
Set the connection manager to drop connections in the pool that have been marked as evicted and those that are idle for more than 5 seconds. This should force re-validation of active connections that Bitbucket may have closed server-side, causing the issue described on Stackoverflow https://stackoverflow.com/questions/10558791/apache-httpclient-interim-error-nohttpresponseexception/10600762#10600762