### PR TITLE
Migrate to Jackson3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
                 <artifactId>bom-${jenkins.baseline}.x</artifactId>
-                <version>6269.v7a_159d68a_366</version>
+                <version>6329.v403d8c87a_5ce</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -90,9 +90,14 @@
             <groupId>io.jenkins.plugins</groupId>
             <artifactId>commons-collections4-api</artifactId>
         </dependency>
+        <!-- Needed by scribejava-core -->
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>jackson2-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.jenkins.plugins</groupId>
+            <artifactId>jackson3-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/BitbucketCloudWorkspace.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/BitbucketCloudWorkspace.java
@@ -24,9 +24,9 @@
 package com.cloudbees.jenkins.plugins.bitbucket.api;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import java.util.List;
 import java.util.Map;
+import tools.jackson.databind.annotation.JsonDeserialize;
 
 public class BitbucketCloudWorkspace implements BitbucketWorkspace {
     @JsonProperty("uuid")

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/BitbucketHref.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/BitbucketHref.java
@@ -23,16 +23,14 @@
  */
 package com.cloudbees.jenkins.plugins.bitbucket.api;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.ObjectCodec;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonDeserializer;
-import com.fasterxml.jackson.databind.JsonNode;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.DoNotUse;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ValueDeserializer;
 
 /**
  * A Href for something on bitbucket.
@@ -71,20 +69,18 @@ public class BitbucketHref {
         this.href = href;
     }
 
-    public static class Deserializer extends JsonDeserializer<List<BitbucketHref>> {
+    public static class Deserializer extends ValueDeserializer<List<BitbucketHref>> {
 
         @Override
-        public List<BitbucketHref> deserialize(JsonParser p, DeserializationContext ctx)
-                throws IOException {
+        public List<BitbucketHref> deserialize(JsonParser p, DeserializationContext ctx) {
             List<BitbucketHref> result = new ArrayList<>();
-            ObjectCodec codec = p.getCodec();
-            JsonNode node = codec.readTree(p);
+            JsonNode node = ctx.readTree(p);
             if (node.isArray()) {
                 for (JsonNode n : node) {
-                    result.add(codec.treeToValue(n, BitbucketHref.class));
+                    result.add(ctx.readTreeAsValue(n, BitbucketHref.class));
                 }
             } else {
-                result.add(codec.treeToValue(node, BitbucketHref.class));
+                result.add(ctx.readTreeAsValue(node, BitbucketHref.class));
             }
             return result;
         }

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/BitbucketProject.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/BitbucketProject.java
@@ -23,9 +23,9 @@
  */
 package com.cloudbees.jenkins.plugins.bitbucket.api;
 
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import java.util.List;
 import java.util.Map;
+import tools.jackson.databind.annotation.JsonDeserialize;
 
 public class BitbucketProject implements BitbucketTeam {
 

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/BitbucketCloudApiClient.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/BitbucketCloudApiClient.java
@@ -55,8 +55,6 @@ import com.cloudbees.jenkins.plugins.bitbucket.impl.util.BitbucketApiUtils;
 import com.cloudbees.jenkins.plugins.bitbucket.impl.util.JsonParser;
 import com.damnhandy.uri.template.UriTemplate;
 import com.damnhandy.uri.template.impl.Operator;
-import com.fasterxml.jackson.core.JacksonException;
-import com.fasterxml.jackson.core.type.TypeReference;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -85,6 +83,8 @@ import org.apache.hc.client5.http.io.HttpClientConnectionManager;
 import org.apache.hc.core5.http.HttpHost;
 import org.apache.hc.core5.http.HttpStatus;
 import org.apache.hc.core5.http.message.BasicNameValuePair;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.type.TypeReference;
 
 import static java.util.concurrent.TimeUnit.HOURS;
 import static java.util.concurrent.TimeUnit.MINUTES;

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/repository/BitbucketCloudRepository.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/repository/BitbucketCloudRepository.java
@@ -28,12 +28,12 @@ import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketProject;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketRepository;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import tools.jackson.databind.annotation.JsonDeserialize;
 
 public class BitbucketCloudRepository implements BitbucketRepository {
 

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/impl/util/DateUtils.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/impl/util/DateUtils.java
@@ -23,7 +23,6 @@
  */
 package com.cloudbees.jenkins.plugins.bitbucket.impl.util;
 
-import com.fasterxml.jackson.databind.util.StdDateFormat;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
@@ -31,6 +30,7 @@ import java.text.ParseException;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.TimeZone;
+import tools.jackson.databind.util.StdDateFormat;
 
 public final class DateUtils {
 

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/impl/util/JsonParser.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/impl/util/JsonParser.java
@@ -23,12 +23,16 @@
  */
 package com.cloudbees.jenkins.plugins.bitbucket.impl.util;
 
+<<<<<<< HEAD
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.databind.util.StdDateFormat;
+=======
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+>>>>>>> a8b31af (Migrate to Jackson3)
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -37,6 +41,11 @@ import java.io.StringReader;
 import java.nio.charset.StandardCharsets;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.DeserializationFeature;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.databind.util.StdDateFormat;
 
 /**
  * Jackson based JSON parser
@@ -76,8 +85,13 @@ public final class JsonParser {
     private static JsonMapper createMapper(){
         return JsonMapper.builder()
                 .defaultDateFormat(new StdDateFormat())
+<<<<<<< HEAD
                 .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
                 .defaultPropertyInclusion(JsonInclude.Value.ALL_NON_NULL)
+=======
+                .disable(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES) // Jackson 3 fail on unknown primitives by default
+                .changeDefaultPropertyInclusion(incl -> incl.withContentInclusion(Include.NON_NULL).withValueInclusion(Include.NON_NULL))
+>>>>>>> a8b31af (Migrate to Jackson3)
                 .build();
     }
 }

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/impl/util/JsonParser.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/impl/util/JsonParser.java
@@ -23,16 +23,7 @@
  */
 package com.cloudbees.jenkins.plugins.bitbucket.impl.util;
 
-<<<<<<< HEAD
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.json.JsonMapper;
-import com.fasterxml.jackson.databind.util.StdDateFormat;
-=======
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
->>>>>>> a8b31af (Migrate to Jackson3)
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -85,13 +76,8 @@ public final class JsonParser {
     private static JsonMapper createMapper(){
         return JsonMapper.builder()
                 .defaultDateFormat(new StdDateFormat())
-<<<<<<< HEAD
-                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
-                .defaultPropertyInclusion(JsonInclude.Value.ALL_NON_NULL)
-=======
                 .disable(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES) // Jackson 3 fail on unknown primitives by default
                 .changeDefaultPropertyInclusion(incl -> incl.withContentInclusion(Include.NON_NULL).withValueInclusion(Include.NON_NULL))
->>>>>>> a8b31af (Migrate to Jackson3)
                 .build();
     }
 }

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/impl/webhook/cloud/CloudWebhookManager.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/impl/webhook/cloud/CloudWebhookManager.java
@@ -38,7 +38,6 @@ import com.cloudbees.jenkins.plugins.bitbucket.impl.util.JsonParser;
 import com.cloudbees.jenkins.plugins.bitbucket.impl.webhook.AbstractWebhookManager;
 import com.cloudbees.jenkins.plugins.bitbucket.util.BitbucketCredentialsUtils;
 import com.damnhandy.uri.template.UriTemplate;
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.common.base.Objects;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
@@ -58,6 +57,7 @@ import jenkins.model.Jenkins;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.Strings;
 import org.jenkinsci.plugins.plaincredentials.StringCredentials;
+import tools.jackson.core.type.TypeReference;
 
 import static java.util.concurrent.TimeUnit.HOURS;
 import static java.util.concurrent.TimeUnit.MINUTES;

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/impl/webhook/server/ServerWebhookManager.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/impl/webhook/server/ServerWebhookManager.java
@@ -38,7 +38,6 @@ import com.cloudbees.jenkins.plugins.bitbucket.server.client.BitbucketServerPage
 import com.cloudbees.jenkins.plugins.bitbucket.server.client.repository.BitbucketServerWebhook;
 import com.cloudbees.jenkins.plugins.bitbucket.util.BitbucketCredentialsUtils;
 import com.damnhandy.uri.template.UriTemplate;
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.common.base.Objects;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
@@ -57,6 +56,7 @@ import java.util.logging.Logger;
 import jenkins.model.Jenkins;
 import org.apache.commons.collections.CollectionUtils;
 import org.jenkinsci.plugins.plaincredentials.StringCredentials;
+import tools.jackson.core.type.TypeReference;
 
 import static java.util.concurrent.TimeUnit.HOURS;
 import static java.util.concurrent.TimeUnit.MINUTES;

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/BitbucketServerAPIClient.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/BitbucketServerAPIClient.java
@@ -55,9 +55,6 @@ import com.cloudbees.jenkins.plugins.bitbucket.server.client.repository.Bitbucke
 import com.cloudbees.jenkins.plugins.bitbucket.server.client.repository.BitbucketServerRepository;
 import com.damnhandy.uri.template.UriTemplate;
 import com.damnhandy.uri.template.impl.Operator;
-import com.fasterxml.jackson.core.JacksonException;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.JsonNode;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
@@ -89,6 +86,9 @@ import org.apache.hc.client5.http.io.HttpClientConnectionManager;
 import org.apache.hc.core5.http.HttpHost;
 import org.apache.hc.core5.http.HttpStatus;
 import org.apache.hc.core5.http.message.BasicNameValuePair;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.JsonNode;
 
 /**
  * Bitbucket API client.
@@ -931,7 +931,7 @@ public class BitbucketServerAPIClient extends AbstractBitbucketApi implements Bi
             String response = getRequest(url);
             JsonNode typeNode = JsonParser.toJson(response).path("type");
             if (!typeNode.isMissingNode() && !typeNode.isNull()) {
-                String responseType = typeNode.asText();
+                String responseType = typeNode.asString();
                 if ("FILE".equals(responseType)) {
                     type = Type.REGULAR_FILE;
                     // type = Type.LINK; does not matter if getFileContent on the linked file/directory returns the content

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/branch/BitbucketServerCommit.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/branch/BitbucketServerCommit.java
@@ -109,6 +109,11 @@ public class BitbucketServerCommit implements BitbucketCommit {
         this.hash = hash;
     }
 
+    @JsonProperty("hash")
+    public void setAlternateHash(String hash) {
+        setHash(hash);
+    }
+
     @Deprecated(since = "936.1.0", forRemoval = true)
     @Override
     public String getDate() {

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/branch/BitbucketServerCommit.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/branch/BitbucketServerCommit.java
@@ -61,14 +61,15 @@ public class BitbucketServerCommit implements BitbucketCommit {
 
     @JsonCreator
     public BitbucketServerCommit(@NonNull @JsonProperty("message") String message,
-                                 @NonNull @JsonProperty("hash") String hash,
+                                 @Nullable @JsonProperty("id") String id,
+                                 @Nullable @JsonProperty("hash") String hash,
                                  @Nullable @JsonProperty("committer") BitbucketServerAuthor committer,
                                  @NonNull @JsonProperty("committerTimestamp") long committerDateMillis,
                                  @Nullable @JsonProperty("author") BitbucketServerAuthor author,
                                  @NonNull @JsonProperty("authorTimestamp") long authorDateMillis,
                                  @Nullable @JsonProperty("parents") List<Parent> parents) {
         // date it is not in the payload
-        this(message, hash, committerDateMillis, author != null ? MessageFormat.format(GIT_COMMIT_AUTHOR, author.getName(), author.getEmail()) : null);
+        this(message, id != null ? id : hash, committerDateMillis, author != null ? MessageFormat.format(GIT_COMMIT_AUTHOR, author.getName(), author.getEmail()) : null);
         if (committer != null) {
             this.committer = MessageFormat.format(GIT_COMMIT_AUTHOR, committer.getName(), committer.getEmail());
         }

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/branch/BitbucketServerCommit.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/branch/BitbucketServerCommit.java
@@ -61,7 +61,7 @@ public class BitbucketServerCommit implements BitbucketCommit {
 
     @JsonCreator
     public BitbucketServerCommit(@NonNull @JsonProperty("message") String message,
-                                 @NonNull @JsonProperty("id") String hash,
+                                 @NonNull @JsonProperty("hash") String hash,
                                  @Nullable @JsonProperty("committer") BitbucketServerAuthor committer,
                                  @NonNull @JsonProperty("committerTimestamp") long committerDateMillis,
                                  @Nullable @JsonProperty("author") BitbucketServerAuthor author,
@@ -107,11 +107,6 @@ public class BitbucketServerCommit implements BitbucketCommit {
 
     public void setHash(String hash) {
         this.hash = hash;
-    }
-
-    @JsonProperty("hash")
-    public void setAlternateHash(String hash) {
-        setHash(hash);
     }
 
     @Deprecated(since = "936.1.0", forRemoval = true)

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/pullrequest/BitbucketServerPullRequest.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/pullrequest/BitbucketServerPullRequest.java
@@ -29,12 +29,12 @@ import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketReviewer;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import tools.jackson.databind.annotation.JsonDeserialize;
 
 public class BitbucketServerPullRequest implements BitbucketPullRequest {
 

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/repository/BitbucketServerProject.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/repository/BitbucketServerProject.java
@@ -26,9 +26,9 @@ package com.cloudbees.jenkins.plugins.bitbucket.server.client.repository;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketHref;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketTeam;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import java.util.List;
 import java.util.Map;
+import tools.jackson.databind.annotation.JsonDeserialize;
 
 public class BitbucketServerProject implements BitbucketTeam {
 

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/repository/BitbucketServerRepository.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/repository/BitbucketServerRepository.java
@@ -29,11 +29,11 @@ import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketRepository;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketRepositoryOwner;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import tools.jackson.databind.annotation.JsonDeserialize;
 
 public class BitbucketServerRepository implements BitbucketRepository {
 


### PR DESCRIPTION
Migrate to Jackson3

Jackson2 remains a dependency because of scribejava-core (looks like a dormant library still supporting Java 7. So I have some doubt it will ever be migrated to Jackson3. Just in case I submited a PR for this library as well: https://github.com/scribejava/scribejava/pull/1088)

I just rely on existing tests

Feel free to take a look at this PR or park it for later

### Your checklist for this pull request

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Did you provide a test-case? That demonstrates feature works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled the information below
Describe your pull request below
-->
