### PR TITLE
Log payload when processing webhooks

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/impl/webhook/cloud/CloudPullRequestWebhookProcessor.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/impl/webhook/cloud/CloudPullRequestWebhookProcessor.java
@@ -35,6 +35,7 @@ import hudson.Extension;
 import hudson.RestrictedSince;
 import java.util.List;
 import java.util.Map;
+import java.util.logging.Level;
 import jenkins.scm.api.SCMEvent;
 import org.apache.commons.collections4.MultiValuedMap;
 import org.kohsuke.accmod.Restricted;
@@ -67,6 +68,7 @@ public class CloudPullRequestWebhookProcessor extends AbstractWebhookProcessor {
 
     @Override
     public void process(@NonNull String hookEventType, @NonNull String payload, @NonNull Map<String, Object> context, @NonNull BitbucketEndpoint endpoint) {
+        logger.log(Level.FINE, () -> "Processing hook: " + hookEventType + " payload: " + " from: " + endpoint.getServerURL());
         HookEventType hookEvent = HookEventType.fromString(hookEventType);
         BitbucketPullRequestEvent pull = BitbucketCloudWebhookPayload.pullRequestEventFromPayload(payload);
         if (pull != null) {

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/impl/webhook/cloud/CloudPushWebhookProcessor.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/impl/webhook/cloud/CloudPushWebhookProcessor.java
@@ -35,6 +35,7 @@ import hudson.Extension;
 import hudson.RestrictedSince;
 import java.util.List;
 import java.util.Map;
+import java.util.logging.Level;
 import jenkins.scm.api.SCMEvent;
 import org.apache.commons.collections4.MultiValuedMap;
 import org.kohsuke.accmod.Restricted;
@@ -64,6 +65,7 @@ public class CloudPushWebhookProcessor extends AbstractWebhookProcessor {
 
     @Override
     public void process(@NonNull String hookEventType, @NonNull String payload, @NonNull Map<String, Object> context, @NonNull BitbucketEndpoint endpoint) {
+        logger.log(Level.FINE, () -> "Processing hook: " + hookEventType + " payload: " + " from: " + endpoint.getServerURL());
         BitbucketPushEvent push = BitbucketCloudWebhookPayload.pushEventFromPayload(payload);
         if (push != null) {
             if (push.getChanges().isEmpty()) {


### PR DESCRIPTION
Hey @nfalco79 I'm using this PR as a springboard to start a discussion on debuggability. I've recently had issues with understanding why builds are not triggered and currently its impossible to figure out if a webhook is being processed with what payload and is a build even triggered and if not why isn't a build triggered.

It seems like restarting jenkins in some cases fixes the issue of builds being triggered but perhaps its better for us to get an understanding as to why this happens and we can avoid having such restarts.

### Your checklist for this pull request

- [ ] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Did you provide a test-case? That demonstrates feature works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled the information below
Describe your pull request below
-->
