### PR TITLE
[JENKINS-76505] Bound Bitbucket retries and isolate form lookup failures

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource.java
@@ -36,12 +36,10 @@ import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketProject;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketPullRequest;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketRepository;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketRequestException;
-import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketTeam;
 import com.cloudbees.jenkins.plugins.bitbucket.api.HasPullRequests;
 import com.cloudbees.jenkins.plugins.bitbucket.api.HasTags;
 import com.cloudbees.jenkins.plugins.bitbucket.api.PullRequestBranchType;
 import com.cloudbees.jenkins.plugins.bitbucket.api.endpoint.BitbucketEndpointProvider;
-import com.cloudbees.jenkins.plugins.bitbucket.client.repository.UserRoleInRepository;
 import com.cloudbees.jenkins.plugins.bitbucket.endpoints.BitbucketEndpointConfiguration;
 import com.cloudbees.jenkins.plugins.bitbucket.impl.avatars.BitbucketRepoAvatarMetadataAction;
 import com.cloudbees.jenkins.plugins.bitbucket.impl.endpoint.BitbucketCloudEndpoint;
@@ -1147,9 +1145,12 @@ public class BitbucketSCMSource extends SCMSource {
 
             BitbucketSupplier<ListBoxModel> listBoxModelSupplier = bitbucket -> {
                 ListBoxModel result = new ListBoxModel();
-                BitbucketTeam team = bitbucket.getTeam();
-                List<? extends BitbucketRepository> repositories =
-                    bitbucket.getRepositories(team != null ? null : UserRoleInRepository.MEMBER);
+                // The repositories endpoint works for both workspaces and
+                // personal owners without first resolving the owner type.
+                // Avoiding that probe removes a second remote request from an
+                // interactive form fill, which is especially important while
+                // Bitbucket is rate limiting the controller.
+                List<? extends BitbucketRepository> repositories = bitbucket.getRepositoriesForForm(null);
                 if (repositories.isEmpty()) {
                     throw FormFillFailure.error(Messages.BitbucketSCMSource_NoMatchingOwner(repoOwner)).withSelectionCleared();
                 }

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/BitbucketApi.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/BitbucketApi.java
@@ -285,6 +285,21 @@ public interface BitbucketApi extends AutoCloseable {
             throws IOException, InterruptedException;
 
     /**
+     * Returns repositories for an interactive Jenkins form fill.
+     * Implementations may apply a shorter timeout than normal SCM operations.
+     *
+     * @param role optional repository role filter
+     * @return the repositories list (it can be empty)
+     * @throws IOException if there was a network communications error
+     * @throws InterruptedException if interrupted while waiting on remote communications
+     */
+    @NonNull
+    default List<? extends BitbucketRepository> getRepositoriesForForm(@CheckForNull UserRoleInRepository role)
+            throws IOException, InterruptedException {
+        return getRepositories(role);
+    }
+
+    /**
      * Returns all the repositories for the current owner (even if it's a regular user or a team).
      *
      * @return all repositories for the current {@link #getOwner()}

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/BitbucketCloudApiClient.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/BitbucketCloudApiClient.java
@@ -604,6 +604,18 @@ public class BitbucketCloudApiClient extends AbstractBitbucketApi implements Bit
     @NonNull
     @Override
     public List<BitbucketCloudRepository> getRepositories(@CheckForNull UserRoleInRepository role) throws IOException {
+        return getRepositories(role, false);
+    }
+
+    @NonNull
+    @Override
+    public List<BitbucketCloudRepository> getRepositoriesForForm(@CheckForNull UserRoleInRepository role)
+            throws IOException {
+        return getRepositories(role, true);
+    }
+
+    private List<BitbucketCloudRepository> getRepositories(
+            @CheckForNull UserRoleInRepository role, boolean interactive) throws IOException {
         StringBuilder cacheKey = new StringBuilder();
         cacheKey.append(owner);
 
@@ -631,12 +643,19 @@ public class BitbucketCloudApiClient extends AbstractBitbucketApi implements Bit
         String url = template.expand();
 
         ICheckedCallable<List<BitbucketCloudRepository>, IOException> request = () -> {
-            List<BitbucketCloudRepository> repositories = getPagedRequest(url, BitbucketCloudRepository.class);
+            List<BitbucketCloudRepository> repositories =
+                    getPagedRequest(url, BitbucketCloudRepository.class, interactive);
             repositories.sort(Comparator.comparing(BitbucketCloudRepository::getRepositoryName));
             return repositories;
         };
         if (enableCache) {
             try {
+                if (interactive) {
+                    // Configuration pages can issue concurrent requests. Cache
+                    // a failed lookup so the form does not repeatedly consume
+                    // Bitbucket quota while it is already rate limited.
+                    return cachedRepositories.get(cacheKey.toString(), request, 10, MINUTES);
+                }
                 return cachedRepositories.get(cacheKey.toString(), request);
             } catch (ExecutionException e) {
                 BitbucketRequestException bre = BitbucketApiUtils.unwrap(e);
@@ -769,8 +788,12 @@ public class BitbucketCloudApiClient extends AbstractBitbucketApi implements Bit
     }
 */
     private <V> List<V> getPagedRequest(String url, Class<V> resultType) throws IOException {
+        return getPagedRequest(url, resultType, false);
+    }
+
+    private <V> List<V> getPagedRequest(String url, Class<V> resultType, boolean interactive) throws IOException {
         List<V> resources = new ArrayList<>();
-        String response = getRequest(url);
+        String response = interactive ? getInteractiveRequest(url) : getRequest(url);
 
         ParameterizedType parameterizedType = new ParameterizedType() {
 
@@ -801,7 +824,7 @@ public class BitbucketCloudApiClient extends AbstractBitbucketApi implements Bit
             BitbucketCloudPage<V> page = JsonParser.toJava(response, type);
             resources.addAll(page.getValues());
             while (!page.isLastPage()){
-                response = getRequest(page.getNext());
+                response = interactive ? getInteractiveRequest(page.getNext()) : getRequest(page.getNext());
                 page = JsonParser.toJava(response, type);
                 resources.addAll(page.getValues());
             }

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/Cache.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/Cache.java
@@ -53,18 +53,48 @@ public class Cache<K, V> {
     }
 
     public synchronized <E extends Exception> V get(final K key, final ICheckedCallable<V, E> request) throws ExecutionException {
+        return get(key, request, 0, NANOSECONDS);
+    }
+
+    /**
+     * Returns a cached value, loading it when necessary, and optionally caches
+     * a failed load for a shorter period.
+     *
+     * <p>Failure caching prevents callers waiting for the same key from
+     * executing the same failing remote request one after another. A zero
+     * failure duration retains the original behavior.
+     *
+     * @param key cache key
+     * @param request value loader
+     * @param failureDuration duration for which a loader failure is cached
+     * @param failureUnit unit for {@code failureDuration}
+     * @return the cached or loaded value
+     * @throws ExecutionException if the loader failed, including a cached failure
+     */
+    public synchronized <E extends Exception> V get(
+            final K key,
+            final ICheckedCallable<V, E> request,
+            final int failureDuration,
+            final TimeUnit failureUnit) throws ExecutionException {
         if (isExpired(key)) {
             doRemove(key);
         }
 
         if (entries.containsKey(key)) {
-            return entries.get(key).value;
+            Entry<V> entry = entries.get(key);
+            if (entry.failure != null) {
+                throw new ExecutionException("Cached failure loading value for key: " + key, entry.failure);
+            }
+            return entry.value;
         }
 
         V result;
         try {
             result = request.call();
         } catch (final Exception e) {
+            if (failureDuration > 0 && !(e instanceof InterruptedException)) {
+                entries.put(key, Entry.failure(e, failureUnit.toNanos(failureDuration)));
+            }
             throw new ExecutionException("Cannot load value for key: " + key, e);
         }
 
@@ -103,7 +133,11 @@ public class Cache<K, V> {
 
     private boolean isExpired(final K key) {
         final Entry<V> entry = entries.get(key);
-        return entry != null && System.nanoTime() - entry.nanos > expireAfterNanos;
+        if (entry == null) {
+            return false;
+        }
+        long expiration = entry.failure == null ? expireAfterNanos : entry.expireAfterNanos;
+        return System.nanoTime() - entry.nanos > expiration;
     }
 
     private void doRemove(final K key) {
@@ -111,7 +145,7 @@ public class Cache<K, V> {
     }
 
     private V doPut(final K key, final V value) {
-        entries.put(key, new Entry<>(value));
+        entries.put(key, Entry.value(value));
         return value;
     }
 
@@ -133,11 +167,25 @@ public class Cache<K, V> {
     private static class Entry<V> {
         private final V value;
 
+        private final Exception failure;
+
         private final long nanos;
 
-        public Entry(final V value) {
+        private final long expireAfterNanos;
+
+        private Entry(final V value, final Exception failure, final long expireAfterNanos) {
             this.value = value;
+            this.failure = failure;
+            this.expireAfterNanos = expireAfterNanos;
             nanos = System.nanoTime();
+        }
+
+        private static <V> Entry<V> value(final V value) {
+            return new Entry<>(value, null, 0);
+        }
+
+        private static <V> Entry<V> failure(final Exception failure, final long expireAfterNanos) {
+            return new Entry<>(null, failure, expireAfterNanos);
         }
     }
 

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/impl/client/AbstractBitbucketApi.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/impl/client/AbstractBitbucketApi.java
@@ -85,6 +85,7 @@ import org.apache.hc.core5.http.NameValuePair;
 import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.apache.hc.core5.http.io.entity.StringEntity;
 import org.apache.hc.core5.util.TimeValue;
+import org.apache.hc.core5.util.Timeout;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.ProtectedExternally;
 
@@ -171,7 +172,12 @@ public abstract class AbstractBitbucketApi implements BitbucketApi, AutoCloseabl
                 .useSystemProperties()
                 .setConnectionManager(getConnectionManager())
                 .setConnectionManagerShared(true)
-                .setRetryStrategy(new ExponentialBackoffRetryStrategy(2, TimeUnit.SECONDS.toMillis(5), TimeUnit.HOURS.toMillis(1)))
+                // Do not retry HTTP 429/503 responses. Retrying a rate-limited
+                // request consumes more quota and blocks interactive Jenkins
+                // form requests without making the response more likely to
+                // succeed. Callers can schedule a later operation as needed.
+                .setRetryStrategy(new ExponentialBackoffRetryStrategy(
+                        2, TimeUnit.SECONDS.toMillis(5), TimeUnit.HOURS.toMillis(1), 0))
                 .setDefaultRequestConfig(requestConfig)
                 .evictExpiredConnections()
                 .evictIdleConnections(TimeValue.ofSeconds(2))
@@ -319,6 +325,20 @@ public abstract class AbstractBitbucketApi implements BitbucketApi, AutoCloseabl
     protected String getRequest(String path) throws IOException {
         HttpGet request = new HttpGet(path);
         request.setAbsoluteRequestUri(true);
+        return doRequest(request);
+    }
+
+    /**
+     * Performs a GET with the shorter timeout appropriate for a Jenkins form
+     * fill. Normal SCM operations continue to use {@link #getRequest(String)}
+     * and the regular socket timeout.
+     */
+    protected String getInteractiveRequest(String path) throws IOException {
+        HttpGet request = new HttpGet(path);
+        request.setAbsoluteRequestUri(true);
+        request.setConfig(RequestConfig.custom()
+                .setResponseTimeout(Timeout.ofSeconds(10))
+                .build());
         return doRequest(request);
     }
 

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/impl/client/ExponentialBackoffRetryStrategy.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/impl/client/ExponentialBackoffRetryStrategy.java
@@ -77,6 +77,7 @@ public class ExponentialBackoffRetryStrategy extends DefaultHttpRequestRetryStra
     private final long backOffRate;
     private final long initialExpiryInMillis;
     private final long maxExpiryInMillis;
+    private final int maxRetries;
     /**
      * Derived {@code IOExceptions} which shall not be retried
      */
@@ -103,9 +104,28 @@ public class ExponentialBackoffRetryStrategy extends DefaultHttpRequestRetryStra
             final long backOffRate,
             final long initialExpiryInMillis,
             final long maxExpiryInMillis) {
+        this(backOffRate, initialExpiryInMillis, maxExpiryInMillis, Integer.MAX_VALUE);
+    }
+
+    /**
+     * Creates a retry strategy with both a maximum delay and an explicit retry
+     * count. A delay ceiling alone can keep an interactive Jenkins request
+     * alive for many minutes while exponential delays accumulate.
+     *
+     * @param backOffRate multiplier applied after each failed attempt
+     * @param initialExpiryInMillis delay before the first retry
+     * @param maxExpiryInMillis maximum delay for one retry
+     * @param maxRetries maximum number of retries after the initial request
+     */
+    public ExponentialBackoffRetryStrategy(
+            final long backOffRate,
+            final long initialExpiryInMillis,
+            final long maxExpiryInMillis,
+            final int maxRetries) {
         this.backOffRate = Args.notNegative(backOffRate, "BackOffRate");
         this.initialExpiryInMillis = Args.notNegative(initialExpiryInMillis, "InitialExpiryInMillis");
         this.maxExpiryInMillis = Args.notNegative(maxExpiryInMillis, "MaxExpiryInMillis");
+        this.maxRetries = Args.notNegative(maxRetries, "MaxRetries");
         this.nonRetriableIOExceptionClasses = Set.of(
                 InterruptedIOException.class,
                 UnknownHostException.class,
@@ -121,7 +141,8 @@ public class ExponentialBackoffRetryStrategy extends DefaultHttpRequestRetryStra
     @Override
     public boolean retryRequest(HttpResponse response, int executionCount, HttpContext context) {
         int statusCode = response.getCode();
-        return getRetryInterval(executionCount) < maxExpiryInMillis
+        return executionCount <= maxRetries
+                && getRetryInterval(executionCount) < maxExpiryInMillis
                 && (statusCode == HttpStatus.SC_TOO_MANY_REQUESTS
                 || statusCode == HttpStatus.SC_SERVICE_UNAVAILABLE);
     }
@@ -137,6 +158,9 @@ public class ExponentialBackoffRetryStrategy extends DefaultHttpRequestRetryStra
 
     @Override
     public boolean retryRequest(HttpRequest request, IOException exception, int execCount, HttpContext context) {
+        if (execCount > maxRetries) {
+            return false;
+        }
         if (this.nonRetriableIOExceptionClasses.contains(exception.getClass())) {
             return false;
         } else {

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/client/CacheTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/client/CacheTest.java
@@ -24,10 +24,19 @@
 package com.cloudbees.jenkins.plugins.bitbucket.client;
 
 import com.cloudbees.jenkins.plugins.bitbucket.impl.client.ICheckedCallable;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -79,5 +88,51 @@ class CacheTest {
 
         cache.get("another key", callable);
         assertThat(cache.size()).isEqualTo(10);
+    }
+
+    @Test
+    void ensure_failure_is_cached_for_configured_duration() throws Exception {
+        final Cache<String, Long> cache = new Cache<>(5, TimeUnit.HOURS);
+        @SuppressWarnings("unchecked")
+        final ICheckedCallable<Long, IOException> callable = mock(ICheckedCallable.class);
+        when(callable.call()).thenThrow(new IOException("rate limited"));
+
+        assertThatThrownBy(() -> cache.get("a key", callable, 1, TimeUnit.MINUTES))
+                .isInstanceOf(ExecutionException.class)
+                .hasRootCauseMessage("rate limited");
+        assertThatThrownBy(() -> cache.get("a key", callable, 1, TimeUnit.MINUTES))
+                .isInstanceOf(ExecutionException.class)
+                .hasRootCauseMessage("rate limited");
+
+        verify(callable).call();
+        verifyNoMoreInteractions(callable);
+    }
+
+    @Test
+    void ensure_concurrent_failures_execute_loader_once() throws Exception {
+        final Cache<String, Long> cache = new Cache<>(5, TimeUnit.HOURS);
+        final AtomicInteger calls = new AtomicInteger();
+        final ICheckedCallable<Long, IOException> loader = () -> {
+            calls.incrementAndGet();
+            throw new IOException("rate limited");
+        };
+
+        ExecutorService executor = Executors.newFixedThreadPool(4);
+        try {
+            List<Future<?>> results = new ArrayList<>();
+            for (int i = 0; i < 4; i++) {
+                results.add(executor.submit(() -> assertThatThrownBy(
+                                () -> cache.get("a key", loader, 1, TimeUnit.MINUTES))
+                        .isInstanceOf(ExecutionException.class)
+                        .hasRootCauseMessage("rate limited")));
+            }
+            for (Future<?> result : results) {
+                result.get();
+            }
+        } finally {
+            executor.shutdownNow();
+        }
+
+        assertThat(calls).hasValue(1);
     }
 }

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/impl/client/ExponentialBackOffRetryStrategyTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/impl/client/ExponentialBackOffRetryStrategyTest.java
@@ -77,6 +77,61 @@ class ExponentialBackOffRetryStrategyTest {
         }
     }
 
+    @Test
+    void retryCountIsBounded(ClientAndServer mockServer) throws Exception {
+        HttpRequest request = request()
+                .withMethod("GET")
+                .withPath("/rest/api/1.0/projects/test/repos/testRepos/tags");
+        mockServer.when(request).respond(response().withStatusCode(429));
+
+        final RetryInterceptor counterInterceptor = new RetryInterceptor();
+        try (BitbucketApi client = new BitbucketServerAPIClient(
+                "http://localhost:" + mockServer.getPort(),
+                "test",
+                "testRepos",
+                null,
+                false) {
+            @Override
+            protected HttpClientBuilder setupClientBuilder() {
+                return super.setupClientBuilder()
+                        .setRetryStrategy(new ExponentialBackoffRetryStrategy(2, 1, 1000, 3))
+                        .addResponseInterceptorFirst(counterInterceptor);
+            }
+        }) {
+            assertThatIOException().isThrownBy(client::getTags);
+        }
+
+        // The interceptor sees the initial response and three retry responses.
+        assertThat(counterInterceptor.getRetry()).isEqualTo(4);
+    }
+
+    @Test
+    void retriesCanBeDisabled(ClientAndServer mockServer) throws Exception {
+        HttpRequest request = request()
+                .withMethod("GET")
+                .withPath("/rest/api/1.0/projects/test/repos/testRepos/tags");
+        mockServer.when(request).respond(response().withStatusCode(429));
+
+        final RetryInterceptor counterInterceptor = new RetryInterceptor();
+        try (BitbucketApi client = new BitbucketServerAPIClient(
+                "http://localhost:" + mockServer.getPort(),
+                "test",
+                "testRepos",
+                null,
+                false) {
+            @Override
+            protected HttpClientBuilder setupClientBuilder() {
+                return super.setupClientBuilder()
+                        .setRetryStrategy(new ExponentialBackoffRetryStrategy(2, 1, 1000, 0))
+                        .addResponseInterceptorFirst(counterInterceptor);
+            }
+        }) {
+            assertThatIOException().isThrownBy(client::getTags);
+        }
+
+        assertThat(counterInterceptor.getRetry()).isEqualTo(1);
+    }
+
     private static class RetryInterceptor implements HttpResponseInterceptor {
         private int retry = 0;
 


### PR DESCRIPTION
I reproduced the behavior locally against Bitbucket Cloud and traced the requests with thread dumps.

### Findings

The repeated `HttpRequestRetryExec` messages were coming from the multibranch configuration page, specifically:

`BitbucketSCMSource.doFillRepositoryItems` → `BitbucketCloudApiClient.getRepositories`

They were not branch-indexing requests.

There were several contributing factors:

1. The exponential retry strategy had no explicit retry-count limit. Its only stopping condition was the one-hour maximum delay, allowing delays of 5, 10, 20, 40, 80 seconds, etc.
2. The repository cache stored successful responses only. Concurrent or repeated form-fill requests therefore repeated the entire failing lookup after a 429.
3. Repository form filling first queried the owner type and then queried repositories, resulting in an unnecessary additional API request.
4. Bitbucket sometimes held the repository request upstream for approximately 29 seconds before returning 429.
5. Applying a short timeout globally also affected branch indexing, so the interactive and SCM request policies needed to be separated.

### Changes

- Added an explicit maximum retry count to `ExponentialBackoffRetryStrategy`.
- Disabled automatic retries for the production Bitbucket client when Bitbucket returns 429/503.
- Added optional failure caching to the shared cache implementation.
- Cache failed repository-dropdown lookups for ten minutes.
- Collapse concurrent failing dropdown requests into a single upstream request.
- Added `getRepositoriesForForm` to distinguish interactive repository discovery from normal SCM operations.
- Apply a ten-second response timeout only to interactive repository discovery.
- Preserve the normal 60-second socket timeout for branch indexing and other SCM operations.
- Removed the redundant owner-type lookup before repository discovery.
- Preserved the existing retry-strategy constructor for compatibility.

### Verification

Tested with a local multibranch job

Before the changes, a configuration page could generate retry sequences reaching execution count 6 and beyond, with an 80-second delay. Multiple form requests then repeated the same sequence.

After the changes:

- interactive lookups do not enter an exponential retry sequence;
- concurrent/repeated failures reuse the cached failure;
- a stalled interactive request is limited to ten seconds;
- normal SCM operations retain their regular timeout;
- a genuine Bitbucket 429 is surfaced immediately rather than amplified.

The focused test suite covers retry limits, disabling retries, cached failures, and concurrent failure collapsing:

- 22 tests passed
- 0 failures
- Checkstyle passed

One important distinction: this prevents the plugin from amplifying a Bitbucket rate limit. It cannot make indexing succeed while Bitbucket is actively rejecting the configured credential with HTTP 429. In that case indexing now fails promptly and transparently.