### PR TITLE
Document and test Bitbucket Cloud OAuth credentials

### DIFF
--- a/docs/USER_GUIDE.adoc
+++ b/docs/USER_GUIDE.adoc
@@ -241,16 +241,36 @@ IMPORTANT: API token requires the email address as a username to authenticate us
 
 === OAuth credentials (Bitbucket Cloud only)
 
-The plugin can make use of OAuth credentials instead of the standard username/password.
+The plugin can make use of OAuth credentials instead of the standard username/password or deprecated app passwords.
+OAuth credentials are a good option for Bitbucket Cloud because the client ID and client secret are stored in Jenkins Credentials, the plugin requests short-lived bearer tokens from Bitbucket, and HTTPS checkout uses the generated token without exposing the consumer secret to builds.
 
-First create a new _OAuth consumer_ in Bitbucket as instructed in the https://confluence.atlassian.com/bitbucket/oauth-on-bitbucket-cloud-238027431.html[Bitbucket OAuth Documentation].
-Don't forget to check _This is a private consumer_ and at least allow _read_ access for repositories and pull requests. If you want the plugin to install the webhooks, also allow _read_ and _write_ access for webhooks.
+First create a new _OAuth consumer_ in Bitbucket as instructed in the https://support.atlassian.com/bitbucket-cloud/docs/use-oauth-on-bitbucket-cloud/[Bitbucket OAuth Documentation].
+Create the consumer in the workspace Jenkins needs to access, check _This is a private consumer_, and keep the generated key and secret private.
+Bitbucket requires a callback URL for OAuth consumers; this plugin uses the client credentials grant and does not receive browser redirects, so use a stable Jenkins URL such as the Jenkins root URL.
+
+At least allow _read_ access for repositories and pull requests. If you want the plugin to install the webhooks, also allow _read_ and _write_ access for webhooks.
 
 image::images/screenshot-10.png[]
 
-Then create new _Username with password credentials_ in Jenkins, enter the Bitbucket OAuth consumer key in the _Username_ field and the Bitbucket OAuth consumer secret in the _Password_ field.
+Then create new _Username with password credentials_ in Jenkins:
+
+* Set the _Username_ field to the Bitbucket OAuth consumer key.
+* Set the _Password_ field to the Bitbucket OAuth consumer secret.
+* Use a clear ID and description, for example `bitbucket-cloud-oauth`.
+* Prefer storing the credential in a Bitbucket-specific credential domain to keep credential lookup fast and avoid selecting unrelated credentials.
 
 image::images/screenshot-11.png[]
+
+Select this credential in the _Credentials_ field of the Bitbucket Branch Source configuration for both _Multibranch Pipeline_ jobs and _Bitbucket Team/Project_ organization folders.
+If automatic webhook management is configured at the endpoint level, update the webhook credentials there as well; otherwise, keep manual webhooks configured as described above.
+
+After changing an existing job or organization folder to OAuth credentials, validate the configuration before removing the legacy credential:
+
+* Run _Scan Repository Now_ or _Scan Organization Now_ and confirm repository indexing completes.
+* Confirm branches and pull requests are discovered according to the configured behaviours.
+* Run a build and confirm HTTPS SCM checkout succeeds.
+* Create or update a pull request and confirm the webhook triggers the expected indexing or build.
+* Open repository browsing links from Jenkins and confirm they still point to the expected Bitbucket Cloud repository.
 
 image::images/screenshot-12.png[]
 

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/impl/credentials/BitbucketOAuthCredentialMatcher.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/impl/credentials/BitbucketOAuthCredentialMatcher.java
@@ -50,10 +50,20 @@ public class BitbucketOAuthCredentialMatcher implements CredentialsMatcher {
         String username = credentials.getUsername();
         String password = Secret.toString(credentials.getPassword());
 
-        boolean isEMail = username.contains(".") && username.contains("@");
-        boolean validConsumerLength = (password.length() == CLIENT_OLD_SECRET_LENGTH && username.length() == CLIENT_OLD_KEY_LENGTH)
-                || (password.length() == CLIENT_SECRET_LENGTH && username.length() == CLIENT_KEY_LENGTH);
+        return !isEmail(username) && isSupportedOAuthConsumer(username, password);
+    }
 
-        return !isEMail && validConsumerLength;
+    private boolean isEmail(String username) {
+        return username.contains(".") && username.contains("@");
+    }
+
+    private boolean isSupportedOAuthConsumer(String key, String secret) {
+        // Bitbucket Cloud has issued OAuth consumers in both legacy and current lengths.
+        return hasLengthPair(key, secret, CLIENT_OLD_KEY_LENGTH, CLIENT_OLD_SECRET_LENGTH)
+                || hasLengthPair(key, secret, CLIENT_KEY_LENGTH, CLIENT_SECRET_LENGTH);
+    }
+
+    private boolean hasLengthPair(String key, String secret, int expectedKeyLength, int expectedSecretLength) {
+        return key.length() == expectedKeyLength && secret.length() == expectedSecretLength;
     }
 }

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/impl/credentials/BitbucketOAuthCredentialMatcherTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/impl/credentials/BitbucketOAuthCredentialMatcherTest.java
@@ -1,0 +1,83 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2026, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.cloudbees.jenkins.plugins.bitbucket.impl.credentials;
+
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl;
+import hudson.model.Descriptor.FormException;
+import hudson.util.Secret;
+import org.jenkinsci.plugins.plaincredentials.impl.StringCredentialsImpl;
+import org.junit.jupiter.api.Test;
+
+import static org.apache.commons.lang3.RandomStringUtils.insecure;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class BitbucketOAuthCredentialMatcherTest {
+
+    private final BitbucketOAuthCredentialMatcher matcher = new BitbucketOAuthCredentialMatcher();
+
+    @Test
+    void matchesCurrentBitbucketCloudOAuthConsumerCredentials() throws FormException {
+        assertThat(matcher.matches(usernamePassword(insecure().nextAlphanumeric(32), insecure().nextAlphanumeric(76))))
+                .isTrue();
+    }
+
+    @Test
+    void matchesLegacyBitbucketCloudOAuthConsumerCredentials() throws FormException {
+        assertThat(matcher.matches(usernamePassword(insecure().nextAlphanumeric(18), insecure().nextAlphanumeric(32))))
+                .isTrue();
+    }
+
+    @Test
+    void doesNotMatchUserApiTokenCredentials() throws FormException {
+        assertThat(matcher.matches(usernamePassword("jenkins@example.com", insecure().nextAlphanumeric(76))))
+                .isFalse();
+    }
+
+    @Test
+    void doesNotMatchUnexpectedConsumerLengths() throws FormException {
+        assertThat(matcher.matches(usernamePassword(insecure().nextAlphanumeric(32), insecure().nextAlphanumeric(75))))
+                .isFalse();
+    }
+
+    @Test
+    void doesNotMatchSecretTextCredentials() {
+        StringCredentialsImpl credentials = new StringCredentialsImpl(
+                CredentialsScope.SYSTEM,
+                "bitbucket-token",
+                "Bitbucket access token",
+                Secret.fromString(insecure().nextAlphanumeric(76)));
+
+        assertThat(matcher.matches(credentials)).isFalse();
+    }
+
+    private UsernamePasswordCredentialsImpl usernamePassword(String username, String password) throws FormException {
+        return new UsernamePasswordCredentialsImpl(
+                CredentialsScope.SYSTEM,
+                "bitbucket-oauth",
+                "Bitbucket Cloud OAuth consumer",
+                username,
+                password);
+    }
+}


### PR DESCRIPTION
### Description

This improves Bitbucket Cloud OAuth credential setup guidance for the Bitbucket Branch Source Plugin.

The plugin already supports OAuth credentials. This PR documents the recommended setup flow more clearly and adds focused tests around OAuth credential detection.

Changes include:

- Document how to create a Bitbucket Cloud OAuth Consumer.
- Document how to store the OAuth consumer key and secret in Jenkins `Username with password` credentials.
- Clarify where to select the OAuth credential for Multibranch Pipeline and Bitbucket Team/Project organization folders.
- Document webhook credential considerations.
- Add a post-migration validation checklist for indexing, branch discovery, pull request discovery, SCM checkout, webhook triggers, and repository browsing.
- Refactor OAuth credential matching into small helper methods.
- Add tests for current OAuth consumer credentials, legacy OAuth consumer credentials, API-token credentials, invalid credential lengths, and secret text credentials.

### Relevant links

- Bitbucket Cloud OAuth documentation: https://support.atlassian.com/bitbucket-cloud/docs/use-oauth-on-bitbucket-cloud/

### Testing done

```bash
mvn -Dtest=BitbucketOAuthCredentialMatcherTest,BitbucketAuthenticatorTest test
```