### PR TITLE
[JENKINS-76426] Reduce the number of API calls processing event of incoming webhook

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource.java
@@ -37,6 +37,7 @@ import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketPullRequest;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketRepository;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketRequestException;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketTeam;
+import com.cloudbees.jenkins.plugins.bitbucket.api.HasBranches;
 import com.cloudbees.jenkins.plugins.bitbucket.api.HasPullRequests;
 import com.cloudbees.jenkins.plugins.bitbucket.api.HasTags;
 import com.cloudbees.jenkins.plugins.bitbucket.api.PullRequestBranchType;
@@ -354,24 +355,25 @@ public class BitbucketSCMSource extends SCMSource {
             }
             gatherPrimaryCloneLinks(buildBitbucketClient());
 
-            // populate the request with its data sources
-            if (request.isFetchPRs() && event instanceof HasPullRequests hasPrEvent) {
-                request.setPullRequests(getBitbucketPullRequestsFromEvent(hasPrEvent, listener));
-            }
-            if (request.isFetchTags() && event instanceof HasTags hasTagEvent) {
-                request.setTags(getBitbucketTagsFromEvent(hasTagEvent, listener));
-            }
-
             // now serve the request
             if (request.isFetchPRs() && !request.isComplete()) {
+                if (event instanceof HasPullRequests prEvent) {
+                    request.setPullRequests(getBitbucketPullRequestsFromEvent(prEvent, listener));
+                }
                 // Search pull requests
                 retrievePullRequests(request);
             }
             if (request.isFetchBranches() && !request.isComplete()) {
+                if (event instanceof HasBranches branchEvent) {
+                    request.setBranches(getBitbucketBranchesFromEvent(branchEvent, listener));
+                }
                 // Search branches
                 retrieveBranches(request);
             }
             if (request.isFetchTags() && !request.isComplete()) {
+                if (event instanceof HasTags tagEvent) {
+                    request.setTags(getBitbucketTagsFromEvent(tagEvent, listener));
+                }
                 // Search tags
                 retrieveTags(request);
             }
@@ -403,6 +405,21 @@ public class BitbucketSCMSource extends SCMSource {
             }
         }
         return initializedPRs;
+    }
+
+    private Iterable<BitbucketBranch> getBitbucketBranchesFromEvent(@NonNull HasBranches incomingEvent,
+                                                                    @NonNull TaskListener listener) throws IOException, InterruptedException {
+        Collection<BitbucketBranch> initializedBranches = new HashSet<>();
+        try (BitbucketApi bitBucket = buildBitbucketClient()) {
+            Iterable<BitbucketBranch> branches = incomingEvent.getBranches(BitbucketSCMSource.this);
+            for (BitbucketBranch branch : branches) {
+                // ensure that the PR is properly initialised via /changes API
+                // see BitbucketServerAPIClient.setupPullRequest()
+                initializedBranches.add(bitBucket.getBranch(branch.getName()));
+                listener.getLogger().format("Initialized branch: %s%n", branch.getName());
+            }
+        }
+        return initializedBranches;
     }
 
     private void retrievePullRequests(final BitbucketSCMSourceRequest request) throws IOException, InterruptedException {

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/HasBranches.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/HasBranches.java
@@ -1,0 +1,32 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2026, Falco Nikolas
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.cloudbees.jenkins.plugins.bitbucket.api;
+
+import com.cloudbees.jenkins.plugins.bitbucket.BitbucketSCMSource;
+
+public interface HasBranches {
+
+    Iterable<BitbucketBranch> getBranches(BitbucketSCMSource src) throws InterruptedException;
+
+}

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/impl/webhook/cloud/CloudPREvent.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/impl/webhook/cloud/CloudPREvent.java
@@ -29,15 +29,21 @@ import com.cloudbees.jenkins.plugins.bitbucket.PullRequestSCMHead;
 import com.cloudbees.jenkins.plugins.bitbucket.PullRequestSCMRevision;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketBranch;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketPullRequest;
+import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketPullRequestDestination;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketPullRequestEvent;
+import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketPullRequestSource;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketRepository;
+import com.cloudbees.jenkins.plugins.bitbucket.api.HasBranches;
 import com.cloudbees.jenkins.plugins.bitbucket.api.HasPullRequests;
 import com.cloudbees.jenkins.plugins.bitbucket.api.HasTags;
+import com.cloudbees.jenkins.plugins.bitbucket.api.PullRequestBranchType;
 import com.cloudbees.jenkins.plugins.bitbucket.hooks.HookEventType;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
@@ -52,7 +58,7 @@ import jenkins.scm.api.mixin.ChangeRequestCheckoutStrategy;
 import static com.cloudbees.jenkins.plugins.bitbucket.hooks.HookEventType.PULL_REQUEST_DECLINED;
 import static com.cloudbees.jenkins.plugins.bitbucket.hooks.HookEventType.PULL_REQUEST_MERGED;
 
-final class CloudPREvent extends AbstractSCMHeadEvent<BitbucketPullRequestEvent> implements HasPullRequests, HasTags {
+final class CloudPREvent extends AbstractSCMHeadEvent<BitbucketPullRequestEvent> implements HasPullRequests, HasTags, HasBranches {
     private final HookEventType hookEvent;
 
     CloudPREvent(Type type, BitbucketPullRequestEvent payload,
@@ -149,7 +155,30 @@ final class CloudPREvent extends AbstractSCMHeadEvent<BitbucketPullRequestEvent>
 
     @Override
     public Iterable<BitbucketBranch> getTags(BitbucketSCMSource src) {
-        return Collections.emptySet();
+        List<BitbucketBranch> tags = new ArrayList<>();
+        BitbucketPullRequest pr = getPayload().getPullRequest();
+
+        BitbucketPullRequestSource source = pr.getSource();
+        if (source != null && PullRequestBranchType.TAG == source.getBranchType()) {
+            tags.add(source.getBranch());
+        }
+        return tags;
+    }
+
+    @Override
+    public Iterable<BitbucketBranch> getBranches(BitbucketSCMSource src) throws InterruptedException {
+        List<BitbucketBranch> branches = new ArrayList<>();
+
+        BitbucketPullRequest pr = getPayload().getPullRequest();
+        BitbucketPullRequestSource source = pr.getSource();
+        if (source != null && PullRequestBranchType.BRANCH == source.getBranchType()) {
+            branches.add(source.getBranch());
+        }
+        BitbucketPullRequestDestination destination = pr.getDestination();
+        if (destination != null) {
+            branches.add(destination.getBranch());
+        }
+        return branches;
     }
 
 }

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/impl/webhook/cloud/CloudPushEvent.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/impl/webhook/cloud/CloudPushEvent.java
@@ -27,10 +27,13 @@ import com.cloudbees.jenkins.plugins.bitbucket.BitbucketSCMSource;
 import com.cloudbees.jenkins.plugins.bitbucket.BitbucketTagSCMHead;
 import com.cloudbees.jenkins.plugins.bitbucket.BranchSCMHead;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketBranch;
+import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketPullRequest;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketPushEvent;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketPushEvent.Reference;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketPushEvent.Target;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketRepository;
+import com.cloudbees.jenkins.plugins.bitbucket.api.HasBranches;
+import com.cloudbees.jenkins.plugins.bitbucket.api.HasPullRequests;
 import com.cloudbees.jenkins.plugins.bitbucket.api.HasTags;
 import com.cloudbees.jenkins.plugins.bitbucket.client.branch.BitbucketCloudAuthor;
 import com.cloudbees.jenkins.plugins.bitbucket.client.branch.BitbucketCloudBranch;
@@ -47,7 +50,7 @@ import jenkins.scm.api.SCMRevision;
 import jenkins.scm.api.SCMSource;
 import org.apache.commons.lang3.Strings;
 
-final class CloudPushEvent extends AbstractSCMHeadEvent<BitbucketPushEvent> implements HasTags {
+final class CloudPushEvent extends AbstractSCMHeadEvent<BitbucketPushEvent> implements HasTags, HasPullRequests, HasBranches {
 
     CloudPushEvent(Type type, BitbucketPushEvent payload, String origin) {
         super(type, payload, origin);
@@ -135,5 +138,38 @@ final class CloudPushEvent extends AbstractSCMHeadEvent<BitbucketPushEvent> impl
             }
         }
         return tags;
+    }
+
+    @Override
+    public Iterable<BitbucketPullRequest> getPullRequests(BitbucketSCMSource src) throws InterruptedException {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public Iterable<BitbucketBranch> getBranches(BitbucketSCMSource src) throws InterruptedException {
+        List<BitbucketBranch> branches = new ArrayList<>();
+        for (BitbucketPushEvent.Change change: getPayload().getChanges()) {
+            if (!change.isClosed()) {
+                // created is true
+                Reference newChange = change.getNew();
+                Target target = newChange.getTarget();
+
+                String eventType = newChange.getType();
+                if ("branch".equals(eventType)) {
+                    // for BB Cloud date is valued only in case of annotated tag
+                    Date commitDate = newChange.getDate() != null ? newChange.getDate() : target.getDate();
+                    if (commitDate == null) {
+                        // fall back to the jenkins time when the request is processed
+                        commitDate = new Date();
+                    }
+                    String hash = target.getHash();
+                    BitbucketCloudBranch.Target commitTarget = new BitbucketCloudBranch.Target(hash, "", commitDate, new BitbucketCloudAuthor(target.getAuthor()));
+                    @SuppressWarnings("deprecation")
+                    BitbucketCloudBranch.Head head = new BitbucketCloudBranch.Head(hash);
+                    branches.add(new BitbucketCloudBranch(newChange.getName(), commitTarget, List.of(head)));
+                }
+            }
+        }
+        return branches;
     }
 }

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/impl/webhook/cloud/CloudPullRequestWebhookProcessorTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/impl/webhook/cloud/CloudPullRequestWebhookProcessorTest.java
@@ -25,6 +25,7 @@ package com.cloudbees.jenkins.plugins.bitbucket.impl.webhook.cloud;
 
 import com.cloudbees.jenkins.plugins.bitbucket.BitbucketSCMNavigator;
 import com.cloudbees.jenkins.plugins.bitbucket.BitbucketSCMSource;
+import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketBranch;
 import com.cloudbees.jenkins.plugins.bitbucket.api.endpoint.BitbucketEndpoint;
 import com.cloudbees.jenkins.plugins.bitbucket.hooks.HookEventType;
 import com.cloudbees.jenkins.plugins.bitbucket.impl.endpoint.BitbucketCloudEndpoint;
@@ -126,6 +127,35 @@ class CloudPullRequestWebhookProcessorTest {
         assertThat(scmEvent.getSourceName()).isEqualTo("test-repos");
         assertThat(scmEvent.getType()).isEqualTo(Type.REMOVED);
         assertThat(scmEvent.isMatch(mock(SCM.class))).isFalse();
+
+        assertThat(scmEvent.getBranches(mock(BitbucketSCMSource.class)))
+            .hasSize(2)
+            .extracting(BitbucketBranch::getName)
+            .contains("feature/test", "master");
+        assertThat(scmEvent.getPullRequests(mock(BitbucketSCMSource.class))).isEmpty();
+        assertThat(scmEvent.getTags(mock(BitbucketSCMSource.class))).isEmpty();
+    }
+
+    @Test
+    void test_pullrequest_updated() throws Exception {
+        sut.process(HookEventType.PULL_REQUEST_UPDATED.getKey(), loadResource("pullrequest_updated.json"), Collections.emptyMap(), mock(BitbucketEndpoint.class));
+
+        assertThat(scmEvent).isNotNull();
+        assertThat(scmEvent.getSourceName()).isEqualTo("test-repos");
+        assertThat(scmEvent.getType()).isEqualTo(Type.UPDATED);
+        assertThat(scmEvent.isMatch(mock(SCM.class))).isFalse();
+
+        assertThat(scmEvent.getBranches(mock(BitbucketSCMSource.class)))
+            .hasSize(2)
+            .extracting(BitbucketBranch::getName)
+            .contains("release/release-1", "master");
+        assertThat(scmEvent.getPullRequests(mock(BitbucketSCMSource.class))).hasSize(1)
+            .element(0)
+            .satisfies(pr -> {
+                assertThat(pr.getId()).isEqualTo("1");
+                assertThat(pr.getTitle()).isEqualTo("Release/release 1");
+            });
+        assertThat(scmEvent.getTags(mock(BitbucketSCMSource.class))).isEmpty();
     }
 
     @Test
@@ -148,6 +178,13 @@ class CloudPullRequestWebhookProcessorTest {
         // workspace/owner is case insensitive
         scmNavigator = new BitbucketSCMNavigator("AMUNIZ");
         assertThat(scmEvent.isMatch(scmNavigator)).isTrue();
+
+        assertThat(scmEvent.getBranches(mock(BitbucketSCMSource.class)))
+            .hasSize(2)
+            .extracting(BitbucketBranch::getName)
+            .contains("feature/test", "master");
+        assertThat(scmEvent.getPullRequests(mock(BitbucketSCMSource.class))).hasSize(1);
+        assertThat(scmEvent.getTags(mock(BitbucketSCMSource.class))).isEmpty();
     }
 
     @WithJenkins
@@ -170,6 +207,11 @@ class CloudPullRequestWebhookProcessorTest {
         scmSource.setTraits(List.of(new OriginPullRequestDiscoveryTrait(1)));
         assertThat(scmEvent.isMatch(scmSource)).isTrue();
 
+        assertThat(scmEvent.getBranches(scmSource))
+            .hasSize(2)
+            .extracting(BitbucketBranch::getName)
+            .contains("feature/test", "master");
+        assertThat(scmEvent.getTags(scmSource)).isEmpty();
         assertThat(scmEvent.getPullRequests(scmSource))
             .isNotEmpty()
             .hasSize(1);
@@ -183,6 +225,12 @@ class CloudPullRequestWebhookProcessorTest {
         BitbucketSCMSource scmSource = new BitbucketSCMSource("aMUNIZ", "test-repos");
         scmSource.setTraits(List.of(new OriginPullRequestDiscoveryTrait(2)));
         assertThat(scmEvent.isMatch(scmSource)).isTrue();
+
+        assertThat(scmEvent.getBranches(scmSource))
+            .hasSize(2)
+            .extracting(BitbucketBranch::getName)
+            .contains("feature/test", "master");
+        assertThat(scmEvent.getTags(scmSource)).isEmpty();
         assertThat(scmEvent.getPullRequests(scmSource)).isEmpty();
     }
 

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/impl/webhook/cloud/CloudPushWebhookProcessorTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/impl/webhook/cloud/CloudPushWebhookProcessorTest.java
@@ -131,6 +131,8 @@ class CloudPushWebhookProcessorTest {
                 assertThat(tag.getName()).isEqualTo("simple-tag");
                 assertThat(tag.getDateMillis()).isEqualTo(1738608795000L);
             });
+        assertThat(scmEvent.getBranches(scmSource)).isEmpty();
+        assertThat(scmEvent.getPullRequests(scmSource)).isEmpty();
     }
 
     @Test
@@ -157,6 +159,9 @@ class CloudPushWebhookProcessorTest {
                 assertThat(tag.getName()).isEqualTo("test-tag");
                 assertThat(tag.getDateMillis()).isEqualTo(1738608816000L);
             });
+
+        assertThat(scmEvent.getBranches(scmSource)).isEmpty();
+        assertThat(scmEvent.getPullRequests(scmSource)).isEmpty();
     }
 
     @Test
@@ -178,6 +183,13 @@ class CloudPushWebhookProcessorTest {
             .first()
             .usingRecursiveComparison()
             .isEqualTo(new SCMRevisionImpl(new BranchSCMHead("feature/issue-819"), "5ecffa3874e96920f24a2b3c0d0038e47d5cd1a4"));
+
+        assertThat(scmEvent.getTags(scmSource)).isEmpty();
+        assertThat(scmEvent.getBranches(scmSource))
+            .hasSize(1)
+            .extracting(BitbucketBranch::getName)
+            .contains("feature/issue-819");
+        assertThat(scmEvent.getPullRequests(scmSource)).isEmpty();
     }
 
     private String loadResource(String resource) throws IOException {

--- a/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/impl/webhook/cloud/pullrequest_updated.json
+++ b/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/impl/webhook/cloud/pullrequest_updated.json
@@ -1,0 +1,289 @@
+{
+    "repository": {
+        "type": "repository",
+        "full_name": "nfalco79/test-repos",
+        "links": {
+            "self": {
+                "href": "https://api.bitbucket.org/2.0/repositories/nfalco79/test-repos"
+            },
+            "html": {
+                "href": "https://bitbucket.org/nfalco79/test-repos"
+            },
+            "avatar": {
+                "href": "https://bytebucket.org/ravatar/%7B3deb8c29-778a-450c-8f69-3e50a18079df%7D?ts=3693474"
+            }
+        },
+        "name": "test-repos",
+        "scm": "git",
+        "website": null,
+        "owner": {
+            "display_name": "Nikolas Falco",
+            "links": {
+                "self": {
+                    "href": "https://api.bitbucket.org/2.0/users/%7B7d3a178a-a087-4756-b2da-2f9eadf50ba8%7D"
+                },
+                "avatar": {
+                    "href": "https://secure.gravatar.com/avatar/9979052fd773fbc9c0d94be07bbc8b5d?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FNF-3.png"
+                },
+                "html": {
+                    "href": "https://bitbucket.org/%7B7d3a178a-a087-4756-b2da-2f9eadf50ba8%7D/"
+                }
+            },
+            "type": "user",
+            "uuid": "{7d3a178a-a087-4756-b2da-2f9eadf50ba8}",
+            "account_id": "557058:270a1f96-cd27-4013-ade6-85df2ab9820c",
+            "nickname": "Nikolas Falco"
+        },
+        "workspace": {
+            "type": "workspace",
+            "uuid": "{7d3a178a-a087-4756-b2da-2f9eadf50ba8}",
+            "name": "Nikolas Falco",
+            "slug": "nfalco79",
+            "links": {
+                "avatar": {
+                    "href": "https://bitbucket.org/workspaces/nfalco79/avatar/?ts=1737924067"
+                },
+                "html": {
+                    "href": "https://bitbucket.org/nfalco79/"
+                },
+                "self": {
+                    "href": "https://api.bitbucket.org/2.0/workspaces/nfalco79"
+                }
+            }
+        },
+        "is_private": true,
+        "project": {
+            "type": "project",
+            "key": "PUB",
+            "uuid": "{ef731d07-06e0-46d2-9b56-2674649b0655}",
+            "name": "public",
+            "links": {
+                "self": {
+                    "href": "https://api.bitbucket.org/2.0/workspaces/nfalco79/projects/PUB"
+                },
+                "html": {
+                    "href": "https://bitbucket.org/nfalco79/workspace/projects/PUB"
+                },
+                "avatar": {
+                    "href": "https://bitbucket.org/nfalco79/workspace/projects/PUB/avatar/32?ts=1738923688"
+                }
+            }
+        },
+        "uuid": "{3deb8c29-778a-450c-8f69-3e50a18079df}",
+        "parent": null
+    },
+    "actor": {
+        "display_name": "Nikolas Falco",
+        "links": {
+            "self": {
+                "href": "https://api.bitbucket.org/2.0/users/%7B7d3a178a-a087-4756-b2da-2f9eadf50ba8%7D"
+            },
+            "avatar": {
+                "href": "https://secure.gravatar.com/avatar/9979052fd773fbc9c0d94be07bbc8b5d?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FNF-3.png"
+            },
+            "html": {
+                "href": "https://bitbucket.org/%7B7d3a178a-a087-4756-b2da-2f9eadf50ba8%7D/"
+            }
+        },
+        "type": "user",
+        "uuid": "{7d3a178a-a087-4756-b2da-2f9eadf50ba8}",
+        "account_id": "557058:270a1f96-cd27-4013-ade6-85df2ab9820c",
+        "nickname": "Nikolas Falco"
+    },
+    "pullrequest": {
+        "comment_count": 0,
+        "task_count": 0,
+        "type": "pullrequest",
+        "id": 1,
+        "title": "Release/release 1",
+        "description": "* Add license\r\n\r\n* [CI] Release version 1.0.0",
+        "rendered": {
+            "title": {
+                "type": "rendered",
+                "raw": "Release/release 1",
+                "markup": "markdown",
+                "html": "<p>Release/release 1</p>"
+            },
+            "description": {
+                "type": "rendered",
+                "raw": "* Add license\r\n\r\n* [CI] Release version 1.0.0",
+                "markup": "markdown",
+                "html": "<ul>\n<li>\n<p>Add license</p>\n</li>\n<li>\n<p>[CI] Release version 1.0.0</p>\n</li>\n</ul>"
+            }
+        },
+        "state": "OPEN",
+        "draft": false,
+        "merge_commit": null,
+        "close_source_branch": true,
+        "closed_by": null,
+        "author": {
+            "display_name": "Former user",
+            "links": {
+                "self": {
+                    "href": "https://api.bitbucket.org/2.0/users/%7B644c7fc2-b15a-4445-9f89-35390694fac9%7D"
+                },
+                "avatar": {
+                    "href": "https://avatar-management--avatars.us-west-2.prod.public.atl-paas.net/default/default-avatar.png"
+                },
+                "html": {
+                    "href": "https://bitbucket.org/%7B644c7fc2-b15a-4445-9f89-35390694fac9%7D/"
+                }
+            },
+            "type": "user",
+            "uuid": "{644c7fc2-b15a-4445-9f89-35390694fac9}",
+            "account_id": "557058:ca1cd232-2017-4216-94be-99637899e18d",
+            "nickname": "Former user"
+        },
+        "reason": "",
+        "created_on": "2018-09-21T14:57:59.455870+00:00",
+        "updated_on": "2026-07-30T01:35:49.207341+00:00",
+        "destination": {
+            "branch": {
+                "name": "master"
+            },
+            "commit": {
+                "hash": "174561d625c9",
+                "links": {
+                    "self": {
+                        "href": "https://api.bitbucket.org/2.0/repositories/nfalco79/test-repos/commit/174561d625c9"
+                    },
+                    "html": {
+                        "href": "https://bitbucket.org/nfalco79/test-repos/commits/174561d625c9"
+                    }
+                },
+                "type": "commit"
+            },
+            "repository": {
+                "type": "repository",
+                "full_name": "nfalco79/test-repos",
+                "links": {
+                    "self": {
+                        "href": "https://api.bitbucket.org/2.0/repositories/nfalco79/test-repos"
+                    },
+                    "html": {
+                        "href": "https://bitbucket.org/nfalco79/test-repos"
+                    },
+                    "avatar": {
+                        "href": "https://bytebucket.org/ravatar/%7B3deb8c29-778a-450c-8f69-3e50a18079df%7D?ts=3693474"
+                    }
+                },
+                "name": "test-repos",
+                "uuid": "{3deb8c29-778a-450c-8f69-3e50a18079df}"
+            }
+        },
+        "source": {
+            "branch": {
+                "name": "release/release-1",
+                "links": {
+                },
+                "sync_strategies": [
+                    "merge_commit",
+                    "rebase"
+                ]
+            },
+            "commit": {
+                "hash": "f945c96c71d0",
+                "links": {
+                    "self": {
+                        "href": "https://api.bitbucket.org/2.0/repositories/nfalco79/test-repos/commit/f945c96c71d0"
+                    },
+                    "html": {
+                        "href": "https://bitbucket.org/nfalco79/test-repos/commits/f945c96c71d0"
+                    }
+                },
+                "type": "commit"
+            },
+            "repository": {
+                "type": "repository",
+                "full_name": "nfalco79/test-repos",
+                "links": {
+                    "self": {
+                        "href": "https://api.bitbucket.org/2.0/repositories/nfalco79/test-repos"
+                    },
+                    "html": {
+                        "href": "https://bitbucket.org/nfalco79/test-repos"
+                    },
+                    "avatar": {
+                        "href": "https://bytebucket.org/ravatar/%7B3deb8c29-778a-450c-8f69-3e50a18079df%7D?ts=3693474"
+                    }
+                },
+                "name": "test-repos",
+                "uuid": "{3deb8c29-778a-450c-8f69-3e50a18079df}"
+            }
+        },
+        "reviewers": [
+        ],
+        "participants": [
+            {
+                "type": "participant",
+                "user": {
+                    "display_name": "Former user",
+                    "links": {
+                        "self": {
+                            "href": "https://api.bitbucket.org/2.0/users/%7B644c7fc2-b15a-4445-9f89-35390694fac9%7D"
+                        },
+                        "avatar": {
+                            "href": "https://avatar-management--avatars.us-west-2.prod.public.atl-paas.net/default/default-avatar.png"
+                        },
+                        "html": {
+                            "href": "https://bitbucket.org/%7B644c7fc2-b15a-4445-9f89-35390694fac9%7D/"
+                        }
+                    },
+                    "type": "user",
+                    "uuid": "{644c7fc2-b15a-4445-9f89-35390694fac9}",
+                    "account_id": "557058:ca1cd232-2017-4216-94be-99637899e18d",
+                    "nickname": "Former user"
+                },
+                "role": "PARTICIPANT",
+                "approved": true,
+                "state": "approved",
+                "participated_on": "2022-02-10T16:10:55.478453+00:00"
+            }
+        ],
+        "links": {
+            "self": {
+                "href": "https://api.bitbucket.org/2.0/repositories/nfalco79/test-repos/pullrequests/1"
+            },
+            "html": {
+                "href": "https://bitbucket.org/nfalco79/test-repos/pull-requests/1"
+            },
+            "commits": {
+                "href": "https://api.bitbucket.org/2.0/repositories/nfalco79/test-repos/pullrequests/1/commits"
+            },
+            "approve": {
+                "href": "https://api.bitbucket.org/2.0/repositories/nfalco79/test-repos/pullrequests/1/approve"
+            },
+            "request-changes": {
+                "href": "https://api.bitbucket.org/2.0/repositories/nfalco79/test-repos/pullrequests/1/request-changes"
+            },
+            "diff": {
+                "href": "https://api.bitbucket.org/2.0/repositories/nfalco79/test-repos/diff/nfalco79/test-repos:f945c96c71d0%0D174561d625c9?from_pullrequest_id=1"
+            },
+            "diffstat": {
+                "href": "https://api.bitbucket.org/2.0/repositories/nfalco79/test-repos/diffstat/nfalco79/test-repos:f945c96c71d0%0D174561d625c9?from_pullrequest_id=1"
+            },
+            "comments": {
+                "href": "https://api.bitbucket.org/2.0/repositories/nfalco79/test-repos/pullrequests/1/comments"
+            },
+            "activity": {
+                "href": "https://api.bitbucket.org/2.0/repositories/nfalco79/test-repos/pullrequests/1/activity"
+            },
+            "merge": {
+                "href": "https://api.bitbucket.org/2.0/repositories/nfalco79/test-repos/pullrequests/1/merge"
+            },
+            "decline": {
+                "href": "https://api.bitbucket.org/2.0/repositories/nfalco79/test-repos/pullrequests/1/decline"
+            },
+            "statuses": {
+                "href": "https://api.bitbucket.org/2.0/repositories/nfalco79/test-repos/pullrequests/1/statuses"
+            }
+        },
+        "summary": {
+            "type": "rendered",
+            "raw": "* Add license\r\n\r\n* [CI] Release version 1.0.0",
+            "markup": "markdown",
+            "html": "<ul>\n<li>\n<p>Add license</p>\n</li>\n<li>\n<p>[CI] Release version 1.0.0</p>\n</li>\n</ul>"
+        },
+        "queued": false
+    }
+}


### PR DESCRIPTION
When BitbucketSCMSource process event from incoming webhook most of informations are already inside the event.
PR and Push Cloud events now implements specific interfaces to provide which branches, tags and pull requests has been changed and must be processed instead to process all existing on remote.