### PR TITLE
Rework the GitClientAuthenticatorExtension

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource.java
@@ -723,10 +723,11 @@ public class BitbucketSCMSource extends SCMSource {
                 .withTraits(traits);
 
         boolean sshAuth = SCMTrait.find(traits, SSHCheckoutTrait.class) != null;
-        BitbucketAuthenticator authenticator = authenticator();
 
+        SCMSourceOwner owner = getOwner();
+        String scmOwner = owner != null ? owner.getFullName() : null;
         return scmBuilder
-                .withExtension(new GitClientAuthenticatorExtension(scmBuilder.remote(), authenticator == null || sshAuth ? null : authenticator.getCredentialsForSCM()))
+                .withExtension(new GitClientAuthenticatorExtension(scmBuilder.remote(), serverUrl, scmOwner, sshAuth ? null : credentialsId))
                 .build();
     }
 

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/impl/util/BitbucketCredentials.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/impl/util/BitbucketCredentials.java
@@ -33,6 +33,8 @@ import com.cloudbees.plugins.credentials.common.StandardListBoxModel;
 import com.cloudbees.plugins.credentials.domains.URIRequirementBuilder;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.model.Item;
+import hudson.model.ItemGroup;
 import hudson.model.Queue;
 import hudson.security.ACL;
 import hudson.security.AccessControlled;
@@ -53,27 +55,49 @@ public class BitbucketCredentials {
     }
 
     @CheckForNull
-    public static <T extends StandardCredentials> T lookupCredentials(@CheckForNull String serverUrl,
-                                                                      @CheckForNull SCMSourceOwner context,
+    public static <T extends StandardCredentials> T lookupCredentials(@CheckForNull String serverURL,
+                                                                      @CheckForNull Item item,
                                                                       @CheckForNull String id,
                                                                       @NonNull Class<T> type) {
-        if (StringUtils.isNotBlank(id) && context != null) {
-            Authentication authentication = context instanceof Queue.Task task
+        if (StringUtils.isNotBlank(id)) {
+            Authentication authentication = item instanceof Queue.Task task
                     ? task.getDefaultAuthentication2()
                     : ACL.SYSTEM2;
 
             return CredentialsMatchers.firstOrNull(
                     CredentialsProvider.lookupCredentialsInItem(
                             type,
-                            context,
+                            item,
                             authentication,
-                            URIRequirementBuilder.fromUri(serverUrl).build()
+                            URIRequirementBuilder.fromUri(serverURL).build()
                     ),
                     CredentialsMatchers.allOf(
                             CredentialsMatchers.withId(id),
                             CredentialsMatchers.anyOf(CredentialsMatchers.instanceOf(type))
                     )
             );
+        }
+        return null;
+    }
+
+    @CheckForNull
+    public static <T extends StandardCredentials> T lookupCredentials(@CheckForNull String serverURL,
+                                                                      @CheckForNull ItemGroup<?> itemGroup,
+                                                                      @CheckForNull String id,
+                                                                      @NonNull Class<T> type) {
+        if (StringUtils.isNotBlank(id)) {
+            return CredentialsMatchers.firstOrNull(
+                    CredentialsProvider.lookupCredentialsInItemGroup(
+                            type,
+                            itemGroup,
+                            null,
+                            URIRequirementBuilder.fromUri(serverURL).build()
+                            ),
+                    CredentialsMatchers.allOf(
+                            CredentialsMatchers.withId(id),
+                            CredentialsMatchers.anyOf(CredentialsMatchers.instanceOf(type))
+                            )
+                    );
         }
         return null;
     }

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSourceTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSourceTest.java
@@ -288,7 +288,7 @@ class BitbucketSCMSourceTest {
 
     @Test
     void verify_built_scm_with_username_password_authenticator() throws Exception {
-        UsernamePasswordCredentialsImpl userCredentials = new UsernamePasswordCredentialsImpl(CredentialsScope.GLOBAL, "token-id", "desc", "user", "passqword");
+        UsernamePasswordCredentialsImpl userCredentials = new UsernamePasswordCredentialsImpl(CredentialsScope.GLOBAL, "username-password", "desc", "user", "password");
 
         CredentialsStore store = CredentialsProvider.lookupStores(j.getInstance()).iterator().next();
         store.addCredentials(Domain.global(), userCredentials);
@@ -307,6 +307,7 @@ class BitbucketSCMSourceTest {
         for (GitSCMExtension ext : scm.getExtensions()) {
             c = ext.decorate(scm, c);
         }
+        // GitClientAuthenticatorExtension never inject custom credentials for standard username/password
         verify(c, never()).setCredentials(any(StandardUsernameCredentials.class));
         verify(c, never()).addCredentials(anyString(), any(StandardUsernameCredentials.class));
     }


### PR DESCRIPTION
The git extension is used to pass inject credentials into the git client before checkout, these changes remove credentials implementation stored in config.xml that potentially could not be updated and cause an authentication failure hidden behind other IOException.