### PR TITLE
Improve logging with deprecation warnings

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/impl/webhook/plugin/PluginDeprecationLogger.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/impl/webhook/plugin/PluginDeprecationLogger.java
@@ -1,0 +1,61 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2025, Allan Burdajewicz
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.cloudbees.jenkins.plugins.bitbucket.impl.webhook.plugin;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Logs a deprecation warning for the Bitbucket Addons support in the plugin.
+ * If the logger is configured to log FINE messages, the warning is logged at FINE level.
+ * Otherwise, the warning is logged at WARNING level at most once every 5 minutes to avoid log flooding in very active environment.
+ */
+public class PluginDeprecationLogger {
+
+    private static final long LOG_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
+    private static final java.util.concurrent.atomic.AtomicLong lastDeprecationLog =
+            new java.util.concurrent.atomic.AtomicLong(0);
+
+    /**
+     * Logs the deprecation warning if the last log was more than LOG_INTERVAL_MS ago.
+     *
+     * @param logger the logger to use
+     */
+    public static void log(Logger logger) {
+        if(logger.isLoggable(Level.FINE)) {
+            logger.fine("Bitbucket Addons support are deprecated in favor of native integrations. Please migrate to Bitbucket Server native webhook.");
+        } else {
+            long now = System.currentTimeMillis();
+            long lastLog = lastDeprecationLog.get();
+            if (now - lastLog > LOG_INTERVAL_MS) {
+                if (lastDeprecationLog.compareAndSet(lastLog, now)) {
+                    logger.log(
+                        Level.WARNING,
+                        () ->
+                            "Bitbucket Addons support are deprecated in favor of native integrations. Please migrate to Bitbucket Server native webhook.");
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/impl/webhook/plugin/PluginPullRequestWebhookProcessor.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/impl/webhook/plugin/PluginPullRequestWebhookProcessor.java
@@ -34,6 +34,8 @@ import hudson.Extension;
 import hudson.RestrictedSince;
 import java.util.List;
 import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import jenkins.scm.api.SCMEvent;
 import org.apache.commons.collections4.MultiValuedMap;
 import org.kohsuke.accmod.Restricted;
@@ -44,6 +46,8 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
 @Restricted(NoExternalUse.class)
 @RestrictedSince("933.3.0")
 public class PluginPullRequestWebhookProcessor extends AbstractWebhookProcessor {
+
+    private static final Logger logger = Logger.getLogger(PluginPullRequestWebhookProcessor.class.getName());
 
     private static final List<String> supportedEvents = List.of(
             HookEventType.PULL_REQUEST_CREATED.getKey(), // needed to create job
@@ -61,6 +65,8 @@ public class PluginPullRequestWebhookProcessor extends AbstractWebhookProcessor 
 
     @Override
     public void process(@NonNull String hookEventType, @NonNull String payload, @NonNull Map<String, Object> context, @NonNull BitbucketEndpoint endpoint) {
+        PluginDeprecationLogger.log(logger);
+        logger.log(Level.FINE, () -> "Processing hook: " + hookEventType + " payload: " + " from: " + endpoint.getServerURL());
         HookEventType hookEvent = HookEventType.fromString(hookEventType);
         BitbucketPullRequestEvent pull = BitbucketServerWebhookPayload.pullRequestEventFromPayload(payload);
         if (pull != null) {

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/impl/webhook/plugin/PluginPushWebhookProcessor.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/impl/webhook/plugin/PluginPushWebhookProcessor.java
@@ -62,6 +62,8 @@ public class PluginPushWebhookProcessor extends AbstractWebhookProcessor {
 
     @Override
     public void process(@NonNull String eventType, @NonNull String payload, @NonNull Map<String, Object> context, @NonNull BitbucketEndpoint endpoint) {
+        PluginDeprecationLogger.log(logger);
+        logger.log(Level.FINE, () -> "Processing hook: " + eventType + " payload: " + " from: " + endpoint.getServerURL());
         BitbucketPushEvent push = BitbucketServerWebhookPayload.pushEventFromPayload(payload);
         if (push != null) {
             if (push.getChanges().isEmpty()) {

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/impl/webhook/plugin/PluginWebhookManager.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/impl/webhook/plugin/PluginWebhookManager.java
@@ -193,6 +193,7 @@ public class PluginWebhookManager implements BitbucketWebhookManager {
 
     @Override
     public void register(@NonNull BitbucketAuthenticatedClient client) throws IOException {
+        PluginDeprecationLogger.log(logger);
         BitbucketPluginWebhook existingHook = (BitbucketPluginWebhook) read(client)
                 .stream()
                 .findFirst()


### PR DESCRIPTION
Add some logging to help detect/warn about deprecated usage in the instance. So that user can act upon it.

* Add FINE loggers for Push / PR processing from Bitbucket addon payloads.
* Add WARNING about the deprecation at most once every 5 minutes to avoid noise in very active environment (or if the logging level is set to FINE, then always log the deprecation at FINE level).

### Your checklist for this pull request

- [ ] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Did you provide a test-case? That demonstrates feature works or fixes the issue.