### PR TITLE
[JENKINS-75786] Incoming webhook from PLUGIN are reject with endpoint not found

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/WebhookConfiguration.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/WebhookConfiguration.java
@@ -207,7 +207,6 @@ public class WebhookConfiguration {
                 hook.setDescription(description);
                 hook.setUrl(rootUrl + BitbucketSCMSourcePushHookReceiver.FULL_PATH);
                 hook.setCommittersToIgnore(committersToIgnore);
-                hook.setSecret(signatureSecret);
                 return hook;
             }
         }

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/WebhookConfiguration.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/WebhookConfiguration.java
@@ -205,7 +205,7 @@ public class WebhookConfiguration {
                 BitbucketServerWebhook hook = new BitbucketServerWebhook();
                 hook.setActive(true);
                 hook.setDescription(description);
-                hook.setUrl(rootUrl + BitbucketSCMSourcePushHookReceiver.FULL_PATH);
+                hook.setUrl(getNativeServerWebhookUrl(serverUrl, rootUrl));
                 hook.setCommittersToIgnore(committersToIgnore);
                 return hook;
             }


### PR DESCRIPTION
Add missing server_url parameter in the Jenkins endpoint to register in the webhook