### PR TITLE
Skip retrieving tags on non tag related events

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource.java
@@ -368,8 +368,14 @@ public class BitbucketSCMSource extends SCMSource {
                 retrieveBranches(request);
             }
             if (request.isFetchTags() && !request.isComplete()) {
-                // Search tags
-                retrieveTags(request);
+                // Skip fetching all tags when the event is not tag-related
+                // (e.g., PR events, branch push events). Tags are only fetched
+                // during a full scan (event == null) or when the event produces
+                // tag-type SCM heads.
+                if (event == null || containsTagHeads(event, this)) {
+                    // Search tags
+                    retrieveTags(request);
+                }
             }
         }
     }
@@ -542,6 +548,19 @@ public class BitbucketSCMSource extends SCMSource {
             }
         }
         request.listener().getLogger().format("%n  %d tags were processed%n", count);
+    }
+
+    /**
+     * Checks if the given event produces any tag-related SCM heads for this source.
+     */
+    private static boolean containsTagHeads(@NonNull SCMHeadEvent<?> event, @NonNull BitbucketSCMSource source) {
+        Map<SCMHead, SCMRevision> heads = event.heads(source);
+        for (SCMHead head : heads.keySet()) {
+            if (head instanceof BitbucketTagSCMHead || head instanceof GitTagSCMHead) {
+                return true;
+            }
+        }
+        return false;
     }
 
     @Override


### PR DESCRIPTION
### Problem:
We have a repository with large number of branches and tags and webhooks enabled.
On every event in this repository, Jenkins is checking all the branches and tags - which takes significant time - a few minutes for single job. Because the number of thread which can process webhooks is limited, sometimes we experience long queues and delays between webhooks is sent and a new build is triggered.

I've checked different jobs configurations and I found that
* The problem occurs when `Discover tags` is trait is configured
* Huge number of branches is checked much faster than huge number of tags
* Tags are always checked, regardless which type of event triggered webhook
* All tags are always checked - no matter if they match `Filter by name`  pattern

### Solution:
I realize, that the fix is a bit dummy, and to fix we need something better.
This is a draft Pull Request - to discuss possible solutions

I'm just checking event contains a Tag entry, if not - whole retrieveTags stage is skipped.

I've also thought about:
* adding a possibility to enable/disable such optimization
* adding similar optimization to branches/PRs
* finding why `Filter by name` is not used to limit the number of checked tags
* checking only tags which are included in webhook's body

What is your opinion - what is a correct way of solving this issue?
Could you please provide a fix on your own or help with with implementing proper fix?

### Your checklist for this pull request

- [ ] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Did you provide a test-case? That demonstrates feature works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled the information below
Describe your pull request below
-->
