### PR TITLE
[JENKINS-48594] Perform scanning of PRs first before scanning branches

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,14 +24,12 @@
     </licenses>
 
     <properties>
-        <revision>936.4.1</revision>
+        <revision>937.0.0</revision>
         <changelist>-SNAPSHOT</changelist>
         <gitHubRepo>jenkinsci/bitbucket-branch-source-plugin</gitHubRepo>
-        <jenkins.baseline>2.479</jenkins.baseline>
-        <jenkins.version>${jenkins.baseline}.3</jenkins.version>
+        <jenkins.baseline>2.504</jenkins.baseline>
+        <jenkins.version>${jenkins.baseline}.2</jenkins.version>
         <hpi.compatibleSinceVersion>936.0.0</hpi.compatibleSinceVersion>
-        <!-- Jenkins.MANAGE is still in Beta -->
-        <useBeta>true</useBeta>
         <tagNameFormat>@{project.version}</tagNameFormat>
     </properties>
 

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource.java
@@ -365,13 +365,13 @@ public class BitbucketSCMSource extends SCMSource {
                 request.setPullRequests(getBitbucketPullRequestsFromEvent(hasPrEvent, listener));
             }
             // now server the request
-            if (request.isFetchBranches() && !request.isComplete()) {
-                // Search branches
-                retrieveBranches(request);
-            }
             if (request.isFetchPRs() && !request.isComplete()) {
                 // Search pull requests
                 retrievePullRequests(request);
+            }
+            if (request.isFetchBranches() && !request.isComplete()) {
+                // Search branches
+                retrieveBranches(request);
             }
             if (request.isFetchTags() && !request.isComplete()) {
                 // Search tags


### PR DESCRIPTION
Swap the retrieveBranches with retrievePullRequests method call to process pull requests before process branches.
_Most probably_ pull request build triggered by events _should_ start before branch build and takes free executors.