### PR TITLE
Move the one remaining lang2 usage to lang3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,7 @@
         <jenkins.baseline>2.541</jenkins.baseline>
         <jenkins.version>${jenkins.baseline}.3</jenkins.version>
         <ban-junit4-imports.skip>false</ban-junit4-imports.skip>
+        <ban-commons-lang-2.skip>false</ban-commons-lang-2.skip>
         <hpi.compatibleSinceVersion>937.0.0</hpi.compatibleSinceVersion>
         <tagNameFormat>@{project.version}</tagNameFormat>
     </properties>

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/impl/webhook/AbstractWebhookProcessor.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/impl/webhook/AbstractWebhookProcessor.java
@@ -60,7 +60,7 @@ import org.jenkinsci.plugins.plaincredentials.StringCredentials;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
-import static org.apache.commons.lang.StringUtils.trimToNull;
+import static org.apache.commons.lang3.StringUtils.trimToNull;
 
 /**
  * Abstract hook processor.


### PR DESCRIPTION
Remove commons-lang2 usages to prepare for https://github.com/jenkinsci/jenkins/pull/26105. 
Lang3 is already a dep in here, so just updating one remaining import path to there.
https://github.com/jenkinsci/bitbucket-branch-source-plugin/blob/c28fcf5ac3788e7730a37965bb9313cccc31d542/pom.xml#L85-L88


**Testing**

Ban enforcer rules failed without the import path update, succeeds afterwards.