### PR TITLE
[JENKINS-75611] Disabling HTTPS cloning protocol on Data Center causes builds to fail even if SSH checkout feature is configured

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketGitSCMBuilder.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketGitSCMBuilder.java
@@ -286,7 +286,7 @@ public class BitbucketGitSCMBuilder extends GitSCMBuilder<BitbucketGitSCMBuilder
     }
 
     @NonNull
-    public String getCloudRepositoryUri(@NonNull String owner, @NonNull String repository) {
+    private String getCloudRepositoryUri(@NonNull String owner, @NonNull String repository) {
         switch (protocol) {
             case HTTP:
                 return "https://bitbucket.org/" + owner + "/" + repository + ".git";

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketGitSCMRevision.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketGitSCMRevision.java
@@ -24,9 +24,7 @@
 package com.cloudbees.jenkins.plugins.bitbucket;
 
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketCommit;
-import com.fasterxml.jackson.databind.util.StdDateFormat;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import java.text.ParseException;
 import java.util.Date;
 import java.util.Objects;
 import jenkins.plugins.git.AbstractGitSCMSource.SCMRevisionImpl;
@@ -55,15 +53,7 @@ public class BitbucketGitSCMRevision extends SCMRevisionImpl {
         super(head, commit.getHash());
         this.message = commit.getMessage();
         this.author = commit.getAuthor();
-        Date commitDate = null;
-        try {
-            if (commit.getDate() != null) {
-                commitDate = new StdDateFormat().parse(commit.getDate());
-            }
-        } catch (ParseException e) {
-            commitDate = null;
-        }
-        this.date = commitDate;
+        this.date = commit.getCommitterDate();
     }
 
     /**

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/BitbucketAuthenticator.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/BitbucketAuthenticator.java
@@ -110,19 +110,19 @@ public interface BitbucketAuthenticator {
      * Generates context that sub-classes can use to determine if they would be able to authenticate against the
      * provided server.
      *
-     * @param serverUrl The URL being authenticated against
+     * @param serverURL The URL being authenticated against
      * @return an {@link AuthenticationTokenContext} for use with the AuthenticationTokens APIs
      */
-    public static AuthenticationTokenContext<BitbucketAuthenticator> authenticationContext(String serverUrl) {
-        if (serverUrl == null) {
-            serverUrl = BitbucketCloudEndpoint.SERVER_URL;
+    public static AuthenticationTokenContext<BitbucketAuthenticator> authenticationContext(String serverURL) {
+        if (serverURL == null) {
+            serverURL = BitbucketCloudEndpoint.SERVER_URL;
         }
 
-        String scheme = serverUrl.split(":")[0].toLowerCase();
-        boolean isCloud = BitbucketApiUtils.isCloud(serverUrl);
+        String scheme = serverURL.split(":")[0].toLowerCase();
+        boolean isCloud = BitbucketApiUtils.isCloud(serverURL);
 
         return AuthenticationTokenContext.builder(BitbucketAuthenticator.class)
-                .with(SERVER_URL, serverUrl)
+                .with(SERVER_URL, serverURL)
                 .with(SCHEME, scheme)
                 .with(BITBUCKET_INSTANCE_TYPE, isCloud ? BITBUCKET_INSTANCE_TYPE_CLOUD : BITBUCKET_INSTANCE_TYPE_SERVER)
                 .build();


### PR DESCRIPTION
Fix the credentialsId passed to the SCMBuilder from the SCMSorce using the credentials that be used to checkout from the remote.