### PR TITLE
[JENKINS-75534] DiscardOldBranch trait uses AuthorDate of HEAD commit to determine branch age rather than CommitDate

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/branch/BitbucketServerCommit.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/branch/BitbucketServerCommit.java
@@ -48,7 +48,7 @@ public class BitbucketServerCommit implements BitbucketCommit {
     @JsonCreator
     public BitbucketServerCommit(@NonNull @JsonProperty("message") String message, //
                                  @NonNull @JsonProperty("id") String hash, //
-                                 @NonNull @JsonProperty("authorTimestamp") long dateMillis, //
+                                 @NonNull @JsonProperty("committerTimestamp") long dateMillis, //
                                  @Nullable @JsonProperty("author") BitbucketServerAuthor author) {
         // date it is not in the payload
         this(message, hash, dateMillis, author != null ? MessageFormat.format(GIT_COMMIT_AUTHOR, author.getName(), author.getEmail()) : null);

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/trait/DiscardOldBranchTrait.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/trait/DiscardOldBranchTrait.java
@@ -67,10 +67,16 @@ public class DiscardOldBranchTrait extends SCMSourceTrait {
 
     @Override
     protected void decorateContext(SCMSourceContext<?, ?> context) {
-        context.withFilter(new ExcludeOldSCMHeadBranch());
+        context.withFilter(new ExcludeOldSCMHeadBranch(keepForDays));
     }
 
-    public final class ExcludeOldSCMHeadBranch extends SCMHeadFilter {
+    public static final class ExcludeOldSCMHeadBranch extends SCMHeadFilter {
+        private int keepForDays;
+
+        public ExcludeOldSCMHeadBranch(int keepForDays) {
+            this.keepForDays = keepForDays;
+        }
+
         @Override
         public boolean isExcluded(SCMSourceRequest request, SCMHead head) throws IOException, InterruptedException {
             if (keepForDays > 0) {

--- a/src/main/resources/com/cloudbees/jenkins/plugins/bitbucket/trait/DiscardOldTagTrait/help-keepForDays.html
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/bitbucket/trait/DiscardOldTagTrait/help-keepForDays.html
@@ -22,5 +22,6 @@
  - THE SOFTWARE.
  -->
 <div>
-    Number of days after the tag creation before it is discarded.
+    Number of days since the commit date referred by the tag before it is discarded.<br/>
+    (Note: Since Bitbucket does not provide API to gather annotated tag details there are not differences between tag and annotated one)
 </div>

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketGitSCMRevisionTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketGitSCMRevisionTest.java
@@ -53,7 +53,7 @@ class BitbucketGitSCMRevisionTest {
         j = rule;
     }
 
-    private static Stream<Arguments> revisionData() {
+    private static Stream<Arguments> revisionDataProvider() {
         return Stream.of(Arguments.of("branch on cloud", new BranchDiscoveryTrait(true, true), BitbucketCloudEndpoint.SERVER_URL), //
                 Arguments.of("branch on server", new BranchDiscoveryTrait(true, true), "localhost"), //
                 Arguments.of("PR on cloud", new OriginPullRequestDiscoveryTrait(2), BitbucketCloudEndpoint.SERVER_URL), //
@@ -66,7 +66,7 @@ class BitbucketGitSCMRevisionTest {
     }
 
     @ParameterizedTest(name = "verify revision informations from {0}")
-    @MethodSource("revisionData")
+    @MethodSource("revisionDataProvider")
     void verify_revision_informations_are_valued(String testName, SCMSourceTrait trait, String serverURL) throws Exception {
         BitbucketMockApiFactory.add(serverURL, getApiMockClient(serverURL));
         BitbucketSCMSource source = new BitbucketSCMSource("amuniz", "test-repos");


### PR DESCRIPTION
Change authorTimestamp to committerTimestamp for Bitbucket DataCenter commit details to reflect the same date that Bitbucket Cloud send in the commit details. Improve help of DiscardOldTagTrait