### PR TITLE
[JENKINS-75804] Webhook auto registration fail with PLUGIN implementation

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/WebhookConfiguration.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/WebhookConfiguration.java
@@ -207,7 +207,6 @@ public class WebhookConfiguration {
                 hook.setDescription(description);
                 hook.setUrl(rootUrl + BitbucketSCMSourcePushHookReceiver.FULL_PATH);
                 hook.setCommittersToIgnore(committersToIgnore);
-                hook.setSecret(signatureSecret);
                 return hook;
             }
         }


### PR DESCRIPTION
Remove hook secret when register webhook for PLUGIN implementation.