### PR TITLE
[JENKINS-76426] add lazy iteration APIs

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource.java
@@ -410,7 +410,7 @@ public class BitbucketSCMSource extends SCMSource {
         final Set<String> livePRs = new HashSet<>();
         int count = 0;
         Map<Boolean, Set<ChangeRequestCheckoutStrategy>> strategies = request.getPRStrategies();
-        for (final BitbucketPullRequest pull : request.getPullRequests()) {
+        for (final BitbucketPullRequest pull : request.getPullRequestsLazy()) {
             String originalBranchName = pull.getSource().getBranch().getName();
             request.listener().getLogger().printf(
                     "Checking PR-%s from %s and %s %s%n",
@@ -514,7 +514,7 @@ public class BitbucketSCMSource extends SCMSource {
         request.listener().getLogger().println("Looking up " + fullName + " for branches");
 
         int count = 0;
-        for (final BitbucketBranch branch : request.getBranches()) {
+        for (final BitbucketBranch branch : request.getBranchesLazy()) {
             request.listener().getLogger().println("Checking branch " + branch.getName() + " from " + fullName);
             count++;
             BranchSCMHead head = new BranchSCMHead(branch.getName());
@@ -532,7 +532,7 @@ public class BitbucketSCMSource extends SCMSource {
         request.listener().getLogger().println("Looking up " + fullName + " for tags");
 
         int count = 0;
-        for (final BitbucketBranch tag : request.getTags()) {
+        for (final BitbucketBranch tag : request.getTagsLazy()) {
             request.listener().getLogger().println("Checking tag " + tag.getName() + " from " + fullName);
             count++;
             BitbucketTagSCMHead head = new BitbucketTagSCMHead(tag.getName(), tag.getDateMillis());

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource.java
@@ -407,7 +407,7 @@ public class BitbucketSCMSource extends SCMSource {
         final Set<String> livePRs = new HashSet<>();
         int count = 0;
         Map<Boolean, Set<ChangeRequestCheckoutStrategy>> strategies = request.getPRStrategies();
-        for (final BitbucketPullRequest pull : request.getPullRequests()) {
+        for (final BitbucketPullRequest pull : request.getPullRequestsLazy()) {
             String originalBranchName = pull.getSource().getBranch().getName();
             request.listener().getLogger().printf(
                     "Checking PR-%s from %s and %s %s%n",
@@ -511,7 +511,7 @@ public class BitbucketSCMSource extends SCMSource {
         request.listener().getLogger().println("Looking up " + fullName + " for branches");
 
         int count = 0;
-        for (final BitbucketBranch branch : request.getBranches()) {
+        for (final BitbucketBranch branch : request.getBranchesLazy()) {
             request.listener().getLogger().println("Checking branch " + branch.getName() + " from " + fullName);
             count++;
             BranchSCMHead head = new BranchSCMHead(branch.getName());
@@ -529,7 +529,7 @@ public class BitbucketSCMSource extends SCMSource {
         request.listener().getLogger().println("Looking up " + fullName + " for tags");
 
         int count = 0;
-        for (final BitbucketBranch tag : request.getTags()) {
+        for (final BitbucketBranch tag : request.getTagsLazy()) {
             request.listener().getLogger().println("Checking tag " + tag.getName() + " from " + fullName);
             count++;
             BitbucketTagSCMHead head = new BitbucketTagSCMHead(tag.getName(), tag.getDateMillis());

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSourceRequest.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSourceRequest.java
@@ -511,6 +511,14 @@ public class BitbucketSCMSourceRequest extends SCMSourceRequest {
         return Util.fixNull(pullRequests);
     }
 
+    @NonNull
+    public final Iterable<BitbucketPullRequest> getPullRequestsLazy() {
+        if (pullRequests != null) {
+            return pullRequests;
+        }
+        return (Iterable<BitbucketPullRequest>) getBitbucketApiClient().getPullRequestsLazy();
+    }
+
     /**
      * Retrieves the full details of a pull request.
      * @param id The id of the pull request to retrieve the details about.
@@ -559,6 +567,14 @@ public class BitbucketSCMSourceRequest extends SCMSourceRequest {
         return Util.fixNull(branches);
     }
 
+    @NonNull
+    public final Iterable<BitbucketBranch> getBranchesLazy() {
+        if (branches != null) {
+            return branches;
+        }
+        return (Iterable<BitbucketBranch>) getBitbucketApiClient().getBranchesLazy();
+    }
+
     /**
      * Provides the requests with the tag details.
      *
@@ -584,6 +600,15 @@ public class BitbucketSCMSourceRequest extends SCMSourceRequest {
         }
         return Util.fixNull(tags);
     }
+
+    @NonNull
+    public final Iterable<BitbucketBranch> getTagsLazy() {
+        if (tags != null) {
+            return tags;
+        }
+        return (Iterable<BitbucketBranch>) getBitbucketApiClient().getTagsLazy();
+    }
+
 
     /**
      * {@inheritDoc}

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSourceRequest.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSourceRequest.java
@@ -529,6 +529,21 @@ public class BitbucketSCMSourceRequest extends SCMSourceRequest {
                 .collect(Collectors.toList()); // NOSONAR
     }
 
+    @NonNull
+    public final Iterable<BitbucketPullRequest> getPullRequestsLazy() {
+        Iterable<BitbucketPullRequest> source;
+        if (pullRequests != null) {
+            source = pullRequests;
+        } else {
+            source = (Iterable<BitbucketPullRequest>) getBitbucketApiClient().getPullRequestsLazy();
+        }
+
+        // Return lazy filtered iterable without materializing the entire list
+        return () -> StreamSupport.stream(Util.fixNull(source).spliterator(), false)
+                .filter(pr -> !skipDraftPRs || (skipDraftPRs && !pr.isDraft()))
+                .iterator();
+    }
+
     /**
      * Retrieves the full details of a pull request.
      * @param id The id of the pull request to retrieve the details about.
@@ -577,6 +592,14 @@ public class BitbucketSCMSourceRequest extends SCMSourceRequest {
         return Util.fixNull(branches);
     }
 
+    @NonNull
+    public final Iterable<BitbucketBranch> getBranchesLazy() {
+        if (branches != null) {
+            return branches;
+        }
+        return (Iterable<BitbucketBranch>) getBitbucketApiClient().getBranchesLazy();
+    }
+
     /**
      * Provides the requests with the tag details.
      *
@@ -602,6 +625,15 @@ public class BitbucketSCMSourceRequest extends SCMSourceRequest {
         }
         return Util.fixNull(tags);
     }
+
+    @NonNull
+    public final Iterable<BitbucketBranch> getTagsLazy() {
+        if (tags != null) {
+            return tags;
+        }
+        return (Iterable<BitbucketBranch>) getBitbucketApiClient().getTagsLazy();
+    }
+
 
     /**
      * {@inheritDoc}

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/BitbucketApi.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/BitbucketApi.java
@@ -82,6 +82,14 @@ public interface BitbucketApi extends AutoCloseable {
     BitbucketPullRequest getPullRequestById(@NonNull Integer id) throws IOException;
 
     /**
+     * Returns the pull requests in the repository lazily
+     *
+     * @return the list of pull requests in the repository.
+     */
+    @NonNull
+    Iterable<? extends BitbucketPullRequest> getPullRequestsLazy();
+
+    /**
      * Returns the repository details.
      *
      * @return the repository specified by {@link #getOwner()}/{@link #getRepositoryName()}
@@ -140,6 +148,14 @@ public interface BitbucketApi extends AutoCloseable {
     List<? extends BitbucketBranch> getBranches() throws IOException, InterruptedException;
 
     /**
+     * Returns the branches in the repository lazily.
+     *
+     * @return an interable of branches in the repository.
+     */
+    @NonNull
+    Iterable<? extends BitbucketBranch> getBranchesLazy();
+
+    /**
      * Returns a tag in the repository.
      *
      * @return a tag in the repository.
@@ -157,6 +173,14 @@ public interface BitbucketApi extends AutoCloseable {
      */
     @NonNull
     List<? extends BitbucketBranch> getTags() throws IOException, InterruptedException;
+
+    /**
+     * Returns the tags in the repository lazily
+     *
+     * @return an iterable of tags in the repository.
+     */
+    @NonNull
+    Iterable<? extends BitbucketBranch> getTagsLazy();
 
     /**
      * Resolve the commit object given its hash.

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/paginated/PageFetcher.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/paginated/PageFetcher.java
@@ -1,0 +1,28 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2026, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.cloudbees.jenkins.plugins.bitbucket.api.paginated;
+
+public interface PageFetcher<T> {
+    PaginatedList<T> fetchNextPage();
+}

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/paginated/PaginatedIterable.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/paginated/PaginatedIterable.java
@@ -1,0 +1,41 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2026, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.cloudbees.jenkins.plugins.bitbucket.api.paginated;
+
+import java.util.Iterator;
+import java.util.function.Supplier;
+
+public class PaginatedIterable<T> implements Iterable<T> {
+
+    private final Supplier<PageFetcher<T>> fetcherSupplier;
+
+    public PaginatedIterable(Supplier<PageFetcher<T>> fetcherSupplier) {
+        this.fetcherSupplier = fetcherSupplier;
+    }
+
+    @Override
+    public Iterator<T> iterator() {
+        return new PaginatedIterator<>(fetcherSupplier.get());
+    }
+}

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/paginated/PaginatedIterator.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/paginated/PaginatedIterator.java
@@ -1,0 +1,73 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2026, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.cloudbees.jenkins.plugins.bitbucket.api.paginated;
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+public class PaginatedIterator<T> implements Iterator<T> {
+
+    private final PageFetcher<T> fetcher;
+    private Iterator<T> currentIterator;
+    private boolean lastPageReached = false;
+
+    public PaginatedIterator(PageFetcher<T> fetcher) {
+        this.fetcher = fetcher;
+        loadNextPage();
+    }
+
+    private void loadNextPage() {
+        if (this.lastPageReached) return;
+
+        PaginatedList<T> page = fetcher.fetchNextPage();
+
+        this.lastPageReached = page.isLastPage();
+
+        if (page.hasItems()) {
+            currentIterator = page.iterator();
+        } else {
+            currentIterator = null;
+        }
+    }
+
+    @Override
+    public boolean hasNext() {
+        if (currentIterator != null && currentIterator.hasNext()) {
+            return true;
+        } else if (!this.lastPageReached) {
+            loadNextPage();
+            return hasNext();
+        }
+
+        return false;
+    }
+
+    @Override
+    public T next() {
+        if (!hasNext()) {
+            throw new NoSuchElementException();
+        }
+        return currentIterator.next();
+    }
+}

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/paginated/PaginatedList.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/paginated/PaginatedList.java
@@ -1,0 +1,51 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2026, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.cloudbees.jenkins.plugins.bitbucket.api.paginated;
+
+import java.util.Iterator;
+import java.util.List;
+
+public class PaginatedList<T> implements Iterable<T> {
+
+    private List<T> items;
+    private boolean isLastPage;
+
+    public PaginatedList(List<T> items, boolean isLastPage) {
+        this.items = items;
+        this.isLastPage = isLastPage;
+    }
+
+    public boolean hasItems() {
+        return items != null && !items.isEmpty();
+    }
+
+    public boolean isLastPage() {
+        return isLastPage;
+    }
+
+    @Override
+    public Iterator<T> iterator() {
+        return items.iterator();
+    }
+}

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/BitbucketCloudApiClient.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/BitbucketCloudApiClient.java
@@ -35,6 +35,9 @@ import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketRepository;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketRequestException;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketTeam;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketWebHook;
+import com.cloudbees.jenkins.plugins.bitbucket.api.paginated.PageFetcher;
+import com.cloudbees.jenkins.plugins.bitbucket.api.paginated.PaginatedIterable;
+import com.cloudbees.jenkins.plugins.bitbucket.api.paginated.PaginatedList;
 import com.cloudbees.jenkins.plugins.bitbucket.client.branch.BitbucketCloudBranch;
 import com.cloudbees.jenkins.plugins.bitbucket.client.branch.BitbucketCloudCommit;
 import com.cloudbees.jenkins.plugins.bitbucket.client.pullrequest.BitbucketCloudPullRequest;
@@ -189,7 +192,7 @@ public class BitbucketCloudApiClient extends AbstractBitbucketApi implements Bit
 
         List<BitbucketCloudPullRequest> pullRequests = getPagedRequest(url, BitbucketCloudPullRequest.class);
         // PRs with missing destination branch are invalid and should be ignored.
-        pullRequests.removeIf(this::shouldIgnore);
+        pullRequests.removeIf(BitbucketCloudApiClient::shouldIgnore);
 
         for (BitbucketCloudPullRequest pullRequest : pullRequests) {
             setupClosureForPRBranch(pullRequest);
@@ -199,12 +202,31 @@ public class BitbucketCloudApiClient extends AbstractBitbucketApi implements Bit
     }
 
     /**
+     * {@inheritDoc}
+     */
+    @NonNull
+    @Override
+    public Iterable<BitbucketCloudPullRequest> getPullRequestsLazy() {
+        // we can not use the default max pagelen also if documented
+        // https://developer.atlassian.com/bitbucket/api/2/reference/resource/repositories/%7Busername%7D/%7Brepo_slug%7D/pullrequests#get
+        // so because with values greater than 50 the API returns HTTP 400
+        int pageLen = 50;
+        String url = UriTemplate.fromTemplate(REPO_URL_TEMPLATE + "/pullrequests{?page,pagelen}")
+                .set("owner", owner)
+                .set("repo", repositoryName)
+                .set("pagelen", pageLen)
+                .expand();
+
+        return getPagedRequestLazy(url, BitbucketCloudPullRequest.class);
+    }
+
+    /**
      * PRs with missing source / destination branch are invalid and should be ignored.
      *
      * @param pr a {@link BitbucketPullRequest}
      * @return whether the PR should be ignored
      */
-    private boolean shouldIgnore(BitbucketPullRequest pr) {
+    private static boolean shouldIgnore(BitbucketPullRequest pr) {
         return pr.getSource().getRepository() == null
             || pr.getSource().getCommit() == null
             || pr.getDestination().getBranch() == null
@@ -371,6 +393,15 @@ public class BitbucketCloudApiClient extends AbstractBitbucketApi implements Bit
     /**
      * {@inheritDoc}
      */
+    @NonNull
+    @Override
+    public Iterable<BitbucketCloudBranch> getTagsLazy() {
+        return getBranchesByRefLazy("/refs/tags");
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public BitbucketCloudBranch getBranch(@NonNull String branchName) throws IOException {
         String url = UriTemplate.fromTemplate(REPO_URL_TEMPLATE + "/refs/branches/{name}")
@@ -390,6 +421,15 @@ public class BitbucketCloudApiClient extends AbstractBitbucketApi implements Bit
         return getBranchesByRef("/refs/branches");
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @NonNull
+    @Override
+    public Iterable<BitbucketCloudBranch> getBranchesLazy() {
+        return getBranchesByRefLazy("/refs/branches");
+    }
+
     public List<BitbucketCloudBranch> getBranchesByRef(String nodePath) throws IOException {
         String url = UriTemplate.fromTemplate(REPO_URL_TEMPLATE + nodePath + "{?pagelen}")
                 .set("owner", owner)
@@ -399,6 +439,15 @@ public class BitbucketCloudApiClient extends AbstractBitbucketApi implements Bit
         return getPagedRequest(url, BitbucketCloudBranch.class).stream()
                 .filter(BitbucketCloudBranch::isActive) // Filter the inactive branches out
                 .toList();
+    }
+
+    private Iterable<BitbucketCloudBranch> getBranchesByRefLazy(String nodePath) {
+        String url = UriTemplate.fromTemplate(REPO_URL_TEMPLATE + nodePath + "{?pagelen}")
+                .set("owner", owner)
+                .set("repo", repositoryName)
+                .set("pagelen", MAX_PAGE_LENGTH)
+                .expand();
+        return getPagedRequestLazy(url, BitbucketCloudBranch.class);
     }
 
     /**
@@ -809,6 +858,67 @@ public class BitbucketCloudApiClient extends AbstractBitbucketApi implements Bit
             throw new IOException("I/O error when parsing response from URL: " + url, e);
         }
         return resources;
+    }
+
+    private <V> PaginatedIterable<V> getPagedRequestLazy(String url, Class<V> resultType) {
+        ParameterizedType parameterizedType = new ParameterizedType() {
+
+            @Override
+            public Type getRawType() {
+                return BitbucketCloudPage.class;
+            }
+
+            @Override
+            public Type getOwnerType() {
+                return null;
+            }
+
+            @Override
+            public Type[] getActualTypeArguments() {
+                return new Type[] { resultType };
+            }
+        };
+        TypeReference<BitbucketCloudPage<V>> type = new TypeReference<BitbucketCloudPage<V>>(){
+            @Override
+            public Type getType() {
+                return parameterizedType;
+            }
+        };
+
+        PaginatedIterable<V> iterable = new PaginatedIterable<>(() -> new PageFetcher<V>() {
+
+            private String nextUrl = url;
+
+            public PaginatedList<V> fetchNextPage() {
+                try {
+                    if (nextUrl == null) {
+                        return new PaginatedList<>(Collections.emptyList(), true);
+                    }
+
+                    List<V> resources = new ArrayList<>();
+                    String response = getRequest(this.nextUrl);
+                    BitbucketCloudPage<V> page = JsonParser.toJava(response, type);
+
+                    resources.addAll(page.getValues());
+                    this.nextUrl = page.getNext();
+
+                    // Special handling for PRs see getPullRequests();
+                    if (resultType == BitbucketCloudPullRequest.class) {
+                        List<BitbucketCloudPullRequest> prs = (List<BitbucketCloudPullRequest>) resources;
+                        prs.removeIf(BitbucketCloudApiClient::shouldIgnore);
+                        for (BitbucketCloudPullRequest pr : prs) {
+                            setupClosureForPRBranch(pr);
+                        }
+                    }
+
+                    return new PaginatedList<>(resources, page.isLastPage());
+                } catch (Exception e) {
+                    throw new IllegalStateException("Error fetching page from: " + this.nextUrl, e);
+                }
+            }
+        });
+
+        return iterable;
     }
 
     private <V> V getRequestAs(String url, Class<V> resultType) throws IOException {

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/BitbucketServerAPIClient.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/server/client/BitbucketServerAPIClient.java
@@ -36,6 +36,9 @@ import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketRepository;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketRequestException;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketTeam;
 import com.cloudbees.jenkins.plugins.bitbucket.api.endpoint.BitbucketEndpointProvider;
+import com.cloudbees.jenkins.plugins.bitbucket.api.paginated.PageFetcher;
+import com.cloudbees.jenkins.plugins.bitbucket.api.paginated.PaginatedIterable;
+import com.cloudbees.jenkins.plugins.bitbucket.api.paginated.PaginatedList;
 import com.cloudbees.jenkins.plugins.bitbucket.client.repository.UserRoleInRepository;
 import com.cloudbees.jenkins.plugins.bitbucket.filesystem.BitbucketSCMFile;
 import com.cloudbees.jenkins.plugins.bitbucket.impl.buildstatus.ServerBuildStatusNotifier;
@@ -204,6 +207,19 @@ public class BitbucketServerAPIClient extends AbstractBitbucketApi implements Bi
         return getPullRequests(template);
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @NonNull
+    @Override
+    public Iterable<BitbucketServerPullRequest> getPullRequestsLazy() {
+        UriTemplate template = UriTemplate
+                .fromTemplate(this.baseURL + API_PULL_REQUESTS_PATH)
+                .set("owner", getOwner())
+                .set("repo", repositoryName);
+        return getPagedRequestLazy(template, BitbucketServerPullRequest.class);
+    }
+
     @NonNull
     public List<BitbucketServerPullRequest> getOutgoingOpenPullRequests(String fromRef) throws IOException {
         UriTemplate template = UriTemplate
@@ -231,7 +247,7 @@ public class BitbucketServerAPIClient extends AbstractBitbucketApi implements Bi
     private List<BitbucketServerPullRequest> getPullRequests(UriTemplate template) throws IOException {
         List<BitbucketServerPullRequest> pullRequests = getPagedRequest(template, BitbucketServerPullRequest.class);
 
-        pullRequests.removeIf(this::shouldIgnore);
+        pullRequests.removeIf(BitbucketServerAPIClient::shouldIgnore);
 
         BitbucketServerEndpoint endpoint = BitbucketEndpointProvider
                 .lookupEndpoint(this.baseURL, BitbucketServerEndpoint.class)
@@ -244,7 +260,7 @@ public class BitbucketServerAPIClient extends AbstractBitbucketApi implements Bi
         if (endpoint != null) {
             // Get PRs again as revisions could be changed by other events during setupPullRequest
             pullRequests = getPagedRequest(template, BitbucketServerPullRequest.class);
-            pullRequests.removeIf(this::shouldIgnore);
+            pullRequests.removeIf(BitbucketServerAPIClient::shouldIgnore);
         }
 
         return pullRequests;
@@ -276,7 +292,7 @@ public class BitbucketServerAPIClient extends AbstractBitbucketApi implements Bi
      * @param pullRequest a {@link BitbucketPullRequest}
      * @return whether the PR should be ignored
      */
-    private boolean shouldIgnore(BitbucketPullRequest pullRequest) {
+    private static boolean shouldIgnore(BitbucketPullRequest pullRequest) {
         return pullRequest.getSource().getRepository() == null
             || pullRequest.getSource().getBranch() == null
             || pullRequest.getDestination().getBranch() == null;
@@ -519,6 +535,15 @@ public class BitbucketServerAPIClient extends AbstractBitbucketApi implements Bi
      * {@inheritDoc}
      */
     @Override
+    @NonNull
+    public Iterable<BitbucketServerBranch> getTagsLazy() {
+        return getServerBranchesLazy(API_TAGS_PATH);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public BitbucketServerBranch getBranch(@NonNull String branchName) throws IOException {
         return getSingleBranch(branchName);
     }
@@ -530,6 +555,15 @@ public class BitbucketServerAPIClient extends AbstractBitbucketApi implements Bi
     @NonNull
     public List<BitbucketServerBranch> getBranches() throws IOException {
         return getServerBranches(API_BRANCHES_PATH);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @NonNull
+    public Iterable<BitbucketServerBranch> getBranchesLazy() {
+        return getServerBranchesLazy(API_BRANCHES_PATH);
     }
 
     private List<BitbucketServerBranch> getServerBranches(String apiPath) throws IOException {
@@ -546,6 +580,15 @@ public class BitbucketServerAPIClient extends AbstractBitbucketApi implements Bi
         }
 
         return branches;
+    }
+
+    private Iterable<BitbucketServerBranch> getServerBranchesLazy(String apiPath) {
+        UriTemplate template = UriTemplate
+                .fromTemplate(this.baseURL + apiPath)
+                .set("owner", getOwner())
+                .set("repo", repositoryName);
+
+        return getPagedRequestLazy(template, BitbucketServerBranch.class);
     }
 
     private BitbucketServerBranch getSingleBranch(String branchName) throws IOException {
@@ -788,6 +831,76 @@ public class BitbucketServerAPIClient extends AbstractBitbucketApi implements Bi
         } catch (JacksonException e) {
             throw new IOException("I/O error when parsing response from URL: " + url, e);
         }
+    }
+
+    private <V> Iterable<V> getPagedRequestLazy(UriTemplate template, Class<V> resultType) {
+        ParameterizedType parameterizedType = new ParameterizedType() {
+
+            @Override
+            public java.lang.reflect.Type getRawType() {
+                return BitbucketServerPage.class;
+            }
+
+            @Override
+            public java.lang.reflect.Type getOwnerType() {
+                return null;
+            }
+
+            @Override
+            public java.lang.reflect.Type[] getActualTypeArguments() {
+                return new java.lang.reflect.Type[] { resultType };
+            }
+        };
+
+        TypeReference<BitbucketServerPage<V>> type = new TypeReference<BitbucketServerPage<V>>(){
+            @Override
+            public java.lang.reflect.Type getType() {
+                return parameterizedType;
+            }
+        };
+
+        PaginatedIterable<V> iterable = new PaginatedIterable<>(() -> new PageFetcher<V>() {
+
+            private UriTemplate uriTemplate = template;
+            private Integer pageNumber = 0;
+            private Integer limit = DEFAULT_PAGE_LIMIT;
+
+            public PaginatedList<V> fetchNextPage() {
+                List<V> resources = new ArrayList<>();
+                String url = uriTemplate //
+                        .set("start", pageNumber) //
+                        .set("limit", limit) //
+                        .expand();
+                try {
+                    String response = getRequest(url);
+                    BitbucketServerPage<V> page = JsonParser.toJava(response, type);
+                    resources.addAll(page.getValues());
+
+                    if (resultType == BitbucketServerBranch.class) {
+                        List<BitbucketServerBranch> branches = (List<BitbucketServerBranch>) resources;
+                        for (BitbucketServerBranch branch : branches) {
+                            if (branch != null) {
+                                branch.setCommitClosure(new CommitClosure(branch.getRawNode()));
+                            }
+                        }
+                    } else if (resultType == BitbucketServerPullRequest.class) {
+                        List<BitbucketServerPullRequest> prs = (List<BitbucketServerPullRequest>) resources;
+                        prs.removeIf(BitbucketServerAPIClient::shouldIgnore);
+                        for (BitbucketServerPullRequest pr : prs) {
+                            setupClosureForPRBranch(pr);
+                        }
+                    }
+
+                    limit = page.getLimit();
+                    pageNumber = page.getNextPageStart();
+
+                    return new PaginatedList<>(resources, page.isLastPage());
+                } catch (Exception e) {
+                    throw new IllegalStateException("Error fetching page from: " + url, e);
+                }
+            }
+        });
+        return iterable;
     }
 
     private BufferedImage getImageRequest(String path) throws IOException {

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSourceRetrieveTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSourceRetrieveTest.java
@@ -155,7 +155,7 @@ class BitbucketSCMSourceRetrieveTest {
 
         List<BitbucketCloudBranch> branches =
             Collections.singletonList(new BitbucketCloudBranch(BRANCH_NAME, COMMIT_HASH, 0));
-        when(client.getBranches()).thenReturn(branches);
+        when(client.getBranchesLazy()).thenReturn(branches);
 
         verifyExpectedClientApiCalls(instance, client);
     }
@@ -176,7 +176,7 @@ class BitbucketSCMSourceRetrieveTest {
 
         List<BitbucketServerBranch> branches =
             Collections.singletonList(new BitbucketServerBranch(BRANCH_NAME, COMMIT_HASH));
-        when(client.getBranches()).thenReturn(branches);
+        when(client.getBranchesLazy()).thenReturn(branches);
         when(client.getRepository()).thenReturn(repository);
 
         verifyExpectedClientApiCalls(instance, client);

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/api/paginated/PaginatedIterableTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/api/paginated/PaginatedIterableTest.java
@@ -1,0 +1,145 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2026, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.cloudbees.jenkins.plugins.bitbucket.api.paginated;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PaginatedIteratorableTest {
+
+    @Test
+    void shouldIterateOverMultiplePages() {
+        List<PaginatedList<Integer>> pages = List.of(
+                new PaginatedList<>(List.of(1, 2), false),
+                new PaginatedList<>(List.of(3, 4), false),
+                new PaginatedList<>(List.of(5), true)
+        );
+
+        AtomicInteger index = new AtomicInteger(0);
+
+        PageFetcher<Integer> fetcher = () -> pages.get(index.getAndIncrement());
+
+        PaginatedIterable<Integer> iterable =
+                new PaginatedIterable<>(() -> fetcher);
+
+        List<Integer> result = new ArrayList<>();
+        for (Integer i : iterable) {
+            result.add(i);
+        }
+
+        assertEquals(List.of(1, 2, 3, 4, 5), result);
+    }
+
+    @Test
+    void shouldHandleEmptyPagesBetweenData() {
+        List<PaginatedList<Integer>> pages = List.of(
+                new PaginatedList<>(Collections.emptyList(), false),
+                new PaginatedList<>(List.of(1, 2), false),
+                new PaginatedList<>(Collections.emptyList(), false),
+                new PaginatedList<>(List.of(3), true)
+        );
+
+        AtomicInteger index = new AtomicInteger(0);
+
+        PageFetcher<Integer> fetcher = () -> pages.get(index.getAndIncrement());
+
+        PaginatedIterable<Integer> iterable =
+                new PaginatedIterable<>(() -> fetcher);
+
+        List<Integer> result = new ArrayList<>();
+        for (Integer i : iterable) {
+            result.add(i);
+        }
+
+        assertEquals(List.of(1, 2, 3), result);
+    }
+
+    @Test
+    void shouldReturnFalseWhenNoElements() {
+        List<PaginatedList<Integer>> pages = List.of(
+                new PaginatedList<>(Collections.emptyList(), true)
+        );
+
+        PageFetcher<Integer> fetcher = () -> pages.get(0);
+
+        PaginatedIterator<Integer> iterator = new PaginatedIterator<>(fetcher);
+
+        assertFalse(iterator.hasNext());
+    }
+
+    @Test
+    void shouldThrowExceptionWhenNoMoreElements() {
+        List<PaginatedList<Integer>> pages = List.of(
+                new PaginatedList<>(List.of(1), true)
+        );
+
+        PageFetcher<Integer> fetcher = () -> pages.get(0);
+
+        PaginatedIterator<Integer> iterator = new PaginatedIterator<>(fetcher);
+
+        assertTrue(iterator.hasNext());
+        assertEquals(1, iterator.next());
+
+        assertFalse(iterator.hasNext());
+        assertThrows(NoSuchElementException.class, iterator::next);
+    }
+
+    @Test
+    void shouldCreateNewFetcherPerIterableIterator() {
+        AtomicInteger fetchCount = new AtomicInteger(0);
+
+        Supplier<PageFetcher<Integer>> supplier = () -> () -> {
+            fetchCount.incrementAndGet();
+            return new PaginatedList<>(List.of(1), true);
+        };
+
+        PaginatedIterable<Integer> iterable = new PaginatedIterable<>(supplier);
+
+        // First iteration
+        List<Integer> firstRun = new ArrayList<>();
+        for (Integer i : iterable) {
+            firstRun.add(i);
+        }
+
+        // Second iteration (should use new fetcher)
+        List<Integer> secondRun = new ArrayList<>();
+        for (Integer i : iterable) {
+            secondRun.add(i);
+        }
+
+        assertEquals(List.of(1), firstRun);
+        assertEquals(List.of(1), secondRun);
+        assertEquals(2, fetchCount.get()); // ensures new fetcher each time
+    }
+}

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/impl/notifier/BitbucketBuildStatusNotificationsJobListenerTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/impl/notifier/BitbucketBuildStatusNotificationsJobListenerTest.java
@@ -115,7 +115,7 @@ class BitbucketBuildStatusNotificationsJobListenerTest {
         BitbucketApi api = mock(BitbucketApi.class);
         BitbucketBranch branch = mock(BitbucketBranch.class);
         List<? extends BitbucketBranch> branchList = Collections.singletonList(branch);
-        when(api.getBranches()).thenAnswer(new Returns(branchList));
+        when(api.getBranchesLazy()).thenAnswer(new Returns(branchList));
         when(api.getBranch("master")).thenAnswer(new Returns(branch));
         when(branch.getName()).thenReturn(branchName);
         when(branch.getRawNode()).thenReturn(sampleRepo.head());

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/test/util/BitbucketClientMockUtils.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/test/util/BitbucketClientMockUtils.java
@@ -71,12 +71,14 @@ public class BitbucketClientMockUtils {
         branches.add(branch2);
         // add branches
         when(client.getBranches()).thenReturn(branches);
+        when(client.getBranchesLazy()).thenReturn(branches);
         when(client.getBranch("branch1")).thenReturn(branch1);
         when(client.getBranch("branch2")).thenReturn(branch2);
         withMockGitRepos(client);
 
         if (includePullRequests) {
             when(client.getPullRequests()).thenReturn(Arrays.asList(getPullRequest()));
+            when(client.getPullRequestsLazy()).thenReturn(Arrays.asList(getPullRequest()));
             when(client.resolveSourceFullHash(any(BitbucketCloudPullRequest.class)))
                     .thenReturn("e851558f77c098d21af6bb8cc54a423f7cf12147");
 

--- a/src/test/java/integration/ScanningFailuresTest.java
+++ b/src/test/java/integration/ScanningFailuresTest.java
@@ -111,16 +111,6 @@ class ScanningFailuresTest {
     }
 
     @Test
-    void getBranchesFailsWithIOException() throws Exception {
-        getBranchesFails(() -> new IOException(message), Result.FAILURE);
-    }
-
-    @Test
-    void getBranchesFailsWithInterruptedException() throws Exception {
-        getBranchesFails(() -> new InterruptedException(message), Result.ABORTED);
-    }
-
-    @Test
     void getBranchesFailsWithRuntimeException() throws Exception {
         getBranchesFails(() -> new RuntimeException(message), Result.FAILURE);
     }
@@ -144,7 +134,7 @@ class ScanningFailuresTest {
 
         BitbucketBranch branch = Mockito.mock(BitbucketBranch.class);
         List<? extends BitbucketBranch> branchList = Collections.singletonList(branch);
-        when(api.getBranches()).thenAnswer(new Returns(branchList));
+        when(api.getBranchesLazy()).thenAnswer(new Returns(branchList));
         when(branch.getName()).thenReturn("main");
         when(branch.getRawNode()).thenReturn(sampleRepo.head());
 
@@ -179,9 +169,9 @@ class ScanningFailuresTest {
         WorkflowJob master = mp.getItem("main");
         assertThat(master).isNotNull();
 
-        // an error in getBranches()
+        // an error in getBranchesLazy()
 
-        when(api.getBranches()).thenThrow(exception.call());
+        when(api.getBranchesLazy()).thenThrow(exception.call());
 
         if (Result.NOT_BUILT.equals(expectedResult) || Result.ABORTED.equals(expectedResult)) {
             // when not built or aborted the future will never complete and the log may not contain the exception stack trace
@@ -214,7 +204,7 @@ class ScanningFailuresTest {
 
         BitbucketBranch branch = Mockito.mock(BitbucketBranch.class);
         List<? extends BitbucketBranch> branchList = Collections.singletonList(branch);
-        when(api.getBranches()).thenAnswer(new Returns(branchList));
+        when(api.getBranchesLazy()).thenAnswer(new Returns(branchList));
         when(branch.getName()).thenReturn("main");
         when(branch.getRawNode()).thenReturn(sampleRepo.head());
 
@@ -274,7 +264,7 @@ class ScanningFailuresTest {
 
         BitbucketBranch branch = Mockito.mock(BitbucketBranch.class);
         List<? extends BitbucketBranch> branchList = Collections.singletonList(branch);
-        when(api.getBranches()).thenAnswer(new Returns(branchList));
+        when(api.getBranchesLazy()).thenAnswer(new Returns(branchList));
         when(branch.getName()).thenReturn("main");
         when(branch.getRawNode()).thenReturn(sampleRepo.head());
 
@@ -338,7 +328,7 @@ class ScanningFailuresTest {
 
         BitbucketBranch branch = Mockito.mock(BitbucketBranch.class);
         List<? extends BitbucketBranch> branchList = Collections.singletonList(branch);
-        when(api.getBranches()).thenAnswer(new Returns(branchList));
+        when(api.getBranchesLazy()).thenAnswer(new Returns(branchList));
         when(branch.getName()).thenReturn("main");
         when(branch.getRawNode()).thenReturn(sampleRepo.head());
 
@@ -378,7 +368,7 @@ class ScanningFailuresTest {
         assertThat(master.getNextBuildNumber()).isEqualTo(2);
 
         // the branch is actually removed
-        when(api.getBranches()).thenAnswer(new Returns(Collections.emptyList()));
+        when(api.getBranchesLazy()).thenAnswer(new Returns(Collections.emptyList()));
 
         mp.scheduleBuild2(0).getFuture().get();
         assertThat(mp.getIndexing().getResult()).isEqualTo(Result.SUCCESS);


### PR DESCRIPTION
We want to reduce the number of API calls from paginated APIs. In some cases e.g BitbucketSCM.retrieve we get the whole list despite there being a loop early exit.

### Your checklist for this pull request

- [ ] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Did you provide a test-case? That demonstrates feature works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled the information below
Describe your pull request below
-->
