### PR TITLE
[JENKINS-75555] InvalidObjectIdException when "Scan Project Now" and multibranch-build-strategy plugin is installed

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -8,8 +8,7 @@
     </module>
 
     <module name="FileTabCharacter" />
-    <module name="NewlineAtEndOfFile">
-    </module>
+
     <module name="RegexpSingleline">
         <property name="format" value="\s+$" />
         <property name="message" value="Trailing spaces are not allowed." />

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/PullRequestSCMRevision.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/PullRequestSCMRevision.java
@@ -23,9 +23,7 @@
  */
 package com.cloudbees.jenkins.plugins.bitbucket;
 
-import com.infradna.tool.bridge_method_injector.WithBridgeMethods;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import jenkins.plugins.git.AbstractGitSCMSource;
 import jenkins.scm.api.SCMRevision;
 import jenkins.scm.api.mixin.ChangeRequestCheckoutStrategy;
 import jenkins.scm.api.mixin.ChangeRequestSCMRevision;
@@ -42,7 +40,7 @@ public class PullRequestSCMRevision extends ChangeRequestSCMRevision<PullRequest
      * The pull head revision.
      */
     @NonNull
-    private final AbstractGitSCMSource.SCMRevisionImpl pull;
+    private final SCMRevision pull;
 
     /**
      * Constructor.
@@ -51,7 +49,7 @@ public class PullRequestSCMRevision extends ChangeRequestSCMRevision<PullRequest
      * @param target the target revision.
      * @param pull   the pull revision.
      */
-    public PullRequestSCMRevision(@NonNull PullRequestSCMHead head, @NonNull AbstractGitSCMSource.SCMRevisionImpl target, @NonNull AbstractGitSCMSource.SCMRevisionImpl pull) {
+    public PullRequestSCMRevision(@NonNull PullRequestSCMHead head, @NonNull SCMRevision target, @NonNull SCMRevision pull) {
         super(head, target);
         this.pull = pull;
     }
@@ -61,8 +59,8 @@ public class PullRequestSCMRevision extends ChangeRequestSCMRevision<PullRequest
      *
      * @return the pull revision.
      */
-    @NonNull @WithBridgeMethods(SCMRevision.class)
-    public AbstractGitSCMSource.SCMRevisionImpl getPull() {
+    @NonNull
+    public SCMRevision getPull() {
         return pull;
     }
 
@@ -76,10 +74,6 @@ public class PullRequestSCMRevision extends ChangeRequestSCMRevision<PullRequest
         }
         PullRequestSCMRevision other = (PullRequestSCMRevision) o;
         return getHead().equals(other.getHead()) && pull.equals(other.pull);
-    }
-
-    public AbstractGitSCMSource.SCMRevisionImpl getTargetImpl() {
-        return (AbstractGitSCMSource.SCMRevisionImpl) getTarget();
     }
 
     /**

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/branch/BitbucketCloudAuthor.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/branch/BitbucketCloudAuthor.java
@@ -23,6 +23,10 @@
  */
 package com.cloudbees.jenkins.plugins.bitbucket.client.branch;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import edu.umd.cs.findbugs.annotations.NonNull;
+
 /**
  * Represents the author information given by Bitbucket Cloud.
  *
@@ -31,6 +35,11 @@ package com.cloudbees.jenkins.plugins.bitbucket.client.branch;
  */
 public class BitbucketCloudAuthor {
     private String raw;
+
+    @JsonCreator
+    public BitbucketCloudAuthor(@NonNull @JsonProperty("raw") String raw) {
+        this.raw = raw;
+    }
 
     /**
      * Returns the raw author string provided by the commit.

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/pullrequest/BitbucketCloudPullRequestCommit.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/pullrequest/BitbucketCloudPullRequestCommit.java
@@ -50,9 +50,10 @@ public class BitbucketCloudPullRequestCommit implements BitbucketCommit {
 
     public void setAuthor(String author) {
         if (this.author == null) {
-            this.author = new BitbucketCloudAuthor();
+            this.author = new BitbucketCloudAuthor(author);
+        } else {
+            this.author.setRaw(author);
         }
-        this.author.setRaw(author);
     }
 
     @Override

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/NativeServerPushHookProcessor.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/NativeServerPushHookProcessor.java
@@ -87,7 +87,8 @@ public class NativeServerPushHookProcessor extends HookProcessor {
                     return;
                 }
             } else {
-                throw new UnsupportedOperationException("Unsupported hook event " + hookEvent);
+                throw new UnsupportedOperationException("Hook event of type " + hookEvent + " is not supported.\n"
+                        + "Please fill an issue at https://issues.jenkins.io to the bitbucket-branch-source-plugin component.");
             }
         } catch (final IOException e) {
             LOGGER.log(Level.SEVERE, "Can not read hook payload", e);

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/impl/util/BitbucketApiUtils.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/impl/util/BitbucketApiUtils.java
@@ -66,7 +66,7 @@ public class BitbucketApiUtils {
     }
 
     public static boolean isCloud(@NonNull String serverURL) {
-        return StringUtils.startsWithAny(serverURL, new String[] { BitbucketCloudEndpoint.SERVER_URL, BitbucketCloudEndpoint.BAD_SERVER_URL });
+        return StringUtils.startsWithAny(serverURL, BitbucketCloudEndpoint.SERVER_URL, BitbucketCloudEndpoint.BAD_SERVER_URL);
     }
 
     public static ListBoxModel getFromBitbucket(SCMSourceOwner context,

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/impl/util/SCMUtils.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/impl/util/SCMUtils.java
@@ -1,0 +1,66 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2025, Nikolas Falco
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.cloudbees.jenkins.plugins.bitbucket.impl.util;
+
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import jenkins.plugins.git.AbstractGitSCMSource.SCMRevisionImpl;
+import jenkins.scm.api.SCMRevision;
+import jenkins.scm.api.mixin.ChangeRequestSCMRevision;
+
+/**
+ * Utility class that helps to extract specific information from implementation
+ * of SCM base classes.
+ *
+ * @author Nikolas Falco
+ * @since 936.1.0
+ */
+public final class SCMUtils {
+
+    private SCMUtils() {
+    }
+
+    /**
+     * Returns the SHA1 hash for the given SCMRevision implementation.
+     * <p>
+     * In case of ChangeRequestSCMRevision returns the SHA1 hash of the target.
+     *
+     * @param revision extract from
+     * @return a SHA1 commit hash in the revision if present
+     */
+    @CheckForNull
+    public static String getHash(@Nullable SCMRevision revision) {
+        if (revision == null) {
+            return null;
+        } else if (revision instanceof SCMRevisionImpl gitRev) {
+            return gitRev.getHash();
+        } else if (revision instanceof ChangeRequestSCMRevision<?> prRev) {
+            return getHash(prRev.getTarget());
+        } else {
+            throw new UnsupportedOperationException("Revision of type " + revision.getClass().getSimpleName() + " is not supported.\n"
+                    + "Please fill an issue at https://issues.jenkins.io to the bitbucket-branch-source-plugin component.");
+        }
+    }
+
+}

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketClientMockUtils.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketClientMockUtils.java
@@ -211,8 +211,7 @@ public class BitbucketClientMockUtils {
     }
 
     private static BitbucketCloudCommit buildCommit(String message, String date, String hash, String authorName) {
-        BitbucketCloudAuthor author = new BitbucketCloudAuthor();
-        author.setRaw(authorName);
+        BitbucketCloudAuthor author = new BitbucketCloudAuthor(authorName);
         return new BitbucketCloudCommit(message, date, hash, author, author, Collections.emptyList());
     }
 

--- a/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/client/payload/2.0-repositories-amuniz-test-repos-pullrequests-1.json
+++ b/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/client/payload/2.0-repositories-amuniz-test-repos-pullrequests-1.json
@@ -1,140 +1,140 @@
 {
-  "description": "* Add license\r\n\r\n* [CI] Release version 1.0.0",
-  "links": {
-    "decline": {
-      "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/pullrequests/1/decline"
-    },
-    "commits": {
-      "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/pullrequests/1/commits"
-    },
-    "self": {
-      "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/pullrequests/1"
-    },
-    "comments": {
-      "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/pullrequests/1/comments"
-    },
-    "merge": {
-      "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/pullrequests/1/merge"
-    },
-    "html": {
-      "href": "https://bitbucket.org/amuniz/test-repos/pull-requests/1"
-    },
-    "activity": {
-      "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/pullrequests/1/activity"
-    },
-    "diff": {
-      "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/pullrequests/1/diff"
-    },
-    "approve": {
-      "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/pullrequests/1/approve"
-    },
-    "statuses": {
-      "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/pullrequests/1/statuses"
-    }
-  },
-  "title": "Release/release 1",
-  "close_source_branch": true,
-  "type": "pullrequest",
-  "id": 1,
-  "destination": {
-    "commit": {
-      "hash": "bf4f4ce8a3a8",
-      "type": "commit",
-      "links": {
-        "self": {
-          "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/commit/bf4f4ce8a3a8"
-        },
-        "html": {
-          "href": "https://bitbucket.org/amuniz/test-repos/commits/bf4f4ce8a3a8"
-        }
-      }
-    },
-    "repository": {
-      "links": {
-        "self": {
-          "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos"
-        },
-        "html": {
-          "href": "https://bitbucket.org/amuniz/test-repos"
-        },
-        "avatar": {
-          "href": "https://bytebucket.org/ravatar/%7B3deb8c29-778a-450c-8f69-3e50a18079df%7D?ts=default"
-        }
-      },
-      "type": "repository",
-      "name": "test-repos",
-      "full_name": "amuniz/test-repos",
-      "uuid": "{3deb8c29-778a-450c-8f69-3e50a18079df}"
-    },
-    "branch": {
-      "name": "main"
-    }
-  },
-  "created_on": "2018-09-21T14:57:59.455870+00:00",
-  "summary": {
-    "raw": "* Add license\r\n\r\n* [CI] Release version 1.0.0",
-    "markup": "markdown",
-    "html": "<ul>\n<li>\n<p>Add license</p>\n</li>\n<li>\n<p>[CI] Release version 1.0.0</p>\n</li>\n</ul>",
-    "type": "rendered"
-  },
-  "source": {
-    "commit": {
-      "hash": "bf0e8b7962c0",
-      "type": "commit",
-      "links": {
-        "self": {
-          "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/commit/bf0e8b7962c0"
-        },
-        "html": {
-          "href": "https://bitbucket.org/amuniz/test-repos/commits/bf0e8b7962c0"
-        }
-      }
-    },
-    "repository": {
-      "links": {
-        "self": {
-          "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos"
-        },
-        "html": {
-          "href": "https://bitbucket.org/amuniz/test-repos"
-        },
-        "avatar": {
-          "href": "https://bytebucket.org/ravatar/%7B3deb8c29-778a-450c-8f69-3e50a18079df%7D?ts=default"
-        }
-      },
-      "type": "repository",
-      "name": "test-repos",
-      "full_name": "amuniz/test-repos",
-      "uuid": "{3deb8c29-778a-450c-8f69-3e50a18079df}"
-    },
-    "branch": {
-      "name": "release/release-1"
-    }
-  },
-  "comment_count": 0,
-  "state": "OPEN",
-  "task_count": 0,
-  "reason": "",
-  "updated_on": "2018-09-21T14:57:59.488719+00:00",
-  "author": {
-    "username": "amuniz",
-    "display_name": "Nikolas Falco",
-    "account_id": "557058:ca1cd232-2017-4216-94be-99637899e18d",
+    "description": "* Add license\r\n\r\n* [CI] Release version 1.0.0",
     "links": {
-      "self": {
-        "href": "https://api.bitbucket.org/2.0/users/amuniz"
-      },
-      "html": {
-        "href": "https://bitbucket.org/amuniz/"
-      },
-      "avatar": {
-        "href": "https://bitbucket.org/account/amuniz/avatar/"
-      }
+        "decline": {
+            "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/pullrequests/1/decline"
+        },
+        "commits": {
+            "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/pullrequests/1/commits"
+        },
+        "self": {
+            "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/pullrequests/1"
+        },
+        "comments": {
+            "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/pullrequests/1/comments"
+        },
+        "merge": {
+            "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/pullrequests/1/merge"
+        },
+        "html": {
+            "href": "https://bitbucket.org/amuniz/test-repos/pull-requests/1"
+        },
+        "activity": {
+            "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/pullrequests/1/activity"
+        },
+        "diff": {
+            "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/pullrequests/1/diff"
+        },
+        "approve": {
+            "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/pullrequests/1/approve"
+        },
+        "statuses": {
+            "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/pullrequests/1/statuses"
+        }
     },
-    "nickname": "amuniz",
-    "type": "user",
-    "uuid": "{644c7fc2-b15a-4445-9f89-35390694fac9}"
-  },
-  "merge_commit": null,
-  "closed_by": null
+    "title": "Release/release 1",
+    "close_source_branch": true,
+    "type": "pullrequest",
+    "id": 1,
+    "destination": {
+        "commit": {
+            "hash": "bf4f4ce8a3a8",
+            "type": "commit",
+            "links": {
+                "self": {
+                    "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/commit/bf4f4ce8a3a8"
+                },
+                "html": {
+                    "href": "https://bitbucket.org/amuniz/test-repos/commits/bf4f4ce8a3a8"
+                }
+            }
+        },
+        "repository": {
+            "links": {
+                "self": {
+                    "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos"
+                },
+                "html": {
+                    "href": "https://bitbucket.org/amuniz/test-repos"
+                },
+                "avatar": {
+                    "href": "https://bytebucket.org/ravatar/%7B3deb8c29-778a-450c-8f69-3e50a18079df%7D?ts=default"
+                }
+            },
+            "type": "repository",
+            "name": "test-repos",
+            "full_name": "amuniz/test-repos",
+            "uuid": "{3deb8c29-778a-450c-8f69-3e50a18079df}"
+        },
+        "branch": {
+            "name": "master"
+        }
+    },
+    "created_on": "2018-09-21T14:57:59.455870+00:00",
+    "summary": {
+        "raw": "* Add license\r\n\r\n* [CI] Release version 1.0.0",
+        "markup": "markdown",
+        "html": "<ul>\n<li>\n<p>Add license</p>\n</li>\n<li>\n<p>[CI] Release version 1.0.0</p>\n</li>\n</ul>",
+        "type": "rendered"
+    },
+    "source": {
+        "commit": {
+            "hash": "bf0e8b7962c0",
+            "type": "commit",
+            "links": {
+                "self": {
+                    "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/commit/bf0e8b7962c0"
+                },
+                "html": {
+                    "href": "https://bitbucket.org/amuniz/test-repos/commits/bf0e8b7962c0"
+                }
+            }
+        },
+        "repository": {
+            "links": {
+                "self": {
+                    "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos"
+                },
+                "html": {
+                    "href": "https://bitbucket.org/amuniz/test-repos"
+                },
+                "avatar": {
+                    "href": "https://bytebucket.org/ravatar/%7B3deb8c29-778a-450c-8f69-3e50a18079df%7D?ts=default"
+                }
+            },
+            "type": "repository",
+            "name": "test-repos",
+            "full_name": "amuniz/test-repos",
+            "uuid": "{3deb8c29-778a-450c-8f69-3e50a18079df}"
+        },
+        "branch": {
+            "name": "release/release-1"
+        }
+    },
+    "comment_count": 0,
+    "state": "OPEN",
+    "task_count": 0,
+    "reason": "",
+    "updated_on": "2018-09-21T14:57:59.488719+00:00",
+    "author": {
+        "username": "amuniz",
+        "display_name": "Nikolas Falco",
+        "account_id": "557058:ca1cd232-2017-4216-94be-99637899e18d",
+        "links": {
+            "self": {
+                "href": "https://api.bitbucket.org/2.0/users/amuniz"
+            },
+            "html": {
+                "href": "https://bitbucket.org/amuniz/"
+            },
+            "avatar": {
+                "href": "https://bitbucket.org/account/amuniz/avatar/"
+            }
+        },
+        "nickname": "amuniz",
+        "type": "user",
+        "uuid": "{644c7fc2-b15a-4445-9f89-35390694fac9}"
+    },
+    "merge_commit": null,
+    "closed_by": null
 }


### PR DESCRIPTION
Fix building of a GitSCM by BitbucketGitSCM in case of revision from a Pull Request web hook event that contains an abbreviate 7 chars of a SHA1 commit hash.