### PR TITLE
Add system property to skip eager fetch of primary clone links during branch indexing

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource.java
@@ -127,6 +127,7 @@ import jenkins.scm.impl.UncategorizedSCMHeadCategory;
 import jenkins.scm.impl.form.NamedArrayList;
 import jenkins.scm.impl.trait.Discovery;
 import jenkins.scm.impl.trait.Selection;
+import jenkins.util.SystemProperties;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
 import org.eclipse.jgit.lib.Constants;
@@ -152,6 +153,16 @@ public class BitbucketSCMSource extends SCMSource {
     private static final Logger LOGGER = Logger.getLogger(BitbucketSCMSource.class.getName());
     private static final String CLOUD_REPO_TEMPLATE = "{/owner,repo}";
     private static final String SERVER_REPO_TEMPLATE = "/projects{/owner}/repos{/repo}";
+
+    /**
+     * Escape hatch for large installations: when set to {@code true}, do not eagerly fetch the
+     * primary clone links from the Bitbucket API on {@link #afterSave()} and on every branch
+     * indexing. Clone links are then resolved lazily (and cached) when a build actually needs
+     * them, see {@code initCloneLinks()}. This avoids one {@code getRepository()} REST call per
+     * source per indexing, which is subject to API rate limits on installations with many
+     * Bitbucket sources.
+     */
+    static final String SKIP_PRIMARY_CLONE_LINKS_PROPERTY_NAME = "bitbucket.scmsource.skipPrimaryCloneLinks";
 
     /** How long to delay events received from Bitbucket in order to allow the API caches to sync. */
     private static /*mostly final*/ int eventDelaySeconds =
@@ -331,6 +342,9 @@ public class BitbucketSCMSource extends SCMSource {
     }
 
     private void gatherPrimaryCloneLinks(@NonNull BitbucketApi apiClient) throws IOException {
+        if (SystemProperties.getBoolean(SKIP_PRIMARY_CLONE_LINKS_PROPERTY_NAME, false)) {
+            return;
+        }
         BitbucketRepository r = apiClient.getRepository();
         Map<String, List<BitbucketHref>> links = r.getLinks();
         if (links != null && links.containsKey("clone")) {

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSourceRetrieveTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSourceRetrieveTest.java
@@ -189,6 +189,47 @@ class BitbucketSCMSourceRetrieveTest {
     }
 
     @Test
+    void retrieve_fetches_primary_clone_links_by_default() throws Exception {
+        BitbucketSCMSource instance = load("retrieve_prs_test_cloud");
+
+        BitbucketCloudApiClient client = BitbucketClientMockUtils.getAPIClientMock(true, false);
+        BitbucketMockApiFactory.add(BitbucketCloudEndpoint.SERVER_URL, client);
+
+        List<BitbucketBranch> branches = Collections.singletonList(new BitbucketCloudBranch(BRANCH_NAME, COMMIT_HASH, 0));
+        when(client.getBranches()).thenReturn(branches);
+
+        SCMHeadEvent<?> event = new HeadEvent(List.of(pullRequest), List.of(tag));
+        dryRun(instance, event, client);
+
+        verify(client).getRepository();
+    }
+
+    @Test
+    void retrieve_does_not_fetch_primary_clone_links_when_skip_property_is_set() throws Exception {
+        BitbucketSCMSource instance = load("retrieve_prs_test_cloud");
+
+        BitbucketCloudApiClient client = BitbucketClientMockUtils.getAPIClientMock(true, false);
+        BitbucketMockApiFactory.add(BitbucketCloudEndpoint.SERVER_URL, client);
+
+        List<BitbucketBranch> branches = Collections.singletonList(new BitbucketCloudBranch(BRANCH_NAME, COMMIT_HASH, 0));
+        when(client.getBranches()).thenReturn(branches);
+
+        SCMHeadEvent<?> event = new HeadEvent(List.of(pullRequest), List.of(tag));
+        System.setProperty(BitbucketSCMSource.SKIP_PRIMARY_CLONE_LINKS_PROPERTY_NAME, "true");
+        try {
+            dryRun(instance, event, client);
+        } finally {
+            System.clearProperty(BitbucketSCMSource.SKIP_PRIMARY_CLONE_LINKS_PROPERTY_NAME);
+        }
+
+        // heads are still discovered as usual
+        Set<String> heads = headObserver.result().keySet().stream().map(SCMHead::getName).collect(Collectors.toSet());
+        assertThat(heads).containsExactlyInAnyOrder("PR-1", BRANCH_NAME, TAG_NAME);
+        // but the per-source repository lookup used to gather primary clone links is skipped
+        verify(client, never()).getRepository();
+    }
+
+    @Test
     void prEvent_does_not_trigger_tag_API_endpoints_cloud() throws Exception {
         BitbucketSCMSource instance = load("retrieve_prs_test_cloud");
         assertThat(instance.getId()).isEqualTo("retrieve_prs_test_cloud");


### PR DESCRIPTION
`BitbucketSCMSource.gatherPrimaryCloneLinks()` performs a `getRepository()` REST call for every SCM source on every `afterSave()`, every branch indexing (`retrieve()`) and every `retrieveActions()`. The result only pre-populates `primaryCloneLinks` — `build()` already resolves clone links lazily via `initCloneLinks()` when they are actually needed, and caches them.

On large installations this eager fetch multiplies into hundreds of repository lookups per indexing round and runs into Bitbucket Cloud API rate limits (HTTP 429). Combined with the client's retry/backoff this can dominate indexing time: on our installation (~700 multibranch projects in one Bitbucket Cloud workspace) it added roughly 45 seconds of backoff per source, turning a full re-index into hours.

This PR adds an opt-in system property, following the existing `SystemProperties` precedent (`bitbucket.hooks.processor.scanOnEmptyChanges`):

```
-Dbitbucket.scmsource.skipPrimaryCloneLinks=true
```

When set, the eager fetch is skipped and clone links are resolved lazily (once per source, cached) by `initCloneLinks()` when a build first needs them. Default behaviour is unchanged, and the property is read per call so it can be toggled from the script console without a restart.

We have been running this patch in production on top of 937.3.3/937.3.4 on a controller with ~700 Bitbucket multibranch sources: full branch indexing dropped from hours to minutes, checkouts unaffected.

Related: #912, which introduced gathering primary clone links during retrieve.

### Your checklist for this pull request

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org) — no existing issue for this; happy to file one if preferred
- [x] Link to relevant pull requests, esp. upstream and downstream changes — #912
- [x] Did you provide a test-case? That demonstrates feature works or fixes the issue — `BitbucketSCMSourceRetrieveTest`: default fetch still happens; with the property set, heads are still discovered but the per-source `getRepository()` lookup is skipped
