### PR TITLE
[JENKINS-76496] Webhooks don't cache since hook signature always triggers secret update

### DIFF
--- a/docs/USER_GUIDE.adoc
+++ b/docs/USER_GUIDE.adoc
@@ -120,6 +120,8 @@ Any incoming webhook payloads from that given endpoint will be validated against
 
 image::images/screenshot-20.png[]
 
+NOTE: Once the secret is configured in Bitbucket Cloud, its value is hidden; automatic updates of the secret could not be supported. Any updates is the user's responsibility and must be done through the Bitbucket Cloud repository configuration page. 
+
 === Enable webhooks cache
 
 If your organisation has a large number of repositories (over 500), you may easily reach the API rate limit.

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/BitbucketWebHook.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/BitbucketWebHook.java
@@ -23,9 +23,11 @@
  */
 package com.cloudbees.jenkins.plugins.bitbucket.api;
 
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Represents a webhook in Bitbucket.
@@ -67,6 +69,15 @@ public interface BitbucketWebHook {
     @Nullable
     default String getSecret() {
         return null;
+    }
+
+    /**
+     * Returns if the given secret has been already setup for this webhook.
+     *
+     * @return {@code true} if the secret has already set, {@code false} otherwise.
+     */
+    default boolean hasSecret(@CheckForNull String secret) {
+        return Objects.equals(secret, getSecret());
     }
 
 }

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/repository/BitbucketCloudWebhook.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/repository/BitbucketCloudWebhook.java
@@ -24,17 +24,22 @@
 package com.cloudbees.jenkins.plugins.bitbucket.client.repository;
 
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketWebHook;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.commons.lang3.ObjectUtils;
+import org.apache.commons.lang3.StringUtils;
 
 public class BitbucketCloudWebhook implements BitbucketWebHook {
 
     private String uuid;
     private String description;
     private String url;
-    private String secret;
+    private String secret; // filled only on create, absent on details
+    @JsonProperty("secret_set")
+    private boolean hasSecret;
     private boolean active;
     @JsonProperty("skip_cert_verification")
     private boolean skipCertVerification;
@@ -102,4 +107,9 @@ public class BitbucketCloudWebhook implements BitbucketWebHook {
         this.skipCertVerification = skipCertVerification;
     }
 
+    @JsonIgnore
+    @Override
+    public boolean hasSecret(@CheckForNull String secret) {
+        return StringUtils.isNotEmpty(secret) && hasSecret;
+    }
 }

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/impl/webhook/cloud/CloudWebhookManager.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/impl/webhook/cloud/CloudWebhookManager.java
@@ -39,7 +39,6 @@ import com.cloudbees.jenkins.plugins.bitbucket.impl.webhook.AbstractWebhookManag
 import com.cloudbees.jenkins.plugins.bitbucket.util.BitbucketCredentialsUtils;
 import com.damnhandy.uri.template.UriTemplate;
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.google.common.base.Objects;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.util.Secret;
@@ -200,7 +199,7 @@ public class CloudWebhookManager extends AbstractWebhookManager<CloudWebhookConf
             update = true;
         }
 
-        if (!Objects.equal(current.getSecret(), expected.getSecret())) {
+        if (!current.hasSecret(expected.getSecret())) {
             current.setSecret(expected.getSecret());
             logger.info(() -> "Update webhook " + current.getUuid() + " signature secret");
             update = true;

--- a/src/main/resources/com/cloudbees/jenkins/plugins/bitbucket/impl/webhook/cloud/CloudWebhookConfiguration/help-hookSignatureCredentialsId.html
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/bitbucket/impl/webhook/cloud/CloudWebhookConfiguration/help-hookSignatureCredentialsId.html
@@ -1,0 +1,9 @@
+<div>
+    <p>
+        Since Bitbucket Cloud does not returns the value of the secret, once set, any updates to the secret value will not be sent,
+        is the responsibility of the user via the Bitbucket Cloud repository configuration page available at:
+        <ul>
+            <li>https://bitbucket.org/&lt;owner&gt;/&lt;repo_slug&gt;/admin/webhooks/{webhook_id}/edit</li>
+        </ul>
+    </p>
+</div>

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/client/repository/BitbucketCloudWebhookTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/client/repository/BitbucketCloudWebhookTest.java
@@ -1,0 +1,61 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2026, Nikolas Falco
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.cloudbees.jenkins.plugins.bitbucket.client.repository;
+
+import com.cloudbees.jenkins.plugins.bitbucket.impl.util.JsonParser;
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class BitbucketCloudWebhookTest {
+
+    @Test
+    void test_secret() throws IOException {
+        BitbucketCloudWebhook sut = JsonParser.toJava("""
+                {
+                    "type": "webhook_subscription",
+                    "uuid": "{a96109fc-8ea6-41aa-9b0d-1c9e3619a7fc}",
+                    "description": "Jenkins hook",
+                    "url": "http://ci.example.lan:8090/jenkins/bitbucket-scmsource-hook/notify",
+                    "active": true,
+                    "skip_cert_verification": false,
+                    "events": [
+                        "pullrequest:created",
+                        "pullrequest:fulfilled",
+                        "repo:push",
+                        "pullrequest:rejected",
+                        "pullrequest:updated"
+                    ],
+                    "source": null,
+                    "read_only": false,
+                    "history_enabled": false,
+                    "secret_set": true
+                }
+                """, BitbucketCloudWebhook.class);
+        assertThat(sut.hasSecret(null)).isFalse();
+        assertThat(sut.hasSecret("")).isFalse();
+        assertThat(sut.hasSecret("password")).isTrue();
+    }
+}


### PR DESCRIPTION
Add hasSecret method on BitbucketWebhook interface.
The Cloud instance only returns if secret has been set, so it's not possible to understand if secret has been changed or not.