### PR TITLE
[JENKINS-75523] PRs created from tags cannot be checked out

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,4 +99,5 @@ Support to run Server under Windows has been dismissed since version 7.14+
 2. run `docker run -it -p 7990:7990 -p 7999:7999 -v %USER%\.m2:/root/.m2 nolddor/atlassian-sdk:17-jdk`
 3. Inside the container:
    - install git with `apk add git`
+   - install git support for http with `apk add git-daemon`
    - run `/opt/atlassian-plugin-sdk/bin/atlas-run-standalone --product bitbucket --version 9.5.2`

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
         <changelist>-SNAPSHOT</changelist>
         <gitHubRepo>jenkinsci/bitbucket-branch-source-plugin</gitHubRepo>
         <jenkins.baseline>2.479</jenkins.baseline>
-        <jenkins.version>${jenkins.baseline}.1</jenkins.version>
+        <jenkins.version>${jenkins.baseline}.3</jenkins.version>
         <hpi.compatibleSinceVersion>936.0.0</hpi.compatibleSinceVersion>
         <!-- Jenkins.MANAGE is still in Beta -->
         <useBeta>true</useBeta>

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketGitSCMBuilder.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketGitSCMBuilder.java
@@ -26,6 +26,7 @@ package com.cloudbees.jenkins.plugins.bitbucket;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketHref;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketRepository;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketRepositoryProtocol;
+import com.cloudbees.jenkins.plugins.bitbucket.api.PullRequestBranchType;
 import com.cloudbees.jenkins.plugins.bitbucket.endpoints.AbstractBitbucketEndpoint;
 import com.cloudbees.jenkins.plugins.bitbucket.endpoints.BitbucketEndpointConfiguration;
 import com.cloudbees.jenkins.plugins.bitbucket.endpoints.BitbucketServerEndpoint;
@@ -208,7 +209,7 @@ public class BitbucketGitSCMBuilder extends GitSCMBuilder<BitbucketGitSCMBuilder
         return this;
     }
 
-    private void withPullRequestRemote(PullRequestSCMHead head, String headName) {
+    private void withPullRequestRemote(PullRequestSCMHead head, String headName) { // NOSONAR
         String scmSourceRepoOwner = scmSource.getRepoOwner();
         String scmSourceRepository = scmSource.getRepository();
         String pullRequestRepoOwner = head.getRepoOwner();
@@ -226,7 +227,11 @@ public class BitbucketGitSCMBuilder extends GitSCMBuilder<BitbucketGitSCMBuilder
         String branchName = head.getBranchName();
         boolean scmCloud = BitbucketApiUtils.isCloud(scmSource.getServerUrl());
         if (prFromTargetRepository) {
-            withRefSpec("+refs/heads/" + branchName + ":refs/remotes/@{remote}/" + branchName);
+            if (head.getBranchType() == PullRequestBranchType.TAG) {
+                withRefSpec("+refs/tags/" + branchName + ":refs/remotes/@{remote}/" + branchName); // NOSONAR
+            } else {
+                withRefSpec("+refs/heads/" + branchName + ":refs/remotes/@{remote}/" + branchName); // NOSONAR
+            }
             if (cloneFromMirror) {
                 PullRequestSCMRevision pullRequestSCMRevision = (PullRequestSCMRevision) revision;
                 String primaryRemoteName = remoteName().equals("primary") ? "primary-primary" : "primary";

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource.java
@@ -37,6 +37,7 @@ import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketPullRequest;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketRepository;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketRequestException;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketTeam;
+import com.cloudbees.jenkins.plugins.bitbucket.api.PullRequestBranchType;
 import com.cloudbees.jenkins.plugins.bitbucket.client.repository.UserRoleInRepository;
 import com.cloudbees.jenkins.plugins.bitbucket.endpoints.AbstractBitbucketEndpoint;
 import com.cloudbees.jenkins.plugins.bitbucket.endpoints.BitbucketCloudEndpoint;
@@ -408,9 +409,10 @@ public class BitbucketSCMSource extends SCMSource {
         for (final BitbucketPullRequest pull : request.getPullRequests()) {
             String originalBranchName = pull.getSource().getBranch().getName();
             request.listener().getLogger().printf(
-                    "Checking PR-%s from %s and branch %s%n",
+                    "Checking PR-%s from %s and %s %s%n",
                     pull.getId(),
                     pull.getSource().getRepository().getFullName(),
+                    pull.getSource().getBranchType() == PullRequestBranchType.TAG ? "tag" : "branch",
                     originalBranchName
             );
             boolean fork = !StringUtils.equalsIgnoreCase(fullName, pull.getSource().getRepository().getFullName());

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/PullRequestSCMHead.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/PullRequestSCMHead.java
@@ -24,6 +24,7 @@
 package com.cloudbees.jenkins.plugins.bitbucket;
 
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketPullRequest;
+import com.cloudbees.jenkins.plugins.bitbucket.api.PullRequestBranchType;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import jenkins.scm.api.SCMHead;
 import jenkins.scm.api.SCMHeadOrigin;
@@ -45,6 +46,8 @@ public class PullRequestSCMHead extends SCMHead implements ChangeRequestSCMHead2
 
     private final String branchName;
 
+    private final PullRequestBranchType branchType;
+
     private final String number;
 
     private final String title;
@@ -55,13 +58,14 @@ public class PullRequestSCMHead extends SCMHead implements ChangeRequestSCMHead2
 
     private final ChangeRequestCheckoutStrategy strategy;
 
-    public PullRequestSCMHead(String name, String repoOwner, String repository, String branchName,
+    public PullRequestSCMHead(String name, String repoOwner, String repository, String branchName, PullRequestBranchType branchType,
                               String number, String title, BranchSCMHead target, SCMHeadOrigin origin,
                               ChangeRequestCheckoutStrategy strategy) {
         super(name);
         this.repoOwner = repoOwner;
         this.repository = repository;
         this.branchName = branchName;
+        this.branchType = branchType;
         this.number = number;
         this.title = title;
         this.target = target;
@@ -71,7 +75,7 @@ public class PullRequestSCMHead extends SCMHead implements ChangeRequestSCMHead2
 
     public PullRequestSCMHead(String name, String repoOwner, String repository, String branchName,
                               BitbucketPullRequest pr, SCMHeadOrigin origin, ChangeRequestCheckoutStrategy strategy) {
-        this(name, repoOwner, repository, branchName,
+        this(name, repoOwner, repository, branchName, pr.getSource().getBranchType(),
              pr.getId(), pr.getTitle(), new BranchSCMHead(pr.getDestination().getBranch().getName()),
              origin, strategy);
     }
@@ -128,6 +132,10 @@ public class PullRequestSCMHead extends SCMHead implements ChangeRequestSCMHead2
     @Override
     public SCMHeadOrigin getOrigin() {
         return origin == null ? SCMHeadOrigin.DEFAULT : origin;
+    }
+
+    public PullRequestBranchType getBranchType() {
+        return branchType;
     }
 
 }

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/PullRequestBranchType.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/PullRequestBranchType.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright (c) 2016, CloudBees, Inc.
+ * Copyright (c) 2025, Nikolas Falco
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -23,36 +23,10 @@
  */
 package com.cloudbees.jenkins.plugins.bitbucket.api;
 
-import edu.umd.cs.findbugs.annotations.NonNull;
-
 /**
- * Represents a pull request source, which is a repository, a branch in that repository and the head commit.
+ * Enumerated type of source HEAD for a pull request.
+ * @since 936.0.0
  */
-public interface BitbucketPullRequestSource {
-
-    /**
-     * @return source repository
-     */
-    BitbucketRepository getRepository();
-
-    /**
-     * @return source branch to be merged in the pull request
-     */
-    BitbucketBranch getBranch();
-
-    /**
-     * Returns the type of the source branch.
-     * <p>
-     * In some server implementations the source HEAD could be a tag.
-     *
-     * @return the source branch type
-     */
-    @NonNull
-    PullRequestBranchType getBranchType();
-
-    /**
-     * @return the branch head commit
-     */
-    BitbucketCommit getCommit();
-
+public enum PullRequestBranchType {
+    TAG, BRANCH
 }

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/pullrequest/BitbucketPullRequestValueRepository.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/pullrequest/BitbucketPullRequestValueRepository.java
@@ -25,6 +25,7 @@ package com.cloudbees.jenkins.plugins.bitbucket.client.pullrequest;
 
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketCommit;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketPullRequestSource;
+import com.cloudbees.jenkins.plugins.bitbucket.api.PullRequestBranchType;
 import com.cloudbees.jenkins.plugins.bitbucket.client.branch.BitbucketCloudBranch;
 import com.cloudbees.jenkins.plugins.bitbucket.client.branch.BitbucketCloudCommit;
 import com.cloudbees.jenkins.plugins.bitbucket.client.repository.BitbucketCloudRepository;
@@ -32,6 +33,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.util.StdDateFormat;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Date;
 
 public class BitbucketPullRequestValueRepository implements BitbucketPullRequestSource {
@@ -94,5 +96,12 @@ public class BitbucketPullRequestValueRepository implements BitbucketPullRequest
 
     public void setCommit(BitbucketCloudCommit commit) {
         this.commit = commit;
+    }
+
+    @NonNull
+    @Override
+    public PullRequestBranchType getBranchType() {
+        // cloud does not support any other kind od source branch
+        return PullRequestBranchType.BRANCH;
     }
 }

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/impl/client/AbstractBitbucketApi.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/impl/client/AbstractBitbucketApi.java
@@ -243,7 +243,7 @@ public abstract class AbstractBitbucketApi implements AutoCloseable {
         return getClient().executeOpen(requestHost, request, context);
     }
 
-    protected String doRequest(HttpUriRequest request) throws IOException {
+    private String doRequest(HttpUriRequest request) throws IOException {
         try (ClassicHttpResponse response =  executeMethod(request)) {
             int statusCode = response.getCode();
             if (statusCode == HttpStatus.SC_NOT_FOUND) {

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/branch/BitbucketServerBranch.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/branch/BitbucketServerBranch.java
@@ -25,6 +25,7 @@ package com.cloudbees.jenkins.plugins.bitbucket.server.client.branch;
 
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketBranch;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketCommit;
+import com.cloudbees.jenkins.plugins.bitbucket.api.PullRequestBranchType;
 import java.util.concurrent.Callable;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -44,6 +45,7 @@ public class BitbucketServerBranch implements BitbucketBranch {
     private Long timestamp;
     private Callable<BitbucketCommit> commitClosure;
     private boolean callableInitialised = false;
+    private PullRequestBranchType type = PullRequestBranchType.BRANCH;
 
     public BitbucketServerBranch() {
     }
@@ -150,5 +152,13 @@ public class BitbucketServerBranch implements BitbucketBranch {
             this.author = "Unknown";
         }
         callableInitialised = true;
+    }
+
+    public PullRequestBranchType getType() {
+        return type;
+    }
+
+    public void setType(PullRequestBranchType type) {
+        this.type = type;
     }
 }

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/pullrequest/BitbucketServerPullRequestSource.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/pullrequest/BitbucketServerPullRequestSource.java
@@ -26,6 +26,7 @@ package com.cloudbees.jenkins.plugins.bitbucket.server.client.pullrequest;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketBranch;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketCommit;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketPullRequestSource;
+import com.cloudbees.jenkins.plugins.bitbucket.api.PullRequestBranchType;
 import com.cloudbees.jenkins.plugins.bitbucket.server.client.branch.BitbucketServerBranch;
 import com.cloudbees.jenkins.plugins.bitbucket.server.client.branch.BitbucketServerCommit;
 import com.cloudbees.jenkins.plugins.bitbucket.server.client.repository.BitbucketServerRepository;
@@ -37,6 +38,8 @@ public class BitbucketServerPullRequestSource implements BitbucketPullRequestSou
     private String refId;
     @JsonProperty("displayId")
     private String branchName;
+    @JsonProperty("type")
+    private PullRequestBranchType branchType;
     @JsonProperty
     private String latestCommit;
 
@@ -61,6 +64,7 @@ public class BitbucketServerPullRequestSource implements BitbucketPullRequestSou
     public BitbucketBranch getBranch() {
         if (branch == null) {
             branch = new BitbucketServerBranch(branchName, latestCommit);
+            branch.setType(branchType);
         }
         return branch;
     }
@@ -75,6 +79,15 @@ public class BitbucketServerPullRequestSource implements BitbucketPullRequestSou
 
     public void setRepository(BitbucketServerRepository repository) {
         this.repository = repository;
+    }
+
+    @Override
+    public PullRequestBranchType getBranchType() {
+        return branchType;
+    }
+
+    public void setBranchType(PullRequestBranchType branchType) {
+        this.branchType = branchType;
     }
 
 }

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketGitSCMBuilderTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketGitSCMBuilderTest.java
@@ -24,6 +24,7 @@
 package com.cloudbees.jenkins.plugins.bitbucket;
 
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketHref;
+import com.cloudbees.jenkins.plugins.bitbucket.api.PullRequestBranchType;
 import com.cloudbees.jenkins.plugins.bitbucket.client.branch.BitbucketCloudCommit;
 import com.cloudbees.jenkins.plugins.bitbucket.impl.extension.FallbackToOtherRepositoryGitSCMExtension;
 import com.cloudbees.jenkins.plugins.bitbucket.server.client.branch.BitbucketServerCommit;
@@ -33,6 +34,7 @@ import com.cloudbees.plugins.credentials.CredentialsScope;
 import com.cloudbees.plugins.credentials.SystemCredentialsProvider;
 import com.cloudbees.plugins.credentials.domains.Domain;
 import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.plugins.git.GitSCM;
 import hudson.plugins.git.Revision;
 import hudson.plugins.git.UserRemoteConfig;
@@ -922,9 +924,7 @@ public class BitbucketGitSCMBuilderTest {
 
     @Test
     public void given__cloud_pullHead_rev_anon__when__build__then__scmBuilt() throws Exception {
-        PullRequestSCMHead head = new PullRequestSCMHead("PR-1", "qa", "qa-repo", "qa-branch", "1", "a fake title",
-                new BranchSCMHead("test-branch"), new SCMHeadOrigin.Fork("qa/qa-repo"),
-                ChangeRequestCheckoutStrategy.HEAD);
+        PullRequestSCMHead head = buildHeadFromFork(ChangeRequestCheckoutStrategy.HEAD);
         PullRequestSCMRevision revision =
                 new PullRequestSCMRevision(head, new AbstractGitSCMSource.SCMRevisionImpl(head.getTarget(),
                         "deadbeefcafebabedeadbeefcafebabedeadbeef"),
@@ -976,9 +976,7 @@ public class BitbucketGitSCMBuilderTest {
 
     @Test
     public void given__cloud_pullHead_rev_userpass__when__build__then__scmBuilt() throws Exception {
-        PullRequestSCMHead head = new PullRequestSCMHead("PR-1", "qa", "qa-repo", "qa-branch", "1", "a fake title",
-                new BranchSCMHead("test-branch"), new SCMHeadOrigin.Fork("qa/qa-repo"),
-                ChangeRequestCheckoutStrategy.HEAD);
+        PullRequestSCMHead head = buildHeadFromFork(ChangeRequestCheckoutStrategy.HEAD);
         PullRequestSCMRevision revision =
                 new PullRequestSCMRevision(head, new AbstractGitSCMSource.SCMRevisionImpl(head.getTarget(),
                         "deadbeefcafebabedeadbeefcafebabedeadbeef"),
@@ -1030,9 +1028,7 @@ public class BitbucketGitSCMBuilderTest {
 
     @Test
     public void given__cloud_pullHead_rev_userkey__when__build__then__scmBuilt() throws Exception {
-        PullRequestSCMHead head = new PullRequestSCMHead("PR-1", "qa", "qa-repo", "qa-branch", "1", "a fake title",
-                new BranchSCMHead("test-branch"), new SCMHeadOrigin.Fork("qa/qa-repo"),
-                ChangeRequestCheckoutStrategy.HEAD);
+        PullRequestSCMHead head = buildHeadFromFork(ChangeRequestCheckoutStrategy.HEAD);
         PullRequestSCMRevision revision =
                 new PullRequestSCMRevision(head, new AbstractGitSCMSource.SCMRevisionImpl(head.getTarget(),
                         "deadbeefcafebabedeadbeefcafebabedeadbeef"),
@@ -1083,9 +1079,7 @@ public class BitbucketGitSCMBuilderTest {
 
     @Test
     public void given__cloud_pullHead_rev_anon_sshtrait_anon__when__build__then__scmBuilt() throws Exception {
-        PullRequestSCMHead head = new PullRequestSCMHead("PR-1", "qa", "qa-repo", "qa-branch", "1", "a fake title",
-                new BranchSCMHead("test-branch"), new SCMHeadOrigin.Fork("qa/qa-repo"),
-                ChangeRequestCheckoutStrategy.HEAD);
+        PullRequestSCMHead head = buildHeadFromFork(ChangeRequestCheckoutStrategy.HEAD);
         PullRequestSCMRevision revision =
                 new PullRequestSCMRevision(head, new AbstractGitSCMSource.SCMRevisionImpl(head.getTarget(),
                         "deadbeefcafebabedeadbeefcafebabedeadbeef"),
@@ -1143,9 +1137,7 @@ public class BitbucketGitSCMBuilderTest {
 
     @Test
     public void given__cloud_pullHead_rev_userpass_sshtrait_anon__when__build__then__scmBuilt() throws Exception {
-        PullRequestSCMHead head = new PullRequestSCMHead("PR-1", "qa", "qa-repo", "qa-branch", "1", "a fake title",
-                new BranchSCMHead("test-branch"), new SCMHeadOrigin.Fork("qa/qa-repo"),
-                ChangeRequestCheckoutStrategy.HEAD);
+        PullRequestSCMHead head = buildHeadFromFork(ChangeRequestCheckoutStrategy.HEAD);
         PullRequestSCMRevision revision =
                 new PullRequestSCMRevision(head, new AbstractGitSCMSource.SCMRevisionImpl(head.getTarget(),
                         "deadbeefcafebabedeadbeefcafebabedeadbeef"),
@@ -1203,9 +1195,7 @@ public class BitbucketGitSCMBuilderTest {
 
     @Test
     public void given__cloud_pullHead_rev_userkey_sshtrait_anon__when__build__then__scmBuilt() throws Exception {
-        PullRequestSCMHead head = new PullRequestSCMHead("PR-1", "qa", "qa-repo", "qa-branch", "1", "a fake title",
-                new BranchSCMHead("test-branch"), new SCMHeadOrigin.Fork("qa/qa-repo"),
-                ChangeRequestCheckoutStrategy.HEAD);
+        PullRequestSCMHead head = buildHeadFromFork(ChangeRequestCheckoutStrategy.HEAD);
         PullRequestSCMRevision revision =
                 new PullRequestSCMRevision(head, new AbstractGitSCMSource.SCMRevisionImpl(head.getTarget(),
                         "deadbeefcafebabedeadbeefcafebabedeadbeef"),
@@ -1262,9 +1252,7 @@ public class BitbucketGitSCMBuilderTest {
 
     @Test
     public void given__cloud_pullHead_rev_anon_sshtrait_userkey__when__build__then__scmBuilt() throws Exception {
-        PullRequestSCMHead head = new PullRequestSCMHead("PR-1", "qa", "qa-repo", "qa-branch", "1", "a fake title",
-                new BranchSCMHead("test-branch"), new SCMHeadOrigin.Fork("qa/qa-repo"),
-                ChangeRequestCheckoutStrategy.HEAD);
+        PullRequestSCMHead head = buildHeadFromFork(ChangeRequestCheckoutStrategy.HEAD);
         PullRequestSCMRevision revision =
                 new PullRequestSCMRevision(head, new AbstractGitSCMSource.SCMRevisionImpl(head.getTarget(),
                         "deadbeefcafebabedeadbeefcafebabedeadbeef"),
@@ -1322,9 +1310,7 @@ public class BitbucketGitSCMBuilderTest {
 
     @Test
     public void given__cloud_pullHead_rev_userpass_sshtrait_userkey__when__build__then__scmBuilt() throws Exception {
-        PullRequestSCMHead head = new PullRequestSCMHead("PR-1", "qa", "qa-repo", "qa-branch", "1", "a fake title",
-                new BranchSCMHead("test-branch"), new SCMHeadOrigin.Fork("qa/qa-repo"),
-                ChangeRequestCheckoutStrategy.HEAD);
+        PullRequestSCMHead head = buildHeadFromFork(ChangeRequestCheckoutStrategy.HEAD);
         PullRequestSCMRevision revision =
                 new PullRequestSCMRevision(head, new AbstractGitSCMSource.SCMRevisionImpl(head.getTarget(),
                         "deadbeefcafebabedeadbeefcafebabedeadbeef"),
@@ -1382,9 +1368,7 @@ public class BitbucketGitSCMBuilderTest {
 
     @Test
     public void given__cloud_pullHead_rev_userkey_sshtrait_userkey__when__build__then__scmBuilt() throws Exception {
-        PullRequestSCMHead head = new PullRequestSCMHead("PR-1", "qa", "qa-repo", "qa-branch", "1", "a fake title",
-                new BranchSCMHead("test-branch"), new SCMHeadOrigin.Fork("qa/qa-repo"),
-                ChangeRequestCheckoutStrategy.HEAD);
+        PullRequestSCMHead head = buildHeadFromFork(ChangeRequestCheckoutStrategy.HEAD);
         PullRequestSCMRevision revision =
                 new PullRequestSCMRevision(head, new AbstractGitSCMSource.SCMRevisionImpl(head.getTarget(),
                         "deadbeefcafebabedeadbeefcafebabedeadbeef"),
@@ -1442,9 +1426,7 @@ public class BitbucketGitSCMBuilderTest {
 
     @Test
     public void given__cloud_pullHead_norev_anon__when__build__then__scmBuilt() throws Exception {
-        PullRequestSCMHead head = new PullRequestSCMHead("PR-1", "qa", "qa-repo", "qa-branch", "1", "a fake title",
-                new BranchSCMHead("test-branch"), new SCMHeadOrigin.Fork("qa/qa-repo"),
-                ChangeRequestCheckoutStrategy.HEAD);
+        PullRequestSCMHead head = buildHeadFromFork(ChangeRequestCheckoutStrategy.HEAD);
         BitbucketGitSCMBuilder instance = new BitbucketGitSCMBuilder(source,
                 head, null, null);
         assertThat(instance.credentialsId(), is(nullValue()));
@@ -1480,9 +1462,7 @@ public class BitbucketGitSCMBuilderTest {
 
     @Test
     public void given__cloud_pullHead_norev_userpass__when__build__then__scmBuilt() throws Exception {
-        PullRequestSCMHead head = new PullRequestSCMHead("PR-1", "qa", "qa-repo", "qa-branch", "1", "a fake title",
-                new BranchSCMHead("test-branch"), new SCMHeadOrigin.Fork("qa/qa-repo"),
-                ChangeRequestCheckoutStrategy.HEAD);
+        PullRequestSCMHead head = buildHeadFromFork(ChangeRequestCheckoutStrategy.HEAD);
         BitbucketGitSCMBuilder instance = new BitbucketGitSCMBuilder(source,
                 head, null, "user-pass");
         assertThat(instance.credentialsId(), is("user-pass"));
@@ -1518,9 +1498,7 @@ public class BitbucketGitSCMBuilderTest {
 
     @Test
     public void given__cloud_pullHead_norev_userkey__when__build__then__scmBuilt() throws Exception {
-        PullRequestSCMHead head = new PullRequestSCMHead("PR-1", "qa", "qa-repo", "qa-branch", "1", "a fake title",
-                new BranchSCMHead("test-branch"), new SCMHeadOrigin.Fork("qa/qa-repo"),
-                ChangeRequestCheckoutStrategy.HEAD);
+        PullRequestSCMHead head = buildHeadFromFork(ChangeRequestCheckoutStrategy.HEAD);
         BitbucketGitSCMBuilder instance = new BitbucketGitSCMBuilder(source, head, null, "user-key");
         assertThat(instance.credentialsId(), is("user-key"));
         assertThat(instance.head(), is((SCMHead) head));
@@ -1556,9 +1534,7 @@ public class BitbucketGitSCMBuilderTest {
     @Test
     public void given__server_pullHead_rev_anon__when__build__then__scmBuilt() throws Exception {
         source.setServerUrl("https://bitbucket.test");
-        PullRequestSCMHead head = new PullRequestSCMHead("PR-1", "qa", "qa-repo", "qa-branch", "1", "a fake title",
-                new BranchSCMHead("test-branch"), new SCMHeadOrigin.Fork("qa/qa-repo"),
-                ChangeRequestCheckoutStrategy.HEAD);
+        PullRequestSCMHead head = buildHeadFromFork(ChangeRequestCheckoutStrategy.HEAD);
         PullRequestSCMRevision revision =
                 new PullRequestSCMRevision(head, new AbstractGitSCMSource.SCMRevisionImpl(head.getTarget(),
                         "deadbeefcafebabedeadbeefcafebabedeadbeef"),
@@ -1617,9 +1593,7 @@ public class BitbucketGitSCMBuilderTest {
     @Test
     public void given__server_withMirror_pullHead_rev_anon__when__build__then__scmBuilt() throws Exception {
         source.setServerUrl("https://bitbucket.test");
-        PullRequestSCMHead head = new PullRequestSCMHead("PR-1", "qa", "qa-repo", "qa-branch", "1", "a fake title",
-                new BranchSCMHead("test-branch"), new SCMHeadOrigin.Fork("qa/qa-repo"),
-                ChangeRequestCheckoutStrategy.HEAD);
+        PullRequestSCMHead head = buildHeadFromFork(ChangeRequestCheckoutStrategy.HEAD);
         PullRequestSCMRevision revision =
                 new PullRequestSCMRevision(head, new AbstractGitSCMSource.SCMRevisionImpl(head.getTarget(),
                         "deadbeefcafebabedeadbeefcafebabedeadbeef"),
@@ -1681,9 +1655,7 @@ public class BitbucketGitSCMBuilderTest {
     @Test
     public void given__server_pullHead_defaultOrigin_rev_anon__when__build__then__scmBuilt() throws Exception {
         source.setServerUrl("https://bitbucket.test");
-        PullRequestSCMHead head = new PullRequestSCMHead("PR-1", "tester", "test-repo", "pr-branch", "1", "a fake title",
-                new BranchSCMHead("test-branch"), SCMHeadOrigin.DEFAULT,
-                ChangeRequestCheckoutStrategy.HEAD);
+        PullRequestSCMHead head = buildHead(ChangeRequestCheckoutStrategy.HEAD);
         PullRequestSCMRevision revision =
                 new PullRequestSCMRevision(head, new AbstractGitSCMSource.SCMRevisionImpl(head.getTarget(),
                         "deadbeefcafebabedeadbeefcafebabedeadbeef"),
@@ -1742,9 +1714,7 @@ public class BitbucketGitSCMBuilderTest {
     @Test
     public void given__server_withMirror_pullHead_defaultOrigin_rev_anon__when__build__then__scmBuilt() throws Exception {
         source.setServerUrl("https://bitbucket.test");
-        PullRequestSCMHead head = new PullRequestSCMHead("PR-1", "tester", "test-repo", "pr-branch", "1", "a fake title",
-                new BranchSCMHead("test-branch"), SCMHeadOrigin.DEFAULT,
-                ChangeRequestCheckoutStrategy.HEAD);
+        PullRequestSCMHead head = buildHead(ChangeRequestCheckoutStrategy.HEAD);
         PullRequestSCMRevision revision =
                 new PullRequestSCMRevision(head, new AbstractGitSCMSource.SCMRevisionImpl(head.getTarget(),
                         "deadbeefcafebabedeadbeefcafebabedeadbeef"),
@@ -1807,9 +1777,7 @@ public class BitbucketGitSCMBuilderTest {
     @Test
     public void given__server_pullMerge_defaultOrigin_rev_anon__when__build__then__scmBuilt() throws Exception {
         source.setServerUrl("https://bitbucket.test");
-        PullRequestSCMHead head = new PullRequestSCMHead("PR-1", "tester", "test-repo", "pr-branch", "1", "a fake title",
-            new BranchSCMHead("test-branch"), SCMHeadOrigin.DEFAULT,
-            ChangeRequestCheckoutStrategy.MERGE);
+        PullRequestSCMHead head = buildHead(ChangeRequestCheckoutStrategy.MERGE);
         PullRequestSCMRevision revision =
             new PullRequestSCMRevision(head, new AbstractGitSCMSource.SCMRevisionImpl(head.getTarget(),
                 "deadbeefcafebabedeadbeefcafebabedeadbeef"),
@@ -1879,9 +1847,7 @@ public class BitbucketGitSCMBuilderTest {
     @Test
     public void given__server_withMirror_pullMerge_defaultOrigin_rev_anon__when__build__then__scmBuilt() throws Exception {
         source.setServerUrl("https://bitbucket.test");
-        PullRequestSCMHead head = new PullRequestSCMHead("PR-1", "tester", "test-repo", "pr-branch", "1", "a fake title",
-            new BranchSCMHead("test-branch"), SCMHeadOrigin.DEFAULT,
-            ChangeRequestCheckoutStrategy.MERGE);
+        PullRequestSCMHead head = buildHead(ChangeRequestCheckoutStrategy.MERGE);
         PullRequestSCMRevision revision =
             new PullRequestSCMRevision(head, new AbstractGitSCMSource.SCMRevisionImpl(head.getTarget(),
                 "deadbeefcafebabedeadbeefcafebabedeadbeef"),
@@ -1955,9 +1921,7 @@ public class BitbucketGitSCMBuilderTest {
     @Test
     public void given__server_pullHead_rev_userpass__when__build__then__scmBuilt() throws Exception {
         source.setServerUrl("https://bitbucket.test");
-        PullRequestSCMHead head = new PullRequestSCMHead("PR-1", "qa", "qa-repo", "qa-branch", "1", "a fake title",
-                new BranchSCMHead("test-branch"), new SCMHeadOrigin.Fork("qa/qa-repo"),
-                ChangeRequestCheckoutStrategy.HEAD);
+        PullRequestSCMHead head = buildHeadFromFork(ChangeRequestCheckoutStrategy.HEAD);
         PullRequestSCMRevision revision =
                 new PullRequestSCMRevision(head, new AbstractGitSCMSource.SCMRevisionImpl(head.getTarget(),
                         "deadbeefcafebabedeadbeefcafebabedeadbeef"),
@@ -2016,9 +1980,7 @@ public class BitbucketGitSCMBuilderTest {
     @Test
     public void given__server_pullHead_rev_userkey__when__build__then__scmBuilt() throws Exception {
         source.setServerUrl("https://bitbucket.test");
-        PullRequestSCMHead head = new PullRequestSCMHead("PR-1", "qa", "qa-repo", "qa-branch", "1", "a fake title",
-                new BranchSCMHead("test-branch"), new SCMHeadOrigin.Fork("qa/qa-repo"),
-                ChangeRequestCheckoutStrategy.HEAD);
+        PullRequestSCMHead head = buildHeadFromFork(ChangeRequestCheckoutStrategy.HEAD);
         PullRequestSCMRevision revision =
                 new PullRequestSCMRevision(head, new AbstractGitSCMSource.SCMRevisionImpl(head.getTarget(),
                         "deadbeefcafebabedeadbeefcafebabedeadbeef"),
@@ -2076,9 +2038,7 @@ public class BitbucketGitSCMBuilderTest {
     @Test
     public void given__server_pullHead_rev_userkey_different_clone_url__when__build__then__scmBuilt() throws Exception {
         source.setServerUrl("https://www.bitbucket.test/web");
-        PullRequestSCMHead head = new PullRequestSCMHead("PR-1", "qa", "qa-repo", "qa-branch", "1", "a fake title",
-                new BranchSCMHead("test-branch"), new SCMHeadOrigin.Fork("qa/qa-repo"),
-                ChangeRequestCheckoutStrategy.HEAD);
+        PullRequestSCMHead head = buildHeadFromFork(ChangeRequestCheckoutStrategy.HEAD);
         PullRequestSCMRevision revision =
                 new PullRequestSCMRevision(head, new AbstractGitSCMSource.SCMRevisionImpl(head.getTarget(),
                         "deadbeefcafebabedeadbeefcafebabedeadbeef"),
@@ -2135,9 +2095,7 @@ public class BitbucketGitSCMBuilderTest {
     @Test
     public void given__server_pullHead_norev_anon__when__build__then__scmBuilt() throws Exception {
         source.setServerUrl("https://bitbucket.test");
-        PullRequestSCMHead head = new PullRequestSCMHead("PR-1", "qa", "qa-repo", "qa-branch", "1", "a fake title",
-                new BranchSCMHead("test-branch"), new SCMHeadOrigin.Fork("qa/qa-repo"),
-                ChangeRequestCheckoutStrategy.HEAD);
+        PullRequestSCMHead head = buildHeadFromFork(ChangeRequestCheckoutStrategy.HEAD);
         BitbucketGitSCMBuilder instance = new BitbucketGitSCMBuilder(source,
                 head, null, null);
         assertThat(instance.credentialsId(), is(nullValue()));
@@ -2180,9 +2138,7 @@ public class BitbucketGitSCMBuilderTest {
     @Test
     public void given__server_pullHead_norev_userpass__when__build__then__scmBuilt() throws Exception {
         source.setServerUrl("https://bitbucket.test");
-        PullRequestSCMHead head = new PullRequestSCMHead("PR-1", "qa", "qa-repo", "qa-branch", "1", "a fake title",
-                new BranchSCMHead("test-branch"), new SCMHeadOrigin.Fork("qa/qa-repo"),
-                ChangeRequestCheckoutStrategy.HEAD);
+        PullRequestSCMHead head = buildHeadFromFork(ChangeRequestCheckoutStrategy.HEAD);
         BitbucketGitSCMBuilder instance = new BitbucketGitSCMBuilder(source,
                 head, null, "user-pass");
         assertThat(instance.credentialsId(), is("user-pass"));
@@ -2225,9 +2181,7 @@ public class BitbucketGitSCMBuilderTest {
     @Test
     public void given__server_pullHead_norev_userkey__when__build__then__scmBuilt() throws Exception {
         source.setServerUrl("https://bitbucket.test");
-        PullRequestSCMHead head = new PullRequestSCMHead("PR-1", "qa", "qa-repo", "qa-branch", "1", "a fake title",
-                new BranchSCMHead("test-branch"), new SCMHeadOrigin.Fork("qa/qa-repo"),
-                ChangeRequestCheckoutStrategy.HEAD);
+        PullRequestSCMHead head = buildHeadFromFork(ChangeRequestCheckoutStrategy.HEAD);
         BitbucketGitSCMBuilder instance = new BitbucketGitSCMBuilder(source, head, null, "user-key");
         assertThat(instance.credentialsId(), is("user-key"));
         assertThat(instance.head(), is((SCMHead) head));
@@ -2269,9 +2223,7 @@ public class BitbucketGitSCMBuilderTest {
     @Test
     public void given__server_pullHead_norev_userkey__when_different_clone_url__build__then__scmBuilt() throws Exception {
         source.setServerUrl("https://www.bitbucket.test/web");
-        PullRequestSCMHead head = new PullRequestSCMHead("PR-1", "qa", "qa-repo", "qa-branch", "1", "a fake title",
-                new BranchSCMHead("test-branch"), new SCMHeadOrigin.Fork("qa/qa-repo"),
-                ChangeRequestCheckoutStrategy.HEAD);
+        PullRequestSCMHead head = buildHeadFromFork(ChangeRequestCheckoutStrategy.HEAD);
         BitbucketGitSCMBuilder instance = new BitbucketGitSCMBuilder(source, head, null, "user-key");
         assertThat(instance.credentialsId(), is("user-key"));
         assertThat(instance.head(), is((SCMHead) head));
@@ -2312,9 +2264,7 @@ public class BitbucketGitSCMBuilderTest {
 
     @Test
     public void given__cloud_pullMerge_rev_anon__when__build__then__scmBuilt() throws Exception {
-        PullRequestSCMHead head = new PullRequestSCMHead("PR-1", "qa", "qa-repo", "qa-branch", "1", "a fake title",
-                new BranchSCMHead("test-branch"), new SCMHeadOrigin.Fork("qa/qa-repo"),
-                ChangeRequestCheckoutStrategy.MERGE);
+        PullRequestSCMHead head = buildHeadFromFork(ChangeRequestCheckoutStrategy.MERGE);
         PullRequestSCMRevision revision =
                 new PullRequestSCMRevision(head, new AbstractGitSCMSource.SCMRevisionImpl(head.getTarget(),
                         "deadbeefcafebabedeadbeefcafebabedeadbeef"),
@@ -2386,9 +2336,7 @@ public class BitbucketGitSCMBuilderTest {
 
     @Test
     public void given__cloud_pullMerge_rev_userpass__when__build__then__scmBuilt() throws Exception {
-        PullRequestSCMHead head = new PullRequestSCMHead("PR-1", "qa", "qa-repo", "qa-branch", "1", "a fake title",
-                new BranchSCMHead("test-branch"), new SCMHeadOrigin.Fork("qa/qa-repo"),
-                ChangeRequestCheckoutStrategy.MERGE);
+        PullRequestSCMHead head = buildHeadFromFork(ChangeRequestCheckoutStrategy.MERGE);
         PullRequestSCMRevision revision =
                 new PullRequestSCMRevision(head, new AbstractGitSCMSource.SCMRevisionImpl(head.getTarget(),
                         "deadbeefcafebabedeadbeefcafebabedeadbeef"),
@@ -2460,9 +2408,7 @@ public class BitbucketGitSCMBuilderTest {
 
     @Test
     public void given__cloud_pullMerge_rev_userkey__when__build__then__scmBuilt() throws Exception {
-        PullRequestSCMHead head = new PullRequestSCMHead("PR-1", "qa", "qa-repo", "qa-branch", "1", "a fake title",
-                new BranchSCMHead("test-branch"), new SCMHeadOrigin.Fork("qa/qa-repo"),
-                ChangeRequestCheckoutStrategy.MERGE);
+        PullRequestSCMHead head = buildHeadFromFork(ChangeRequestCheckoutStrategy.MERGE);
         PullRequestSCMRevision revision =
                 new PullRequestSCMRevision(head, new AbstractGitSCMSource.SCMRevisionImpl(head.getTarget(),
                         "deadbeefcafebabedeadbeefcafebabedeadbeef"),
@@ -2533,9 +2479,7 @@ public class BitbucketGitSCMBuilderTest {
 
     @Test
     public void given__cloud_pullMerge_norev_anon__when__build__then__scmBuilt() throws Exception {
-        PullRequestSCMHead head = new PullRequestSCMHead("PR-1", "qa", "qa-repo", "qa-branch", "1", "a fake title",
-                new BranchSCMHead("test-branch"), new SCMHeadOrigin.Fork("qa/qa-repo"),
-                ChangeRequestCheckoutStrategy.MERGE);
+        PullRequestSCMHead head = buildHeadFromFork(ChangeRequestCheckoutStrategy.MERGE);
         BitbucketGitSCMBuilder instance = new BitbucketGitSCMBuilder(source,
                 head, null, null);
         assertThat(instance.credentialsId(), is(nullValue()));
@@ -2591,9 +2535,7 @@ public class BitbucketGitSCMBuilderTest {
 
     @Test
     public void given__cloud_pullMerge_norev_userpass__when__build__then__scmBuilt() throws Exception {
-        PullRequestSCMHead head = new PullRequestSCMHead("PR-1", "qa", "qa-repo", "qa-branch", "1", "a fake title",
-                new BranchSCMHead("test-branch"), new SCMHeadOrigin.Fork("qa/qa-repo"),
-                ChangeRequestCheckoutStrategy.MERGE);
+        PullRequestSCMHead head = buildHeadFromFork(ChangeRequestCheckoutStrategy.MERGE);
         BitbucketGitSCMBuilder instance = new BitbucketGitSCMBuilder(source,
                 head, null, "user-pass");
         assertThat(instance.credentialsId(), is("user-pass"));
@@ -2649,9 +2591,7 @@ public class BitbucketGitSCMBuilderTest {
 
     @Test
     public void given__cloud_pullMerge_norev_userkey__when__build__then__scmBuilt() throws Exception {
-        PullRequestSCMHead head = new PullRequestSCMHead("PR-1", "qa", "qa-repo", "qa-branch", "1", "a fake title",
-                new BranchSCMHead("test-branch"), new SCMHeadOrigin.Fork("qa/qa-repo"),
-                ChangeRequestCheckoutStrategy.MERGE);
+        PullRequestSCMHead head = buildHeadFromFork(ChangeRequestCheckoutStrategy.MERGE);
         BitbucketGitSCMBuilder instance = new BitbucketGitSCMBuilder(source, head, null, "user-key");
         assertThat(instance.credentialsId(), is("user-key"));
         assertThat(instance.head(), is((SCMHead) head));
@@ -2707,9 +2647,7 @@ public class BitbucketGitSCMBuilderTest {
     @Test
     public void given__server_pullMerge_rev_anon__when__build__then__scmBuilt() throws Exception {
         source.setServerUrl("https://bitbucket.test");
-        PullRequestSCMHead head = new PullRequestSCMHead("PR-1", "qa", "qa-repo", "qa-branch", "1", "a fake title",
-                new BranchSCMHead("test-branch"), new SCMHeadOrigin.Fork("qa/qa-repo"),
-                ChangeRequestCheckoutStrategy.MERGE);
+        PullRequestSCMHead head = buildHeadFromFork(ChangeRequestCheckoutStrategy.MERGE);
         PullRequestSCMRevision revision =
                 new PullRequestSCMRevision(head, new AbstractGitSCMSource.SCMRevisionImpl(head.getTarget(),
                         "deadbeefcafebabedeadbeefcafebabedeadbeef"),
@@ -2785,9 +2723,7 @@ public class BitbucketGitSCMBuilderTest {
     @Test
     public void given__server_pullMerge_rev_userpass__when__build__then__scmBuilt() throws Exception {
         source.setServerUrl("https://bitbucket.test");
-        PullRequestSCMHead head = new PullRequestSCMHead("PR-1", "qa", "qa-repo", "qa-branch", "1", "a fake title",
-                new BranchSCMHead("test-branch"), new SCMHeadOrigin.Fork("qa/qa-repo"),
-                ChangeRequestCheckoutStrategy.MERGE);
+        PullRequestSCMHead head = buildHeadFromFork(ChangeRequestCheckoutStrategy.MERGE);
         PullRequestSCMRevision revision =
                 new PullRequestSCMRevision(head, new AbstractGitSCMSource.SCMRevisionImpl(head.getTarget(),
                         "deadbeefcafebabedeadbeefcafebabedeadbeef"),
@@ -2862,9 +2798,7 @@ public class BitbucketGitSCMBuilderTest {
     @Test
     public void given__server_pullMerge_rev_userkey__when__build__then__scmBuilt() throws Exception {
         source.setServerUrl("https://bitbucket.test");
-        PullRequestSCMHead head = new PullRequestSCMHead("PR-1", "qa", "qa-repo", "qa-branch", "1", "a fake title",
-                new BranchSCMHead("test-branch"), new SCMHeadOrigin.Fork("qa/qa-repo"),
-                ChangeRequestCheckoutStrategy.MERGE);
+        PullRequestSCMHead head = buildHeadFromFork(ChangeRequestCheckoutStrategy.MERGE);
         PullRequestSCMRevision revision =
                 new PullRequestSCMRevision(head, new AbstractGitSCMSource.SCMRevisionImpl(head.getTarget(),
                         "deadbeefcafebabedeadbeefcafebabedeadbeef"),
@@ -2938,9 +2872,7 @@ public class BitbucketGitSCMBuilderTest {
     @Test
     public void given__server_pullMerge_rev_userkey__when_different_clone_url__build__then__scmBuilt() throws Exception {
         source.setServerUrl("https://www.bitbucket.test/web");
-        PullRequestSCMHead head = new PullRequestSCMHead("PR-1", "qa", "qa-repo", "qa-branch", "1", "a fake title",
-                new BranchSCMHead("test-branch"), new SCMHeadOrigin.Fork("qa/qa-repo"),
-                ChangeRequestCheckoutStrategy.MERGE);
+        PullRequestSCMHead head = buildHeadFromFork(ChangeRequestCheckoutStrategy.MERGE);
         PullRequestSCMRevision revision =
                 new PullRequestSCMRevision(head, new AbstractGitSCMSource.SCMRevisionImpl(head.getTarget(),
                         "deadbeefcafebabedeadbeefcafebabedeadbeef"),
@@ -3014,9 +2946,7 @@ public class BitbucketGitSCMBuilderTest {
     @Test
     public void given__server_pullMerge_norev_anon__when__build__then__scmBuilt() throws Exception {
         source.setServerUrl("https://bitbucket.test");
-        PullRequestSCMHead head = new PullRequestSCMHead("PR-1", "qa", "qa-repo", "qa-branch", "1", "a fake title",
-                new BranchSCMHead("test-branch"), new SCMHeadOrigin.Fork("qa/qa-repo"),
-                ChangeRequestCheckoutStrategy.MERGE);
+        PullRequestSCMHead head = buildHeadFromFork(ChangeRequestCheckoutStrategy.MERGE);
         BitbucketGitSCMBuilder instance = new BitbucketGitSCMBuilder(source,
                 head, null, null);
         assertThat(instance.credentialsId(), is(nullValue()));
@@ -3076,9 +3006,7 @@ public class BitbucketGitSCMBuilderTest {
     @Test
     public void given__server_pullMerge_norev_userpass__when__build__then__scmBuilt() throws Exception {
         source.setServerUrl("https://bitbucket.test");
-        PullRequestSCMHead head = new PullRequestSCMHead("PR-1", "qa", "qa-repo", "qa-branch", "1", "a fake title",
-                new BranchSCMHead("test-branch"), new SCMHeadOrigin.Fork("qa/qa-repo"),
-                ChangeRequestCheckoutStrategy.MERGE);
+        PullRequestSCMHead head = buildHeadFromFork(ChangeRequestCheckoutStrategy.MERGE);
         BitbucketGitSCMBuilder instance = new BitbucketGitSCMBuilder(source,
                 head, null, "user-pass");
         assertThat(instance.credentialsId(), is("user-pass"));
@@ -3138,9 +3066,7 @@ public class BitbucketGitSCMBuilderTest {
     @Test
     public void given__server_pullMerge_norev_userkey__when__build__then__scmBuilt() throws Exception {
         source.setServerUrl("https://bitbucket.test");
-        PullRequestSCMHead head = new PullRequestSCMHead("PR-1", "qa", "qa-repo", "qa-branch", "1", "a fake title",
-                new BranchSCMHead("test-branch"), new SCMHeadOrigin.Fork("qa/qa-repo"),
-                ChangeRequestCheckoutStrategy.MERGE);
+        PullRequestSCMHead head = buildHeadFromFork(ChangeRequestCheckoutStrategy.MERGE);
         BitbucketGitSCMBuilder instance = new BitbucketGitSCMBuilder(source, head, null, "user-key");
         assertThat(instance.credentialsId(), is("user-key"));
         assertThat(instance.head(), is((SCMHead) head));
@@ -3199,9 +3125,7 @@ public class BitbucketGitSCMBuilderTest {
     @Test
     public void given__server_pullMerge_norev_userkey_different_clone_url__when__build__then__scmBuilt() throws Exception {
         source.setServerUrl("https://www.bitbucket.test/web");
-        PullRequestSCMHead head = new PullRequestSCMHead("PR-1", "qa", "qa-repo", "qa-branch", "1", "a fake title",
-                new BranchSCMHead("test-branch"), new SCMHeadOrigin.Fork("qa/qa-repo"),
-                ChangeRequestCheckoutStrategy.MERGE);
+        PullRequestSCMHead head = buildHeadFromFork(ChangeRequestCheckoutStrategy.MERGE);
         BitbucketGitSCMBuilder instance = new BitbucketGitSCMBuilder(source, head, null, "user-key");
         assertThat(instance.credentialsId(), is("user-key"));
         assertThat(instance.head(), is((SCMHead) head));
@@ -3273,4 +3197,20 @@ public class BitbucketGitSCMBuilderTest {
             new BitbucketHref("ssh", String.format("ssh://git@%s/%s/%s.git", serverURL.getHost(), source.getRepoOwner(), source.getRepository()))
         );
     }
+
+
+    private PullRequestSCMHead buildHead(@NonNull ChangeRequestCheckoutStrategy checkoutStrategy) {
+        return new PullRequestSCMHead("PR-1", "tester", "test-repo", "pr-branch",
+                PullRequestBranchType.BRANCH, "1", "a fake title",
+                new BranchSCMHead("test-branch"), SCMHeadOrigin.DEFAULT,
+                checkoutStrategy);
+    }
+
+    private PullRequestSCMHead buildHeadFromFork(@NonNull ChangeRequestCheckoutStrategy checkoutStrategy) {
+        return new PullRequestSCMHead("PR-1", "qa", "qa-repo", "qa-branch",
+                PullRequestBranchType.BRANCH, "1", "a fake title",
+                new BranchSCMHead("test-branch"), new SCMHeadOrigin.Fork("qa/qa-repo"),
+                checkoutStrategy);
+    }
+
 }

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/NativeServerPullRequestHookProcessorTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/NativeServerPullRequestHookProcessorTest.java
@@ -1,0 +1,97 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2025, Allan Burdajewicz
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.cloudbees.jenkins.plugins.bitbucket.hooks;
+
+import com.cloudbees.jenkins.plugins.bitbucket.BitbucketSCMSource;
+import com.cloudbees.jenkins.plugins.bitbucket.BranchSCMHead;
+import com.cloudbees.jenkins.plugins.bitbucket.OriginPullRequestDiscoveryTrait;
+import com.cloudbees.jenkins.plugins.bitbucket.PullRequestSCMHead;
+import com.cloudbees.jenkins.plugins.bitbucket.api.PullRequestBranchType;
+import hudson.scm.SCM;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import jenkins.scm.api.SCMEvent;
+import jenkins.scm.api.SCMHead;
+import jenkins.scm.api.SCMHeadEvent;
+import jenkins.scm.api.SCMHeadOrigin;
+import jenkins.scm.api.SCMRevision;
+import jenkins.scm.api.mixin.ChangeRequestCheckoutStrategy;
+import org.apache.commons.io.IOUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+class NativeServerPullRequestHookProcessorTest {
+
+    private static final String SERVER_URL = "http://localhost:7990";
+    private NativeServerPullRequestHookProcessor sut;
+    private SCMHeadEvent<?> scmEvent;
+
+    @BeforeEach
+    void setup() {
+        sut = new NativeServerPullRequestHookProcessor() {
+            @Override
+            protected void notifyEvent(SCMHeadEvent<?> event, int delaySeconds) {
+                NativeServerPullRequestHookProcessorTest.this.scmEvent = event;
+            }
+        };
+    }
+
+    @WithJenkins
+    @Test
+    @Issue("JENKINS-75523")
+    void test_pr_where_source_is_tag(JenkinsRule rule) throws Exception {
+        sut.process(HookEventType.SERVER_PULL_REQUEST_OPENED, loadResource("native/prOpenFromTagPayload.json"), BitbucketType.SERVER, "origin", SERVER_URL);
+
+        ServerHeadEvent event = (ServerHeadEvent) scmEvent;
+        assertThat(event).isNotNull();
+        assertThat(event.getSourceName()).isEqualTo("test-repos");
+        assertThat(event.getType()).isEqualTo(SCMEvent.Type.CREATED);
+        assertThat(event.isMatch(mock(SCM.class))).isFalse();
+
+        BitbucketSCMSource scmSource = new BitbucketSCMSource("aMUNIZ", "test-repos");
+        scmSource.setTraits(List.of(new OriginPullRequestDiscoveryTrait(Set.of(ChangeRequestCheckoutStrategy.HEAD))));
+        Map<SCMHead, SCMRevision> heads = event.heads(scmSource);
+        assertThat(heads.keySet())
+            .first()
+            .usingRecursiveComparison()
+            .isEqualTo(new PullRequestSCMHead("PR-1", "AMUNIZ", "test-repos", "v1.0", PullRequestBranchType.TAG,
+                    "1", "pr from tag", new BranchSCMHead("master"), SCMHeadOrigin.DEFAULT, ChangeRequestCheckoutStrategy.HEAD));
+    }
+
+    private String loadResource(String resource) throws IOException {
+        try (InputStream stream = this.getClass().getResourceAsStream(resource)) {
+            return IOUtils.toString(stream, StandardCharsets.UTF_8);
+        }
+    }
+}

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/impl/notifier/BitbucketBuildStatusNotificationsJUnit5Test.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/impl/notifier/BitbucketBuildStatusNotificationsJUnit5Test.java
@@ -34,6 +34,7 @@ import com.cloudbees.jenkins.plugins.bitbucket.PullRequestSCMRevision;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketApi;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketBuildStatus;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketBuildStatus.Status;
+import com.cloudbees.jenkins.plugins.bitbucket.api.PullRequestBranchType;
 import com.cloudbees.jenkins.plugins.bitbucket.client.BitbucketCloudApiClient;
 import com.cloudbees.jenkins.plugins.bitbucket.endpoints.BitbucketCloudEndpoint;
 import com.cloudbees.jenkins.plugins.bitbucket.endpoints.BitbucketEndpointConfiguration;
@@ -182,7 +183,8 @@ class BitbucketBuildStatusNotificationsJUnit5Test {
 
         ForkPullRequestDiscoveryTrait trait = new ForkPullRequestDiscoveryTrait(2, new TrustEveryone());
         BranchSCMHead targetHead = new BranchSCMHead("master");
-        PullRequestSCMHead scmHead = new PullRequestSCMHead("name", "repoOwner", "repository1", "feature1", "1", "title", targetHead, new Fork("repository1"), ChangeRequestCheckoutStrategy.HEAD);
+        PullRequestSCMHead scmHead = new PullRequestSCMHead("name", "repoOwner", "repository1", "feature1",
+                PullRequestBranchType.BRANCH, "1", "title", targetHead, new Fork("repository1"), ChangeRequestCheckoutStrategy.HEAD);
         SCMRevisionImpl prRevision = new SCMRevisionImpl(scmHead, "cff417db");
         SCMRevisionImpl targetRevision = new SCMRevisionImpl(targetHead, "c341232342311");
         SCMRevision scmRevision = new PullRequestSCMRevision(scmHead, targetRevision, prRevision);

--- a/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/hooks/native/prOpenFromTagPayload.json
+++ b/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/hooks/native/prOpenFromTagPayload.json
@@ -1,0 +1,124 @@
+{
+    "date": "2025-04-12T18:19:58+0000",
+    "actor": {
+        "emailAddress": "amuniz@acme.com",
+        "displayName": "amuniz",
+        "name": "amuniz",
+        "active": true,
+        "links": {"self": [{"href": "http://localhost:7990/bitbucket/users/amuniz"}]},
+        "id": 2,
+        "type": "NORMAL",
+        "slug": "amuniz"
+    },
+    "eventKey": "pr:opened",
+    "pullRequest": {
+        "author": {
+            "approved": false,
+            "role": "AUTHOR",
+            "user": {
+                "emailAddress": "amuniz@acme.com",
+                "displayName": "amuniz",
+                "name": "amuniz",
+                "active": true,
+                "links": {"self": [{"href": "http://localhost:7990/bitbucket/users/amuniz"}]},
+                "id": 2,
+                "type": "NORMAL",
+                "slug": "amuniz"
+            },
+            "status": "UNAPPROVED"
+        },
+        "updatedDate": 1744481998567,
+        "title": "pr from tag",
+        "version": 0,
+        "reviewers": [],
+        "toRef": {
+            "latestCommit": "ff55824c164c4c785810cb49f7aa44d8d68789e3",
+            "id": "refs/heads/master",
+            "displayId": "master",
+            "type": "BRANCH",
+            "repository": {
+                "archived": false,
+                "public": false,
+                "hierarchyId": "d90392f4221f3cde8980",
+                "name": "test-repos",
+                "forkable": true,
+                "project": {
+                    "public": false,
+                    "name": "Project 1",
+                    "description": "Default configuration project #1",
+                    "links": {"self": [{"href": "http://localhost:7990/bitbucket/projects/AMUNIZ"}]},
+                    "id": 1,
+                    "type": "NORMAL",
+                    "key": "AMUNIZ"
+                },
+                "links": {
+                    "clone": [
+                        {
+                            "name": "ssh",
+                            "href": "ssh://git@localhost:7999/AMUNIZ/test-repos.git"
+                        },
+                        {
+                            "name": "http",
+                            "href": "http://localhost:7990/bitbucket/scm/AMUNIZ/test-repos.git"
+                        }
+                    ],
+                    "self": [{"href": "http://localhost:7990/bitbucket/projects/AMUNIZ/repos/test-repos/browse"}]
+                },
+                "id": 2,
+                "scmId": "git",
+                "state": "AVAILABLE",
+                "slug": "test-repos",
+                "statusMessage": "Available"
+            }
+        },
+        "createdDate": 1744481998567,
+        "draft": false,
+        "closed": false,
+        "fromRef": {
+            "latestCommit": "f0d122cd8b8bc393eb1953f4127a4addeae8fe97",
+            "id": "refs/tags/v1.0",
+            "displayId": "v1.0",
+            "type": "TAG",
+            "repository": {
+                "archived": false,
+                "public": false,
+                "hierarchyId": "d90392f4221f3cde8980",
+                "name": "test-repos",
+                "forkable": true,
+                "project": {
+                    "public": false,
+                    "name": "Project 1",
+                    "description": "Default configuration project #1",
+                    "links": {"self": [{"href": "http://localhost:7990/bitbucket/projects/AMUNIZ"}]},
+                    "id": 1,
+                    "type": "NORMAL",
+                    "key": "AMUNIZ"
+                },
+                "links": {
+                    "clone": [
+                        {
+                            "name": "ssh",
+                            "href": "ssh://git@localhost:7999/AMUNIZ/test-repos.git"
+                        },
+                        {
+                            "name": "http",
+                            "href": "http://localhost:7990/bitbucket/scm/AMUNIZ/test-repos.git"
+                        }
+                    ],
+                    "self": [{"href": "http://localhost:7990/bitbucket/projects/AMUNIZ/repos/test-repos/browse"}]
+                },
+                "id": 2,
+                "scmId": "git",
+                "state": "AVAILABLE",
+                "slug": "test-repos",
+                "statusMessage": "Available"
+            }
+        },
+        "links": {"self": [{"href": "http://localhost:7990/bitbucket/projects/AMUNIZ/repos/test-repos/pull-requests/1"}]},
+        "id": 1,
+        "state": "OPEN",
+        "locked": false,
+        "open": true,
+        "participants": []
+    }
+}


### PR DESCRIPTION
Add a new branchType field in the pull request bean that is used to identify in case of pull requests for which the source HEAD is a tag instead of branch. This kind of pull request are available only in Bitbucket DataCenter. Failure during checkout of PR jobs from HEAD tag has been resolved using as source reference "+refs/tags/<tag_name>:..." instead of "+refs/heads/<tag_name>:...".