### PR TITLE
[JENKINS-75466] Notifying commit build result sometimes returns HTTP 404

### DIFF
--- a/docs/USER_GUIDE.adoc
+++ b/docs/USER_GUIDE.adoc
@@ -287,6 +287,11 @@ In case of slow network, you can increase socket timeout using the link:https://
 System.setProperty("http.socket.timeout", "300") // 5 minutes
 ----
 
+=== Client OAuth2 cache Timeout
+
+In case Bitbucket has been configured to expire OAuth2 tokens before 5 minutes, you can configure via a JVM property the release time of the cache where all obtained OAuth2 tokens are stored. This setting is to avoid requests with expired tokens that will produce HTTP 401 responses. link:https://support.atlassian.com/bitbucket-cloud/docs/use-oauth-on-bitbucket-cloud/[Bitbucket Cloud] access tokens expire in two hours.
+To change this amount of time (default is 300 seconds), add the system property `bitbucket.oauth2.cache.timeout=60` on Jenkins startup.
+
 === Disable Branch Indexing on Empty changes
 
 By default, the plugin triggers *a full branch indexing* when a push event contains *empty* changes. This may happen on various scenario, mainly in Bitbucket Data Center, such as:

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/impl/credentials/BitbucketAuthenticatorUtils.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/impl/credentials/BitbucketAuthenticatorUtils.java
@@ -49,4 +49,19 @@ final class BitbucketAuthenticatorUtils {
             throw new RuntimeException(e);
         }
     }
+
+    @SuppressWarnings("unchecked")
+    public static <T extends Exception> T unwrap(@NonNull Exception e, Class<T> exClass) {
+        Throwable cause = e;
+        while (cause != null) {
+            if (exClass.isInstance(cause)) {
+                return (T) cause;
+            } else if (cause != cause.getCause()) { // avoid stackoverflow when exception contains itself as cause
+                cause = cause.getCause();
+            } else {
+                break;
+            }
+        }
+        return null;
+    }
 }

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/impl/util/BitbucketApiUtils.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/impl/util/BitbucketApiUtils.java
@@ -119,10 +119,10 @@ public class BitbucketApiUtils {
     public static BitbucketRequestException unwrap(Exception e) {
         Throwable cause = e;
         while (cause != null) {
-            if (e instanceof BitbucketRequestException bbException) {
+            if (cause instanceof BitbucketRequestException bbException) {
                 return bbException;
-            } else if (cause != e.getCause()) { // avoid stackoverflow when cause is also the exception
-                cause = e.getCause();
+            } else if (cause != cause.getCause()) { // avoid stackoverflow when exception contains itself as cause
+                cause = cause.getCause();
             } else {
                 break;
             }

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/impl/credentials/BitbucketAuthenticatorUtilsTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/impl/credentials/BitbucketAuthenticatorUtilsTest.java
@@ -1,0 +1,57 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2025, Nikolas Falco
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.cloudbees.jenkins.plugins.bitbucket.impl.credentials;
+
+import com.cloudbees.jenkins.plugins.bitbucket.endpoints.BitbucketCloudEndpoint;
+import com.github.scribejava.core.model.OAuth2AccessTokenErrorResponse;
+import com.github.scribejava.core.model.OAuthResponseException;
+import com.github.scribejava.core.model.Response;
+import com.github.scribejava.core.oauth2.OAuth2Error;
+import java.net.URI;
+import java.util.Collections;
+import java.util.concurrent.ExecutionException;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class BitbucketAuthenticatorUtilsTest {
+
+    @Test
+    void test_unwrap() throws Exception {
+        Response rawResponse = new Response(401, "message", Collections.emptyMap(), "{\"type\": \"error\", \"error\": {\"message\": \"You may not have access to this repository or it no longer exists in this workspace. If you think this repository exists and you have access, make sure you are authenticated.\"}}");
+
+        OAuthResponseException expectedException = new OAuth2AccessTokenErrorResponse(OAuth2Error.INVALID_CLIENT, "description", new URI(BitbucketCloudEndpoint.SERVER_URL), rawResponse);
+        Exception e = new ExecutionException(new RuntimeException(expectedException));
+        OAuth2AccessTokenErrorResponse cause = BitbucketAuthenticatorUtils.unwrap(e, OAuth2AccessTokenErrorResponse.class);
+        assertThat(cause)
+            .isNotNull()
+            .isInstanceOf(OAuth2AccessTokenErrorResponse.class)
+            .isSameAs(expectedException);
+
+        OAuthResponseException oauth2Ex = new OAuthResponseException(rawResponse);
+        e = new ExecutionException(oauth2Ex);
+        cause = BitbucketAuthenticatorUtils.unwrap(e, OAuth2AccessTokenErrorResponse.class);
+        assertThat(cause).isNull();
+    }
+}

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/impl/util/BitbucketApiUtilsTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/impl/util/BitbucketApiUtilsTest.java
@@ -1,0 +1,43 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2025, Nikolas Falco
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.cloudbees.jenkins.plugins.bitbucket.impl.util;
+
+import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketRequestException;
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class BitbucketApiUtilsTest {
+
+    @Test
+    void test_unwrap() {
+        BitbucketRequestException expectedException = new BitbucketRequestException(401, "message", new IOException("cause"));
+        Exception e = new RuntimeException(new IOException(expectedException));
+        assertThat(BitbucketApiUtils.unwrap(e))
+            .isNotNull()
+            .isInstanceOf(BitbucketRequestException.class)
+            .isSameAs(expectedException);
+    }
+}


### PR DESCRIPTION
Add token cache lease time configurable by bitbucket.oauth2.cache.timeout system property.
Fix unwrapping exception utility method.