### PR TITLE
[JENKINS-76156] Add webhook processor listener of incoming payload

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/webhook/BitbucketWebhookProcessorListener.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/webhook/BitbucketWebhookProcessorListener.java
@@ -1,0 +1,58 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2025, Nikolas Falco
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.cloudbees.jenkins.plugins.bitbucket.api.webhook;
+
+import com.cloudbees.jenkins.plugins.bitbucket.api.endpoint.BitbucketEndpoint;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.ExtensionPoint;
+
+/**
+ * Listener for {@link BitbucketWebhookProcessor} to receive notification about
+ * each steps done by the matching processor for an incoming webhook.
+ */
+public interface BitbucketWebhookProcessorListener extends ExtensionPoint {
+
+    /**
+     * Notify when the processor has been matches.
+     *
+     * @param processor class
+     */
+    void onStart(@NonNull Class<? extends BitbucketWebhookProcessor> processor);
+
+    /**
+     * Notify after the processor has processed the incoming webhook payload.
+     *
+     * @param eventType of incoming request
+     * @param payload content that comes with incoming request
+     * @param endpoint that match the incoming request
+     */
+    void onProcess(@NonNull String eventType, @NonNull String payload, @NonNull BitbucketEndpoint endpoint);
+
+    /**
+     * Notify of failure while processing the incoming webhook.
+     *
+     * @param failure exception raised by webhook consumer or by processor.
+     */
+    void onFailure(@NonNull BitbucketWebhookProcessorException failure);
+}

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/WebhookProcessorListenersHandler.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/WebhookProcessorListenersHandler.java
@@ -1,0 +1,92 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2025, Nikolas Falco
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.cloudbees.jenkins.plugins.bitbucket.hooks;
+
+import com.cloudbees.jenkins.plugins.bitbucket.api.endpoint.BitbucketEndpoint;
+import com.cloudbees.jenkins.plugins.bitbucket.api.webhook.BitbucketWebhookProcessor;
+import com.cloudbees.jenkins.plugins.bitbucket.api.webhook.BitbucketWebhookProcessorException;
+import com.cloudbees.jenkins.plugins.bitbucket.api.webhook.BitbucketWebhookProcessorListener;
+import hudson.ExtensionList;
+import hudson.triggers.SafeTimerTask;
+import hudson.util.DaemonThreadFactory;
+import hudson.util.NamingThreadFactory;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.function.Consumer;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public class WebhookProcessorListenersHandler implements BitbucketWebhookProcessorListener {
+    private static ExecutorService executorService;
+    private static final Logger logger = Logger.getLogger(WebhookProcessorListenersHandler.class.getName());
+
+    // We need a single thread executor to run webhooks operations in background
+    // but in order.
+    private static synchronized ExecutorService getExecutorService() {
+        if (executorService == null) {
+            executorService = Executors.newSingleThreadExecutor(new NamingThreadFactory(new DaemonThreadFactory(), WebhookProcessorListenersHandler.class.getName()));
+        }
+        return executorService;
+    }
+
+    private List<BitbucketWebhookProcessorListener> listeners;
+
+    public WebhookProcessorListenersHandler() {
+        listeners = ExtensionList.lookup(BitbucketWebhookProcessorListener.class);
+    }
+
+    @Override
+    public void onStart(Class<? extends BitbucketWebhookProcessor> processorClass) {
+        execute(listener -> listener.onStart(processorClass));
+    }
+
+    @Override
+    public void onFailure(BitbucketWebhookProcessorException e) {
+        execute(listener -> listener.onFailure(e));
+    }
+
+    @Override
+    public void onProcess(String eventType, String body, BitbucketEndpoint endpoint) {
+        execute(listener -> listener.onProcess(eventType, body, endpoint));
+    }
+
+    private void execute(Consumer<BitbucketWebhookProcessorListener> predicate) {
+        getExecutorService().submit(new SafeTimerTask() {
+            @Override
+            public void doRun() {
+                listeners.forEach(listener -> {
+                    String listenerName = listener.getClass().getName();
+                    logger.log(Level.FINEST, () -> "Processing listener " + listenerName);
+                    try {
+                        predicate.accept(listener);
+                        logger.log(Level.FINEST, () -> "Processing listener " + listenerName + " completed");
+                    } catch (Exception e) {
+                        logger.log(Level.SEVERE, e, () -> "Processing failed on listener " + listenerName);
+                    }
+                });
+            }
+        });
+    }
+}

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/impl/webhook/AbstractBitbucketWebhookConfigurationBuilderImpl.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/impl/webhook/AbstractBitbucketWebhookConfigurationBuilderImpl.java
@@ -26,6 +26,7 @@ package com.cloudbees.jenkins.plugins.bitbucket.impl.webhook;
 import com.cloudbees.jenkins.plugins.bitbucket.api.webhook.BitbucketWebhookConfigurationBuilder;
 import com.cloudbees.jenkins.plugins.bitbucket.api.webhook.NativeBitbucketWebhookConfigurationBuilder;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Util;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
@@ -38,13 +39,13 @@ public abstract class AbstractBitbucketWebhookConfigurationBuilderImpl implement
 
     @Override
     public NativeBitbucketWebhookConfigurationBuilder autoManaged(@NonNull String credentialsId) {
-        this.credentialsId = credentialsId;
+        this.credentialsId = Util.fixEmptyAndTrim(credentialsId);
         return this;
     }
 
     @Override
     public NativeBitbucketWebhookConfigurationBuilder signature(@NonNull String credentialsId) {
-        this.signatureId = credentialsId;
+        this.signatureId = Util.fixEmptyAndTrim(credentialsId);
         return this;
     }
 

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/BitbucketSCMSourcePushHookReceiverTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/hooks/BitbucketSCMSourcePushHookReceiverTest.java
@@ -23,16 +23,21 @@
  */
 package com.cloudbees.jenkins.plugins.bitbucket.hooks;
 
+import com.cloudbees.jenkins.plugins.bitbucket.api.endpoint.BitbucketEndpoint;
 import com.cloudbees.jenkins.plugins.bitbucket.api.webhook.BitbucketWebhookProcessor;
+import com.cloudbees.jenkins.plugins.bitbucket.api.webhook.BitbucketWebhookProcessorException;
+import com.cloudbees.jenkins.plugins.bitbucket.api.webhook.BitbucketWebhookProcessorListener;
 import com.cloudbees.jenkins.plugins.bitbucket.endpoints.BitbucketEndpointConfiguration;
 import com.cloudbees.jenkins.plugins.bitbucket.impl.endpoint.BitbucketCloudEndpoint;
 import com.cloudbees.jenkins.plugins.bitbucket.impl.webhook.cloud.CloudWebhookConfiguration;
 import com.cloudbees.jenkins.plugins.bitbucket.test.util.HookProcessorTestUtil;
 import com.cloudbees.jenkins.plugins.bitbucket.test.util.MockRequest;
+import hudson.util.RingBufferLogHandler;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.logging.Logger;
 import java.util.stream.Stream;
 import org.apache.commons.collections4.MultiValuedMap;
 import org.apache.commons.collections4.map.CaseInsensitiveMap;
@@ -40,6 +45,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.TestExtension;
 import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 import org.kohsuke.stapler.HttpResponse;
 import org.kohsuke.stapler.StaplerRequest2;
@@ -59,6 +65,27 @@ import static org.mockito.Mockito.when;
 
 @WithJenkins
 class BitbucketSCMSourcePushHookReceiverTest {
+
+    @TestExtension
+    public static class ProcessorLogListener implements BitbucketWebhookProcessorListener {
+        private static final Logger logger = Logger.getLogger(ProcessorLogListener.class.getName());
+
+        @Override
+        public void onStart(Class<? extends BitbucketWebhookProcessor> processor) {
+            logger.info("Selected processor " + processor.getName());
+        }
+
+        @Override
+        public void onProcess(String eventType, String payload, BitbucketEndpoint endpoint) {
+            logger.info("Processing event " + eventType + " with payload " + payload + " for endpoint " + endpoint.getServerURL());
+        }
+
+        @Override
+        public void onFailure(BitbucketWebhookProcessorException failure) {
+            logger.severe("Processor failure " + failure.getMessage());
+        }
+
+    }
 
     @SuppressWarnings("unused")
     private static JenkinsRule rule;
@@ -147,6 +174,37 @@ class BitbucketSCMSourcePushHookReceiverTest {
                     eq("{}"),
                     eq(Collections.emptyMap()),
                     eq(endpoint));
+        } finally {
+            BitbucketEndpointConfiguration.get().removeEndpoint(endpoint.getServerURL());
+        }
+    }
+
+    @Test
+    void test_listeners_handler() throws Exception {
+        CloudWebhookConfiguration webhook = new CloudWebhookConfiguration(false, null, true, "hmac");
+        webhook.setEndpointJenkinsRootURL("https://jenkins.example.com");
+        BitbucketCloudEndpoint endpoint = new BitbucketCloudEndpoint(false, 0, 0, webhook);
+        BitbucketEndpointConfiguration.get().updateEndpoint(endpoint);
+
+        try {
+            BitbucketWebhookProcessor hookProcessor = mock(BitbucketWebhookProcessor.class);
+            sut = new BitbucketSCMSourcePushHookReceiver() {
+                @Override
+                Stream<BitbucketWebhookProcessor> getHookProcessors() {
+                    return Stream.of(hookProcessor);
+                }
+            };
+            mockRequest();
+            headers.putAll(HookProcessorTestUtil.getCloudHeaders());
+            when(hookProcessor.canHandle(any(), any())).thenReturn(true);
+            when(hookProcessor.getServerURL(any(), any())).thenReturn(endpoint.getServerURL());
+            when(hookProcessor.getEventType(any(), any())).thenReturn("event:X");
+
+            RingBufferLogHandler log = HookProcessorTestUtil.createJULTestHandler(ProcessorLogListener.class);
+
+            sut.doNotify(req);
+            HookProcessorTestUtil.waitForLogFileMessage(rule, "Selected processor ", log);
+            HookProcessorTestUtil.waitForLogFileMessage(rule, "Processing event event:X with payload {} for endpoint https://bitbucket.org", log);
         } finally {
             BitbucketEndpointConfiguration.get().removeEndpoint(endpoint.getServerURL());
         }

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/test/util/HookProcessorTestUtil.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/test/util/HookProcessorTestUtil.java
@@ -23,9 +23,17 @@
  */
 package com.cloudbees.jenkins.plugins.bitbucket.test.util;
 
+import hudson.util.RingBufferLogHandler;
+import java.io.File;
+import java.text.MessageFormat;
 import java.util.Map;
 import java.util.UUID;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+import java.util.logging.SimpleFormatter;
 import org.apache.commons.collections4.map.CaseInsensitiveMap;
+import org.assertj.core.api.Assertions;
+import org.jvnet.hudson.test.JenkinsRule;
 
 public final class HookProcessorTestUtil {
 
@@ -58,5 +66,37 @@ public final class HookProcessorTestUtil {
         headers.put("X-Bitbucket-Type", "server");
         headers.put("User-Agent", "Bitbucket version: 8.18.0, Post webhook plugin version: 7.13.41-SNAPSHOT");
         return headers;
+    }
+
+    @SafeVarargs
+    public static RingBufferLogHandler createJULTestHandler(Class<?> ... loggers) throws SecurityException {
+        RingBufferLogHandler handler = new RingBufferLogHandler(RingBufferLogHandler.getDefaultRingBufferSize());
+        SimpleFormatter formatter = new SimpleFormatter();
+        handler.setFormatter(formatter);
+        for (Class<?> logger : loggers) {
+            Logger.getLogger(logger.getName()).addHandler(handler);
+        }
+        return handler;
+    }
+
+    public static void waitForLogFileMessage(JenkinsRule rule, String string, RingBufferLogHandler logs) throws InterruptedException {
+        File rootDir = rule.jenkins.getRootDir();
+        synchronized (rootDir) {
+            int limit = 0;
+            while (limit < 5) {
+                rootDir.wait(1000);
+                for (LogRecord r : logs.getView()) {
+                    String message = r.getMessage();
+                    if (r.getParameters() != null) {
+                        message = MessageFormat.format(message, r.getParameters());
+                    }
+                    if (message.contains(string)) {
+                        return;
+                    }
+                }
+                limit++;
+            }
+        }
+        Assertions.fail("Expected log not found: " + string);
     }
 }


### PR DESCRIPTION
Add an extension point to notify the listener of all processing steps for each incoming webhook, allowing it to perform additional operations.
Each listener runs asynchronously with respect to the webhook's processing, but receives processor events sequentially and in an ordered manner.