### PR TITLE
Bugfix/jenkins 76486

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource.java
@@ -770,6 +770,11 @@ public class BitbucketSCMSource extends SCMSource {
     }
 
     private void setPrimaryCloneLinks(List<BitbucketHref> links) {
+        stripAuthenticationFromHttpCloneLinks(links);
+        primaryCloneLinks = links;
+    }
+
+    private void stripAuthenticationFromHttpCloneLinks(List<BitbucketHref> links) {
         links.forEach(link -> {
             if (StringUtils.startsWithIgnoreCase(link.getName(), "http")) {
                 // Remove the username from URL because it will be set into the GIT_URL variable
@@ -779,7 +784,6 @@ public class BitbucketSCMSource extends SCMSource {
                 link.setHref(URLUtils.removeAuthority(link.getHref()));
             }
         });
-        primaryCloneLinks = links;
     }
 
     @NonNull
@@ -1022,6 +1026,7 @@ public class BitbucketSCMSource extends SCMSource {
             if (mirroredRepositoryCloneLinks == null) {
                 throw new IllegalStateException("There is no mirrored repository clone links for mirror id " + mirrorIdLocal);
             }
+            stripAuthenticationFromHttpCloneLinks(mirroredRepositoryCloneLinks);
             mirrorCloneLinks = mirroredRepositoryCloneLinks;
         } catch (Exception e) {
             LOGGER.log(Level.SEVERE,

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/impl/extension/GitClientAuthenticatorExtension.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/impl/extension/GitClientAuthenticatorExtension.java
@@ -39,6 +39,7 @@ import hudson.plugins.git.extensions.GitSCMExtension;
 import hudson.plugins.git.extensions.GitSCMExtensionDescriptor;
 import hudson.security.ACL;
 import hudson.security.ACLContext;
+import java.util.List;
 import java.util.Objects;
 import jenkins.authentication.tokens.api.AuthenticationTokens;
 import jenkins.model.Jenkins;
@@ -94,10 +95,18 @@ public class GitClientAuthenticatorExtension extends GitSCMExtension {
                 // example, an API token needs a different username on Bitbucket Cloud), so apply
                 // the translated credential to every remote configured with the same credential
                 // ID. Remotes with a different credential ID must retain their own credentials.
-                for (UserRemoteConfig remote : scm.getUserRemoteConfigs()) {
-                    if (Objects.equals(credentialsId, remote.getCredentialsId())
-                            && !Objects.equals(url, remote.getUrl())) {
-                        git.addCredentials(remote.getUrl(), credentials);
+                List<UserRemoteConfig> remotes = scm != null ? scm.getUserRemoteConfigs() : null;
+                if (remotes != null) {
+                    for (UserRemoteConfig remote : remotes) {
+                        if (remote == null) {
+                            continue;
+                        }
+                        String remoteUrl = remote.getUrl();
+                        if (remoteUrl != null
+                                && !Objects.equals(url, remoteUrl)
+                                && Objects.equals(credentialsId, remote.getCredentialsId())) {
+                            git.addCredentials(remoteUrl, credentials);
+                        }
                     }
                 }
             }

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/impl/extension/GitClientAuthenticatorExtension.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/impl/extension/GitClientAuthenticatorExtension.java
@@ -24,6 +24,7 @@
 package com.cloudbees.jenkins.plugins.bitbucket.impl.extension;
 
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketAuthenticator;
+import com.cloudbees.jenkins.plugins.bitbucket.impl.util.URLUtils;
 import com.cloudbees.jenkins.plugins.bitbucket.util.BitbucketCredentialsUtils;
 import com.cloudbees.plugins.credentials.common.StandardCredentials;
 import com.cloudbees.plugins.credentials.common.StandardUsernameCredentials;
@@ -89,6 +90,10 @@ public class GitClientAuthenticatorExtension extends GitSCMExtension {
                 // Keep registering the primary URL directly for compatibility with SCMs whose
                 // primary URL is not represented in getUserRemoteConfigs().
                 git.addCredentials(url, credentials);
+                String normalizedUrl = URLUtils.removeAuthority(url);
+                if (!Objects.equals(url, normalizedUrl)) {
+                    git.addCredentials(normalizedUrl, credentials);
+                }
 
                 // GitSCM initially registers the raw Jenkins credential for each remote. A
                 // Bitbucket authenticator can translate that credential for Git operations (for
@@ -102,10 +107,14 @@ public class GitClientAuthenticatorExtension extends GitSCMExtension {
                             continue;
                         }
                         String remoteUrl = remote.getUrl();
+                        String normalizedRemoteUrl = URLUtils.removeAuthority(remoteUrl);
                         if (remoteUrl != null
-                                && !Objects.equals(url, remoteUrl)
+                                && !Objects.equals(normalizedUrl, normalizedRemoteUrl)
                                 && Objects.equals(credentialsId, remote.getCredentialsId())) {
                             git.addCredentials(remoteUrl, credentials);
+                            if (!Objects.equals(remoteUrl, normalizedRemoteUrl)) {
+                                git.addCredentials(normalizedRemoteUrl, credentials);
+                            }
                         }
                     }
                 }

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/impl/extension/GitClientAuthenticatorExtension.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/impl/extension/GitClientAuthenticatorExtension.java
@@ -34,6 +34,7 @@ import hudson.Extension;
 import hudson.model.Item;
 import hudson.plugins.git.GitException;
 import hudson.plugins.git.GitSCM;
+import hudson.plugins.git.UserRemoteConfig;
 import hudson.plugins.git.extensions.GitSCMExtension;
 import hudson.plugins.git.extensions.GitSCMExtensionDescriptor;
 import hudson.security.ACL;
@@ -84,7 +85,21 @@ public class GitClientAuthenticatorExtension extends GitSCMExtension {
             if (url == null) {
                 git.setCredentials(credentials);
             } else {
+                // Keep registering the primary URL directly for compatibility with SCMs whose
+                // primary URL is not represented in getUserRemoteConfigs().
                 git.addCredentials(url, credentials);
+
+                // GitSCM initially registers the raw Jenkins credential for each remote. A
+                // Bitbucket authenticator can translate that credential for Git operations (for
+                // example, an API token needs a different username on Bitbucket Cloud), so apply
+                // the translated credential to every remote configured with the same credential
+                // ID. Remotes with a different credential ID must retain their own credentials.
+                for (UserRemoteConfig remote : scm.getUserRemoteConfigs()) {
+                    if (Objects.equals(credentialsId, remote.getCredentialsId())
+                            && !Objects.equals(url, remote.getUrl())) {
+                        git.addCredentials(remote.getUrl(), credentials);
+                    }
+                }
             }
         }
         return git;

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/impl/extension/GitClientAuthenticatorExtensionTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/impl/extension/GitClientAuthenticatorExtensionTest.java
@@ -23,12 +23,21 @@
  */
 package com.cloudbees.jenkins.plugins.bitbucket.impl.extension;
 
+import com.cloudbees.plugins.credentials.common.StandardUsernameCredentials;
 import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl;
+import hudson.plugins.git.GitSCM;
+import hudson.plugins.git.UserRemoteConfig;
 import hudson.plugins.git.extensions.GitSCMExtension;
+import java.util.List;
+import org.jenkinsci.plugins.gitclient.GitClient;
 import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.Issue;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 class GitClientAuthenticatorExtensionTest {
 
@@ -46,5 +55,28 @@ class GitClientAuthenticatorExtensionTest {
         extension = new GitClientAuthenticatorExtension("url", new UsernamePasswordCredentialsImpl(null, null, null, null, null));
         assertThat(extension.hashCode()).isNotZero();
         assertThat(extension).isNotEqualTo(new GitClientAuthenticatorExtension("url", new UsernamePasswordCredentialsImpl(null, "some-id", null, null, null)));
+    }
+
+    @Issue("JENKINS-76486")
+    @Test
+    void decoratesAllRemotesUsingTheTranslatedCredential() throws Exception {
+        StandardUsernameCredentials credentials = mock(StandardUsernameCredentials.class);
+        GitClientAuthenticatorExtension extension =
+                new GitClientAuthenticatorExtension("https://bitbucket.org/fork/repository.git", credentials);
+        UserRemoteConfig origin = new UserRemoteConfig(
+                "https://bitbucket.org/fork/repository.git", "origin", null, null);
+        UserRemoteConfig upstream = new UserRemoteConfig(
+                "https://bitbucket.org/upstream/repository.git", "upstream", null, null);
+        UserRemoteConfig other = new UserRemoteConfig(
+                "https://example.com/other/repository.git", "other", null, "other-credential");
+        GitSCM scm = mock(GitSCM.class);
+        GitClient git = mock(GitClient.class);
+        when(scm.getUserRemoteConfigs()).thenReturn(List.of(origin, upstream, other));
+
+        assertThat(extension.decorate(scm, git)).isSameAs(git);
+
+        verify(git).addCredentials(origin.getUrl(), credentials);
+        verify(git).addCredentials(upstream.getUrl(), credentials);
+        verify(git, never()).addCredentials(other.getUrl(), credentials);
     }
 }

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/impl/extension/GitClientAuthenticatorExtensionTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/impl/extension/GitClientAuthenticatorExtensionTest.java
@@ -129,4 +129,27 @@ class GitClientAuthenticatorExtensionTest {
         verify(git).addCredentials(upstream.getUrl(), credentials);
         verify(git, never()).addCredentials(null, credentials);
     }
+
+    @Issue("JENKINS-76486")
+    @Test
+    void decorateHandlesAuthenticatedMirrorUrls() throws Exception {
+        StandardUsernameCredentials credentials = mock(StandardUsernameCredentials.class);
+        GitClientAuthenticatorExtension extension =
+                new GitClientAuthenticatorExtension(
+                        "https://mirror-user:mirror-token@mirror.example.com/project/repository.git", credentials);
+        UserRemoteConfig origin = new UserRemoteConfig(
+                "https://mirror.example.com/project/repository.git", "origin", null, null);
+        UserRemoteConfig upstream = new UserRemoteConfig(
+                "https://upstream-user:upstream-token@mirror.example.com/project/upstream.git", "upstream", null, null);
+        GitSCM scm = mock(GitSCM.class);
+        GitClient git = mock(GitClient.class);
+        when(scm.getUserRemoteConfigs()).thenReturn(List.of(origin, upstream));
+
+        assertThat(extension.decorate(scm, git)).isSameAs(git);
+
+        verify(git).addCredentials("https://mirror-user:mirror-token@mirror.example.com/project/repository.git", credentials);
+        verify(git).addCredentials("https://mirror.example.com/project/repository.git", credentials);
+        verify(git).addCredentials("https://upstream-user:upstream-token@mirror.example.com/project/upstream.git", credentials);
+        verify(git).addCredentials("https://mirror.example.com/project/upstream.git", credentials);
+    }
 }

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/impl/extension/GitClientAuthenticatorExtensionTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/impl/extension/GitClientAuthenticatorExtensionTest.java
@@ -28,11 +28,13 @@ import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl;
 import hudson.plugins.git.GitSCM;
 import hudson.plugins.git.UserRemoteConfig;
 import hudson.plugins.git.extensions.GitSCMExtension;
+import java.util.Arrays;
 import java.util.List;
 import org.jenkinsci.plugins.gitclient.GitClient;
 import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.Issue;
 
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -78,5 +80,53 @@ class GitClientAuthenticatorExtensionTest {
         verify(git).addCredentials(origin.getUrl(), credentials);
         verify(git).addCredentials(upstream.getUrl(), credentials);
         verify(git, never()).addCredentials(other.getUrl(), credentials);
+    }
+
+    @Issue("JENKINS-76486")
+    @Test
+    void decorateIgnoresMissingScmRemoteConfiguration() throws Exception {
+        StandardUsernameCredentials credentials = mock(StandardUsernameCredentials.class);
+        GitClientAuthenticatorExtension extension =
+                new GitClientAuthenticatorExtension("https://bitbucket.org/fork/repository.git", credentials);
+        GitClient git = mock(GitClient.class);
+
+        assertThatCode(() -> extension.decorate(null, git)).doesNotThrowAnyException();
+
+        verify(git).addCredentials("https://bitbucket.org/fork/repository.git", credentials);
+    }
+
+    @Issue("JENKINS-76486")
+    @Test
+    void decorateIgnoresMissingRemoteList() throws Exception {
+        StandardUsernameCredentials credentials = mock(StandardUsernameCredentials.class);
+        GitClientAuthenticatorExtension extension =
+                new GitClientAuthenticatorExtension("https://bitbucket.org/fork/repository.git", credentials);
+        GitSCM scm = mock(GitSCM.class);
+        GitClient git = mock(GitClient.class);
+        when(scm.getUserRemoteConfigs()).thenReturn(null);
+
+        assertThatCode(() -> extension.decorate(scm, git)).doesNotThrowAnyException();
+
+        verify(git).addCredentials("https://bitbucket.org/fork/repository.git", credentials);
+    }
+
+    @Issue("JENKINS-76486")
+    @Test
+    void decorateIgnoresNullRemoteEntriesAndUrls() throws Exception {
+        StandardUsernameCredentials credentials = mock(StandardUsernameCredentials.class);
+        GitClientAuthenticatorExtension extension =
+                new GitClientAuthenticatorExtension("https://bitbucket.org/fork/repository.git", credentials);
+        UserRemoteConfig nullUrl = new UserRemoteConfig(null, "null-url", null, null);
+        UserRemoteConfig upstream = new UserRemoteConfig(
+                "https://bitbucket.org/upstream/repository.git", "upstream", null, null);
+        GitSCM scm = mock(GitSCM.class);
+        GitClient git = mock(GitClient.class);
+        when(scm.getUserRemoteConfigs()).thenReturn(Arrays.asList(null, nullUrl, upstream));
+
+        assertThat(extension.decorate(scm, git)).isSameAs(git);
+
+        verify(git).addCredentials("https://bitbucket.org/fork/repository.git", credentials);
+        verify(git).addCredentials(upstream.getUrl(), credentials);
+        verify(git, never()).addCredentials(null, credentials);
     }
 }


### PR DESCRIPTION
Fixes [JENKINS-76486](https://issues.jenkins.io/browse/JENKINS-76486)

This updates Bitbucket mirror credential handling so authenticated mirror clone URLs are normalized consistently before Git credentials are registered.

Changes made:

- Strip embedded authentication from mirror clone links, matching the existing primary clone link behavior.
- Compare normalized remote URLs when deciding whether to register translated Bitbucket credentials.
- Register both the original authenticated URL and the auth-stripped URL when needed, so Git credential lookup works for either form.
- Add test coverage for authenticated mirror URLs.

Tested with:

```bash
mvn -q -Dtest=GitClientAuthenticatorExtensionTest test
```