### PR TITLE
Restore BitbucketEndpointConfiguration.normalizeServerUrl() for compatibility

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/endpoints/BitbucketEndpointConfiguration.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/endpoints/BitbucketEndpointConfiguration.java
@@ -291,6 +291,20 @@ public class BitbucketEndpointConfiguration extends GlobalConfiguration {
      *
      * @param serverURL the server URL.
      * @return the normalized server URL.
+     * @deprecated
+     * @see #normalizeServerURL
+     */
+    @CheckForNull
+    @Deprecated
+    public static String normalizeServerUrl(@CheckForNull String serverURL) {
+        return normalizeServerURL(serverURL);
+    }
+
+    /**
+     * Fix a server URL.
+     *
+     * @param serverURL the server URL.
+     * @return the normalized server URL.
      */
     @CheckForNull
     public static String normalizeServerURL(@CheckForNull String serverURL) {


### PR DESCRIPTION
## Restore BitbucketEndpointConfiguration.normalizeServerUrl() for compatibility

Blue Ocean Bitbucket plugin depends on this plugin and uses the BitbucketEndpointConfiguration.normalizeServerUrl method.  Rather than require a new release of Blue Ocean, let's retain compatibility by restoring that method and marking it as deprecated.

Detected in:

* https://github.com/jenkinsci/bom/issues/5076
* https://github.com/jenkinsci/bom/pull/5088

### Testing done:

```
mvn -Dtest=BitbucketSCMNavigatorTest,BitbucketEndpointConfigurationTest,BitbucketServerEndpointTest,BitbucketSCMNavigatorTest clean verify
```

Will use the incremental build of this pull request in:

* https://github.com/jenkinsci/bom/pull/5088

### Your checklist for this pull request

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Did you provide a test-case? That demonstrates feature works or fixes the issue.
