### PR TITLE
[JENKINS-76514] Bitbucket tag deletion event webhook no longer removes jobs

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSource.java
@@ -101,6 +101,7 @@ import jenkins.authentication.tokens.api.AuthenticationTokens;
 import jenkins.model.Jenkins;
 import jenkins.plugins.git.GitTagSCMHead;
 import jenkins.plugins.git.traits.GitBrowserSCMSourceTrait;
+import jenkins.scm.api.SCMEvent.Type;
 import jenkins.scm.api.SCMHead;
 import jenkins.scm.api.SCMHeadCategory;
 import jenkins.scm.api.SCMHeadEvent;
@@ -342,9 +343,10 @@ public class BitbucketSCMSource extends SCMSource {
     protected void retrieve(@CheckForNull SCMSourceCriteria criteria, @NonNull SCMHeadObserver observer,
                             @CheckForNull SCMHeadEvent<?> event, @NonNull TaskListener listener)
             throws IOException, InterruptedException {
-        try (BitbucketSCMSourceRequest request = new BitbucketSCMSourceContext(criteria, observer)
-                .withTraits(traits)
-                .newRequest(this, listener)) {
+        try (BitbucketApi client = buildBitbucketClient();
+                BitbucketSCMSourceRequest request = new BitbucketSCMSourceContext(criteria, observer)
+                    .withTraits(traits)
+                    .newRequest(this, listener)) {
             StandardCredentials scanCredentials = credentials();
             if (scanCredentials == null) {
                 listener.getLogger().format("Connecting to %s with no credentials, anonymous access%n", getServerUrl());
@@ -357,22 +359,24 @@ public class BitbucketSCMSource extends SCMSource {
 
             // now serve the request
             if (request.isFetchPRs() && !request.isComplete()) {
-                if (event instanceof HasPullRequests prEvent) {
-                    request.setPullRequests(getBitbucketPullRequestsFromEvent(prEvent, listener));
+                if (event instanceof HasPullRequests) {
+                    // extract PRs from event
+                    request.setPullRequests(getBitbucketPullRequestsFromEvent(client, event, listener));
                 }
                 // Search pull requests
                 retrievePullRequests(request);
             }
             if (request.isFetchBranches() && !request.isComplete()) {
-                if (event instanceof HasBranches branchEvent) {
-                    request.setBranches(getBitbucketBranchesFromEvent(branchEvent, listener));
+                if (event instanceof HasBranches) {
+                    request.setBranches(getBitbucketBranchesFromEvent(client, event, listener));
                 }
                 // Search branches
                 retrieveBranches(request);
             }
             if (request.isFetchTags() && !request.isComplete()) {
-                if (event instanceof HasTags tagEvent) {
-                    request.setTags(getBitbucketTagsFromEvent(tagEvent, listener));
+                if (event instanceof HasTags) {
+                    // extract tags from event
+                    request.setTags(getBitbucketTagsFromEvent(client, event, listener));
                 }
                 // Search tags
                 retrieveTags(request);
@@ -380,42 +384,45 @@ public class BitbucketSCMSource extends SCMSource {
         }
     }
 
-    private Iterable<BitbucketBranch> getBitbucketTagsFromEvent(@NonNull HasTags incomingTagEvent, @NonNull TaskListener listener) throws IOException, InterruptedException {
+    private Iterable<BitbucketBranch> getBitbucketTagsFromEvent(@NonNull BitbucketApi client,
+                                                                @NonNull SCMHeadEvent<?> event,
+                                                                @NonNull TaskListener listener) throws IOException {
         Collection<BitbucketBranch> initializedTags = new HashSet<>();
-        try (BitbucketApi bitBucket = buildBitbucketClient()) {
+        if (event instanceof HasTags incomingTagEvent) {
             Iterable<BitbucketBranch> tags = incomingTagEvent.getTags(BitbucketSCMSource.this);
             for (BitbucketBranch tag : tags) {
-                initializedTags.add(bitBucket.getTag(tag.getName()));
+                initializedTags.add(event.getType() == Type.REMOVED ? tag : client.getTag(tag.getName()));
                 listener.getLogger().format("Initialized Tag: %s%n", tag.getName());
             }
         }
         return initializedTags;
     }
 
-    private Iterable<BitbucketPullRequest> getBitbucketPullRequestsFromEvent(@NonNull HasPullRequests incomingPrEvent,
-                                                                             @NonNull TaskListener listener) throws IOException, InterruptedException {
+    private Iterable<BitbucketPullRequest> getBitbucketPullRequestsFromEvent(@NonNull BitbucketApi client,
+                                                                             @NonNull SCMHeadEvent<?> event,
+                                                                             @NonNull TaskListener listener) throws IOException {
         Collection<BitbucketPullRequest> initializedPRs = new HashSet<>();
-        try (BitbucketApi bitBucket = buildBitbucketClient()) {
-            Iterable<BitbucketPullRequest> pullRequests = incomingPrEvent.getPullRequests(BitbucketSCMSource.this);
+        if (event instanceof HasPullRequests prEvent) {
+            Iterable<BitbucketPullRequest> pullRequests = prEvent.getPullRequests(BitbucketSCMSource.this);
             for (BitbucketPullRequest pr : pullRequests) {
                 // ensure that the PR is properly initialised via /changes API
                 // see BitbucketServerAPIClient.setupPullRequest()
-                initializedPRs.add(bitBucket.getPullRequestById(Integer.parseInt(pr.getId())));
+                // PRs can not be deleted only closed/declined
+                initializedPRs.add(client.getPullRequestById(Integer.parseInt(pr.getId())));
                 listener.getLogger().format("Initialized PR: %s%n", pr.getLink());
             }
         }
         return initializedPRs;
     }
 
-    private Iterable<BitbucketBranch> getBitbucketBranchesFromEvent(@NonNull HasBranches incomingEvent,
-                                                                    @NonNull TaskListener listener) throws IOException, InterruptedException {
+    private Iterable<BitbucketBranch> getBitbucketBranchesFromEvent(@NonNull BitbucketApi client,
+                                                                    @NonNull SCMHeadEvent<?> event,
+                                                                    @NonNull TaskListener listener) throws IOException {
         Collection<BitbucketBranch> initializedBranches = new HashSet<>();
-        try (BitbucketApi bitBucket = buildBitbucketClient()) {
-            Iterable<BitbucketBranch> branches = incomingEvent.getBranches(BitbucketSCMSource.this);
+        if (event instanceof HasBranches branchEvent) {
+            Iterable<BitbucketBranch> branches = branchEvent.getBranches(BitbucketSCMSource.this);
             for (BitbucketBranch branch : branches) {
-                // ensure that the PR is properly initialised via /changes API
-                // see BitbucketServerAPIClient.setupPullRequest()
-                initializedBranches.add(bitBucket.getBranch(branch.getName()));
+                initializedBranches.add(event.getType() == Type.REMOVED ? branch : client.getBranch(branch.getName()));
                 listener.getLogger().format("Initialized branch: %s%n", branch.getName());
             }
         }

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/HasBranches.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/HasBranches.java
@@ -27,6 +27,6 @@ import com.cloudbees.jenkins.plugins.bitbucket.BitbucketSCMSource;
 
 public interface HasBranches {
 
-    Iterable<BitbucketBranch> getBranches(BitbucketSCMSource src) throws InterruptedException;
+    Iterable<BitbucketBranch> getBranches(BitbucketSCMSource src);
 
 }

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/HasPullRequests.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/api/HasPullRequests.java
@@ -27,6 +27,6 @@ import com.cloudbees.jenkins.plugins.bitbucket.BitbucketSCMSource;
 
 public interface HasPullRequests {
 
-    Iterable<BitbucketPullRequest> getPullRequests(BitbucketSCMSource src) throws InterruptedException;
+    Iterable<BitbucketPullRequest> getPullRequests(BitbucketSCMSource src);
 
 }

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/branch/BitbucketCloudBranch.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/branch/BitbucketCloudBranch.java
@@ -30,7 +30,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.util.Date;
-import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -50,8 +49,7 @@ public class BitbucketCloudBranch implements BitbucketBranch {
 
     @JsonCreator
     public BitbucketCloudBranch(@NonNull @JsonProperty("name") String name,
-                                @Nullable @JsonProperty("target") BitbucketCloudBranch.Target target,
-                                @Nullable @JsonProperty("heads") List<Head> heads) { // TODO delete heads arg if possible
+                                @Nullable @JsonProperty("target") BitbucketCloudBranch.Target target) {
         this.name = name;
         if (target != null) {
             this.dateInMillis = target.date.getTime();

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/impl/webhook/cloud/CloudPREvent.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/impl/webhook/cloud/CloudPREvent.java
@@ -146,7 +146,7 @@ final class CloudPREvent extends AbstractSCMHeadEvent<BitbucketPullRequestEvent>
     }
 
     @Override
-    public Iterable<BitbucketPullRequest> getPullRequests(BitbucketSCMSource src) throws InterruptedException {
+    public Iterable<BitbucketPullRequest> getPullRequests(BitbucketSCMSource src) {
         if (hookEvent == PULL_REQUEST_DECLINED || hookEvent == PULL_REQUEST_MERGED) {
             return Collections.emptySet();
         }
@@ -166,7 +166,7 @@ final class CloudPREvent extends AbstractSCMHeadEvent<BitbucketPullRequestEvent>
     }
 
     @Override
-    public Iterable<BitbucketBranch> getBranches(BitbucketSCMSource src) throws InterruptedException {
+    public Iterable<BitbucketBranch> getBranches(BitbucketSCMSource src) {
         List<BitbucketBranch> branches = new ArrayList<>();
 
         BitbucketPullRequest pr = getPayload().getPullRequest();

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/impl/webhook/cloud/CloudPushEvent.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/impl/webhook/cloud/CloudPushEvent.java
@@ -35,7 +35,6 @@ import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketRepository;
 import com.cloudbees.jenkins.plugins.bitbucket.api.HasBranches;
 import com.cloudbees.jenkins.plugins.bitbucket.api.HasPullRequests;
 import com.cloudbees.jenkins.plugins.bitbucket.api.HasTags;
-import com.cloudbees.jenkins.plugins.bitbucket.client.branch.BitbucketCloudAuthor;
 import com.cloudbees.jenkins.plugins.bitbucket.client.branch.BitbucketCloudBranch;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.ArrayList;
@@ -81,28 +80,23 @@ final class CloudPushEvent extends AbstractSCMHeadEvent<BitbucketPushEvent> impl
 
         Map<SCMHead, SCMRevision> result = new HashMap<>();
         for (BitbucketPushEvent.Change change: getPayload().getChanges()) {
-            if (change.isClosed()) {
-                result.put(new BranchSCMHead(change.getOld().getName()), null);
-            } else {
-                // created is true
-                Reference newChange = change.getNew();
-                Target target = newChange.getTarget();
+            Reference changeRef = change.isClosed() ? change.getOld(): change.getNew();
+            Target target = changeRef.getTarget();
 
-                SCMHead head = null;
-                String eventType = newChange.getType();
-                if ("tag".equals(eventType)) {
-                    // for BB Cloud date is valued only in case of annotated tag
-                    Date tagDate = newChange.getDate() != null ? newChange.getDate() : target.getDate();
-                    if (tagDate == null) {
-                        // fall back to the jenkins time when the request is processed
-                        tagDate = new Date();
-                    }
-                    head = new BitbucketTagSCMHead(newChange.getName(), tagDate.getTime());
-                } else {
-                    head = new BranchSCMHead(newChange.getName());
+            SCMHead head = null;
+            String eventType = changeRef.getType();
+            if ("tag".equals(eventType)) {
+                // for BB Cloud date is valued only in case of annotated tag
+                Date tagDate = changeRef.getDate() != null ? changeRef.getDate() : target.getDate();
+                if (tagDate == null) {
+                    // fall back to the jenkins time when the request is processed
+                    tagDate = new Date();
                 }
-                result.put(head, new AbstractGitSCMSource.SCMRevisionImpl(head, target.getHash()));
+                head = new BitbucketTagSCMHead(changeRef.getName(), tagDate.getTime());
+            } else {
+                head = new BranchSCMHead(changeRef.getName());
             }
+            result.put(head, new AbstractGitSCMSource.SCMRevisionImpl(head, target.getHash()));
         }
         return result;
     }
@@ -116,58 +110,46 @@ final class CloudPushEvent extends AbstractSCMHeadEvent<BitbucketPushEvent> impl
     public Iterable<BitbucketBranch> getTags(BitbucketSCMSource src) {
         List<BitbucketBranch> tags = new ArrayList<>();
         for (BitbucketPushEvent.Change change: getPayload().getChanges()) {
-            if (!change.isClosed()) {
-                // created is true
-                Reference newChange = change.getNew();
-                Target target = newChange.getTarget();
+            Reference changeRef = change.isCreated() ? change.getNew() : change.getOld();
+            Target target = changeRef.getTarget();
 
-                String eventType = newChange.getType();
-                if ("tag".equals(eventType)) {
-                    // for BB Cloud date is valued only in case of annotated tag
-                    Date tagDate = newChange.getDate() != null ? newChange.getDate() : target.getDate();
-                    if (tagDate == null) {
-                        // fall back to the jenkins time when the request is processed
-                        tagDate = new Date();
-                    }
-                    String hash = target.getHash();
-                    BitbucketCloudBranch.Target tagTarget = new BitbucketCloudBranch.Target(hash, "", tagDate, new BitbucketCloudAuthor(target.getAuthor()));
-                    @SuppressWarnings("deprecation")
-                    BitbucketCloudBranch.Head head = new BitbucketCloudBranch.Head(hash);
-                    tags.add(new BitbucketCloudBranch(newChange.getName(), tagTarget, List.of(head)));
+            String eventType = changeRef.getType();
+            if ("tag".equals(eventType)) {
+                // for BB Cloud date is valued only in case of annotated tag
+                Date tagDate = changeRef.getDate() != null ? changeRef.getDate() : target.getDate();
+                if (tagDate == null) {
+                    // fall back to the jenkins time when the request is processed
+                    tagDate = new Date();
                 }
+                BitbucketCloudBranch tagRef = new BitbucketCloudBranch(changeRef.getName(), target.getHash(), tagDate.getTime());
+                tagRef.setAuthor(target.getAuthor());
+                tags.add(tagRef);
             }
         }
         return tags;
     }
 
     @Override
-    public Iterable<BitbucketPullRequest> getPullRequests(BitbucketSCMSource src) throws InterruptedException {
+    public Iterable<BitbucketPullRequest> getPullRequests(BitbucketSCMSource src) {
         return Collections.emptyList();
     }
 
     @Override
-    public Iterable<BitbucketBranch> getBranches(BitbucketSCMSource src) throws InterruptedException {
+    public Iterable<BitbucketBranch> getBranches(BitbucketSCMSource src) {
         List<BitbucketBranch> branches = new ArrayList<>();
         for (BitbucketPushEvent.Change change: getPayload().getChanges()) {
-            if (!change.isClosed()) {
-                // created is true
-                Reference newChange = change.getNew();
-                Target target = newChange.getTarget();
+            Reference changeRef = change.isCreated() ? change.getNew() : change.getOld();
+            Target target = changeRef.getTarget();
 
-                String eventType = newChange.getType();
-                if ("branch".equals(eventType)) {
-                    // for BB Cloud date is valued only in case of annotated tag
-                    Date commitDate = newChange.getDate() != null ? newChange.getDate() : target.getDate();
-                    if (commitDate == null) {
-                        // fall back to the jenkins time when the request is processed
-                        commitDate = new Date();
-                    }
-                    String hash = target.getHash();
-                    BitbucketCloudBranch.Target commitTarget = new BitbucketCloudBranch.Target(hash, "", commitDate, new BitbucketCloudAuthor(target.getAuthor()));
-                    @SuppressWarnings("deprecation")
-                    BitbucketCloudBranch.Head head = new BitbucketCloudBranch.Head(hash);
-                    branches.add(new BitbucketCloudBranch(newChange.getName(), commitTarget, List.of(head)));
+            String eventType = changeRef.getType();
+            if ("branch".equals(eventType)) {
+                // for BB Cloud date is valued only in case of annotated tag
+                Date commitDate = changeRef.getDate() != null ? changeRef.getDate() : target.getDate();
+                if (commitDate == null) {
+                    // fall back to the jenkins time when the request is processed
+                    commitDate = new Date();
                 }
+                branches.add(new BitbucketCloudBranch(changeRef.getName(), target.getHash(), commitDate.getTime()));
             }
         }
         return branches;

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/impl/webhook/plugin/PluginPREvent.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/impl/webhook/plugin/PluginPREvent.java
@@ -141,7 +141,7 @@ final class PluginPREvent extends AbstractSCMHeadEvent<BitbucketPullRequestEvent
     }
 
     @Override
-    public Iterable<BitbucketPullRequest> getPullRequests(BitbucketSCMSource src) throws InterruptedException {
+    public Iterable<BitbucketPullRequest> getPullRequests(BitbucketSCMSource src) {
         if (hookEvent == PULL_REQUEST_DECLINED || hookEvent == PULL_REQUEST_MERGED) {
             return Collections.emptySet();
         }

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/impl/webhook/server/ServerHeadEvent.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/impl/webhook/server/ServerHeadEvent.java
@@ -114,7 +114,7 @@ final class ServerHeadEvent extends AbstractNativeServerSCMHeadEvent<NativeServe
     }
 
     @Override
-    public Iterable<BitbucketPullRequest> getPullRequests(BitbucketSCMSource src) throws InterruptedException {
+    public Iterable<BitbucketPullRequest> getPullRequests(BitbucketSCMSource src) {
         if (Type.REMOVED.equals(getType())) {
             return Collections.emptySet();
         }

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/impl/webhook/server/ServerPushEvent.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/impl/webhook/server/ServerPushEvent.java
@@ -326,7 +326,7 @@ final class ServerPushEvent extends AbstractNativeServerSCMHeadEvent<Collection<
     }
 
     @Override
-    public Collection<BitbucketPullRequest> getPullRequests(BitbucketSCMSource src) throws InterruptedException {
+    public Collection<BitbucketPullRequest> getPullRequests(BitbucketSCMSource src) {
         List<BitbucketPullRequest> prs = new ArrayList<>();
         for (final NativeServerChange change : getPayload()) {
             Map<String, BitbucketServerPullRequest> prsForChange = getPullRequests(src, change);

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/impl/webhook/cloud/CloudPushWebhookProcessorTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/impl/webhook/cloud/CloudPushWebhookProcessorTest.java
@@ -43,6 +43,7 @@ import jenkins.scm.api.SCMEvent.Type;
 import jenkins.scm.api.SCMHead;
 import jenkins.scm.api.SCMHeadEvent;
 import jenkins.scm.api.SCMRevision;
+import jenkins.scm.api.mixin.SCMHeadMixin;
 import org.apache.commons.collections4.MultiValuedMap;
 import org.apache.commons.collections4.map.CaseInsensitiveMap;
 import org.apache.commons.collections4.multimap.ArrayListValuedHashMap;
@@ -130,6 +131,88 @@ class CloudPushWebhookProcessorTest {
                 assertThat(tag.getAuthor()).isEqualTo("Nikolas Falco <email@domain.com>");
                 assertThat(tag.getName()).isEqualTo("simple-tag");
                 assertThat(tag.getDateMillis()).isEqualTo(1738608795000L);
+            });
+        assertThat(scmEvent.getBranches(scmSource)).isEmpty();
+        assertThat(scmEvent.getPullRequests(scmSource)).isEmpty();
+    }
+
+    @Test
+    void test_branch_created() throws Exception {
+        sut.process(HookEventType.PUSH.getKey(), loadResource("branch_created.json"), Collections.emptyMap(), mock(BitbucketEndpoint.class));
+
+        assertThat(scmEvent).isNotNull();
+        assertThat(scmEvent.getSourceName()).isEqualTo("test-repos");
+        assertThat(scmEvent.getType()).isEqualTo(Type.CREATED);
+        assertThat(scmEvent.isMatch(mock(SCM.class))).isFalse();
+
+        BitbucketSCMSource scmSource = new BitbucketSCMSource("AMUNIZ", "test-repos");
+        Map<SCMHead, SCMRevision> heads = scmEvent.heads(scmSource);
+            assertThat(heads.keySet())
+            .first()
+            .usingRecursiveComparison()
+            .isEqualTo(new BranchSCMHead("feature/test"));
+        Iterable<BitbucketBranch> branches = scmEvent.getBranches(scmSource);
+        assertThat(branches)
+            .element(0)
+            .satisfies(branch -> {
+                assertThat(branch.getName()).isEqualTo("feature/test");
+                assertThat(branch.getRawNode()).isEqualTo("174561d625c9623b60d8aba09b7f08ddc9df45cd");
+                assertThat(branch.getDateMillis()).isEqualTo(1745660606000L);
+            });
+        assertThat(scmEvent.getTags(scmSource)).isEmpty();
+        assertThat(scmEvent.getPullRequests(scmSource)).isEmpty();
+    }
+
+    @Test
+    void test_branch_deleted() throws Exception {
+        sut.process(HookEventType.PUSH.getKey(), loadResource("branch_deleted.json"), Collections.emptyMap(), mock(BitbucketEndpoint.class));
+
+        assertThat(scmEvent).isNotNull();
+        assertThat(scmEvent.getSourceName()).isEqualTo("test-repos");
+        assertThat(scmEvent.getType()).isEqualTo(Type.REMOVED);
+        assertThat(scmEvent.isMatch(mock(SCM.class))).isFalse();
+
+        BitbucketSCMSource scmSource = new BitbucketSCMSource("AMUNIZ", "test-repos");
+        Map<SCMHead, SCMRevision> heads = scmEvent.heads(scmSource);
+        assertThat(heads.keySet())
+            .first()
+            .usingRecursiveComparison()
+            .isEqualTo(new BranchSCMHead("feature/test"));
+        Iterable<BitbucketBranch> branches = scmEvent.getBranches(scmSource);
+        assertThat(branches)
+            .element(0)
+            .satisfies(branch -> {
+                assertThat(branch.getName()).isEqualTo("feature/test");
+                assertThat(branch.getRawNode()).isEqualTo("174561d625c9623b60d8aba09b7f08ddc9df45cd");
+                assertThat(branch.getDateMillis()).isEqualTo(1745660606000L);
+            });
+        assertThat(scmEvent.getTags(scmSource)).isEmpty();
+        assertThat(scmEvent.getPullRequests(scmSource)).isEmpty();
+    }
+
+    @Test
+    void test_tag_deleted() throws Exception {
+        sut.process(HookEventType.PUSH.getKey(), loadResource("tag_deleted.json"), Collections.emptyMap(), mock(BitbucketEndpoint.class));
+
+        assertThat(scmEvent).isNotNull();
+        assertThat(scmEvent.getSourceName()).isEqualTo("test-repos");
+        assertThat(scmEvent.getType()).isEqualTo(Type.REMOVED);
+        assertThat(scmEvent.isMatch(mock(SCM.class))).isFalse();
+
+        BitbucketSCMSource scmSource = new BitbucketSCMSource("AMUNIZ", "test-repos");
+        Map<SCMHead, SCMRevision> heads = scmEvent.heads(scmSource);
+        assertThat(heads.keySet())
+            .first()
+            .isInstanceOf(BitbucketTagSCMHead.class)
+            .extracting(SCMHeadMixin::getName)
+            .isEqualTo("test");
+
+        Iterable<BitbucketBranch> tags = scmEvent.getTags(scmSource);
+        assertThat(tags)
+            .element(0)
+            .satisfies(tag -> {
+                assertThat(tag.getAuthor()).isEqualTo("Nikolas Falco <email@domain.com>");
+                assertThat(tag.getName()).isEqualTo("test");
             });
         assertThat(scmEvent.getBranches(scmSource)).isEmpty();
         assertThat(scmEvent.getPullRequests(scmSource)).isEmpty();

--- a/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/impl/webhook/cloud/branch_created.json
+++ b/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/impl/webhook/cloud/branch_created.json
@@ -1,0 +1,451 @@
+{
+    "push": {
+        "changes": [
+            {
+                "old": null,
+                "new": {
+                    "name": "feature/test",
+                    "target": {
+                        "type": "commit",
+                        "hash": "174561d625c9623b60d8aba09b7f08ddc9df45cd",
+                        "date": "2025-04-26T09:43:26+00:00",
+                        "author": {
+                            "type": "author",
+                            "raw": "Nikolas Falco <email@domain.com>",
+                            "user": {
+                                "display_name": "Nikolas Falco",
+                                "links": {
+                                    "self": {
+                                        "href": "https://api.bitbucket.org/2.0/users/%7B7d3a178a-a087-4756-b2da-2f9eadf50ba8%7D"
+                                    },
+                                    "avatar": {
+                                        "href": "https://secure.gravatar.com/avatar/9979052fd773fbc9c0d94be07bbc8b5d?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FNF-3.png"
+                                    },
+                                    "html": {
+                                        "href": "https://bitbucket.org/%7B7d3a178a-a087-4756-b2da-2f9eadf50ba8%7D/"
+                                    }
+                                },
+                                "type": "user",
+                                "uuid": "{7d3a178a-a087-4756-b2da-2f9eadf50ba8}",
+                                "account_id": "557058:270a1f96-cd27-4013-ade6-85df2ab9820c",
+                                "nickname": "Nikolas Falco"
+                            }
+                        },
+                        "committer": {},
+                        "message": "Add simple pipeline\n",
+                        "summary": {
+                            "type": "rendered",
+                            "raw": "Add simple pipeline\n",
+                            "markup": "markdown",
+                            "html": "<p>Add simple pipeline</p>"
+                        },
+                        "links": {
+                            "self": {
+                                "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/commit/174561d625c9623b60d8aba09b7f08ddc9df45cd"
+                            },
+                            "html": {
+                                "href": "https://bitbucket.org/amuniz/test-repos/commits/174561d625c9623b60d8aba09b7f08ddc9df45cd"
+                            }
+                        },
+                        "parents": [
+                            {
+                                "hash": "e43fdffe2def75053da30efa8204d0317a0b932a",
+                                "links": {
+                                    "self": {
+                                        "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/commit/e43fdffe2def75053da30efa8204d0317a0b932a"
+                                    },
+                                    "html": {
+                                        "href": "https://bitbucket.org/amuniz/test-repos/commits/e43fdffe2def75053da30efa8204d0317a0b932a"
+                                    }
+                                },
+                                "type": "commit"
+                            }
+                        ],
+                        "rendered": {},
+                        "properties": {}
+                    },
+                    "links": {
+                        "self": {
+                            "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/refs/branches/feature/test"
+                        },
+                        "commits": {
+                            "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/commits/feature/test"
+                        },
+                        "html": {
+                            "href": "https://bitbucket.org/amuniz/test-repos/branch/feature/test"
+                        },
+                        "pullrequest_create": {
+                            "href": "https://bitbucket.org/amuniz/test-repos/pull-requests/new?source=feature/test&t=1"
+                        }
+                    },
+                    "type": "branch",
+                    "merge_strategies": [
+                        "merge_commit",
+                        "squash",
+                        "fast_forward",
+                        "squash_fast_forward",
+                        "rebase_fast_forward",
+                        "rebase_merge"
+                    ],
+                    "sync_strategies": [
+                        "merge_commit",
+                        "rebase"
+                    ],
+                    "default_merge_strategy": "merge_commit"
+                },
+                "truncated": false,
+                "created": true,
+                "forced": false,
+                "closed": false,
+                "links": {
+                    "commits": {
+                        "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/commits?include=174561d625c9623b60d8aba09b7f08ddc9df45cd"
+                    },
+                    "html": {
+                        "href": "https://bitbucket.org/amuniz/test-repos/branch/feature/test"
+                    }
+                },
+                "commits": [
+                    {
+                        "type": "commit",
+                        "hash": "174561d625c9623b60d8aba09b7f08ddc9df45cd",
+                        "date": "2025-04-26T09:43:26+00:00",
+                        "author": {
+                            "type": "author",
+                            "raw": "Nikolas Falco <email@domain.com>",
+                            "user": {
+                                "display_name": "Nikolas Falco",
+                                "links": {
+                                    "self": {
+                                        "href": "https://api.bitbucket.org/2.0/users/%7B7d3a178a-a087-4756-b2da-2f9eadf50ba8%7D"
+                                    },
+                                    "avatar": {
+                                        "href": "https://secure.gravatar.com/avatar/9979052fd773fbc9c0d94be07bbc8b5d?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FNF-3.png"
+                                    },
+                                    "html": {
+                                        "href": "https://bitbucket.org/%7B7d3a178a-a087-4756-b2da-2f9eadf50ba8%7D/"
+                                    }
+                                },
+                                "type": "user",
+                                "uuid": "{7d3a178a-a087-4756-b2da-2f9eadf50ba8}",
+                                "account_id": "557058:270a1f96-cd27-4013-ade6-85df2ab9820c",
+                                "nickname": "Nikolas Falco"
+                            }
+                        },
+                        "committer": {},
+                        "message": "Add simple pipeline\n",
+                        "summary": {
+                            "type": "rendered",
+                            "raw": "Add simple pipeline\n",
+                            "markup": "markdown",
+                            "html": "<p>Add simple pipeline</p>"
+                        },
+                        "links": {
+                            "self": {
+                                "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/commit/174561d625c9623b60d8aba09b7f08ddc9df45cd"
+                            },
+                            "html": {
+                                "href": "https://bitbucket.org/amuniz/test-repos/commits/174561d625c9623b60d8aba09b7f08ddc9df45cd"
+                            },
+                            "diff": {
+                                "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/diff/174561d625c9623b60d8aba09b7f08ddc9df45cd"
+                            },
+                            "approve": {
+                                "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/commit/174561d625c9623b60d8aba09b7f08ddc9df45cd/approve"
+                            },
+                            "comments": {
+                                "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/commit/174561d625c9623b60d8aba09b7f08ddc9df45cd/comments"
+                            },
+                            "statuses": {
+                                "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/commit/174561d625c9623b60d8aba09b7f08ddc9df45cd/statuses"
+                            },
+                            "patch": {
+                                "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/patch/174561d625c9623b60d8aba09b7f08ddc9df45cd"
+                            }
+                        },
+                        "parents": [
+                            {
+                                "hash": "e43fdffe2def75053da30efa8204d0317a0b932a",
+                                "links": {
+                                    "self": {
+                                        "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/commit/e43fdffe2def75053da30efa8204d0317a0b932a"
+                                    },
+                                    "html": {
+                                        "href": "https://bitbucket.org/amuniz/test-repos/commits/e43fdffe2def75053da30efa8204d0317a0b932a"
+                                    }
+                                },
+                                "type": "commit"
+                            }
+                        ],
+                        "rendered": {},
+                        "properties": {}
+                    },
+                    {
+                        "type": "commit",
+                        "hash": "e43fdffe2def75053da30efa8204d0317a0b932a",
+                        "date": "2025-01-18T16:10:05+00:00",
+                        "author": {
+                            "type": "author",
+                            "raw": "Nikolas Falco <email@domain.com>",
+                            "user": {
+                                "display_name": "Nikolas Falco",
+                                "links": {
+                                    "self": {
+                                        "href": "https://api.bitbucket.org/2.0/users/%7B7d3a178a-a087-4756-b2da-2f9eadf50ba8%7D"
+                                    },
+                                    "avatar": {
+                                        "href": "https://secure.gravatar.com/avatar/9979052fd773fbc9c0d94be07bbc8b5d?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FNF-3.png"
+                                    },
+                                    "html": {
+                                        "href": "https://bitbucket.org/%7B7d3a178a-a087-4756-b2da-2f9eadf50ba8%7D/"
+                                    }
+                                },
+                                "type": "user",
+                                "uuid": "{7d3a178a-a087-4756-b2da-2f9eadf50ba8}",
+                                "account_id": "557058:270a1f96-cd27-4013-ade6-85df2ab9820c",
+                                "nickname": "Nikolas Falco"
+                            }
+                        },
+                        "committer": {},
+                        "message": "Add resource file under a folder to test resource metadata\n",
+                        "summary": {
+                            "type": "rendered",
+                            "raw": "Add resource file under a folder to test resource metadata\n",
+                            "markup": "markdown",
+                            "html": "<p>Add resource file under a folder to test resource metadata</p>"
+                        },
+                        "links": {
+                            "self": {
+                                "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/commit/e43fdffe2def75053da30efa8204d0317a0b932a"
+                            },
+                            "html": {
+                                "href": "https://bitbucket.org/amuniz/test-repos/commits/e43fdffe2def75053da30efa8204d0317a0b932a"
+                            },
+                            "diff": {
+                                "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/diff/e43fdffe2def75053da30efa8204d0317a0b932a"
+                            },
+                            "approve": {
+                                "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/commit/e43fdffe2def75053da30efa8204d0317a0b932a/approve"
+                            },
+                            "comments": {
+                                "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/commit/e43fdffe2def75053da30efa8204d0317a0b932a/comments"
+                            },
+                            "statuses": {
+                                "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/commit/e43fdffe2def75053da30efa8204d0317a0b932a/statuses"
+                            },
+                            "patch": {
+                                "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/patch/e43fdffe2def75053da30efa8204d0317a0b932a"
+                            }
+                        },
+                        "parents": [
+                            {
+                                "hash": "bf4f4ce8a3a8d5c7dbfe7d609973a81a6c6664cf",
+                                "links": {
+                                    "self": {
+                                        "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/commit/bf4f4ce8a3a8d5c7dbfe7d609973a81a6c6664cf"
+                                    },
+                                    "html": {
+                                        "href": "https://bitbucket.org/amuniz/test-repos/commits/bf4f4ce8a3a8d5c7dbfe7d609973a81a6c6664cf"
+                                    }
+                                },
+                                "type": "commit"
+                            }
+                        ],
+                        "rendered": {},
+                        "properties": {}
+                    },
+                    {
+                        "type": "commit",
+                        "hash": "bf4f4ce8a3a8d5c7dbfe7d609973a81a6c6664cf",
+                        "date": "2018-09-21T14:07:25+00:00",
+                        "author": {
+                            "type": "author",
+                            "raw": "Antonio Muniz <amuniz@example.com>"
+                        },
+                        "committer": {},
+                        "message": "Add sample script hello world",
+                        "summary": {
+                            "type": "rendered",
+                            "raw": "Add sample script hello world",
+                            "markup": "markdown",
+                            "html": "<p>Add sample script hello world</p>"
+                        },
+                        "links": {
+                            "self": {
+                                "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/commit/bf4f4ce8a3a8d5c7dbfe7d609973a81a6c6664cf"
+                            },
+                            "html": {
+                                "href": "https://bitbucket.org/amuniz/test-repos/commits/bf4f4ce8a3a8d5c7dbfe7d609973a81a6c6664cf"
+                            },
+                            "diff": {
+                                "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/diff/bf4f4ce8a3a8d5c7dbfe7d609973a81a6c6664cf"
+                            },
+                            "approve": {
+                                "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/commit/bf4f4ce8a3a8d5c7dbfe7d609973a81a6c6664cf/approve"
+                            },
+                            "comments": {
+                                "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/commit/bf4f4ce8a3a8d5c7dbfe7d609973a81a6c6664cf/comments"
+                            },
+                            "statuses": {
+                                "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/commit/bf4f4ce8a3a8d5c7dbfe7d609973a81a6c6664cf/statuses"
+                            },
+                            "patch": {
+                                "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/patch/bf4f4ce8a3a8d5c7dbfe7d609973a81a6c6664cf"
+                            }
+                        },
+                        "parents": [
+                            {
+                                "hash": "8d0fa145bde5151f1d103ab1c3dc1033e6ec4ac1",
+                                "links": {
+                                    "self": {
+                                        "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/commit/8d0fa145bde5151f1d103ab1c3dc1033e6ec4ac1"
+                                    },
+                                    "html": {
+                                        "href": "https://bitbucket.org/amuniz/test-repos/commits/8d0fa145bde5151f1d103ab1c3dc1033e6ec4ac1"
+                                    }
+                                },
+                                "type": "commit"
+                            }
+                        ],
+                        "rendered": {},
+                        "properties": {}
+                    },
+                    {
+                        "type": "commit",
+                        "hash": "8d0fa145bde5151f1d103ab1c3dc1033e6ec4ac1",
+                        "date": "2018-09-21T14:04:55+00:00",
+                        "author": {
+                            "type": "author",
+                            "raw": "Antonio Muniz <amuniz@example.com>"
+                        },
+                        "committer": {},
+                        "message": "Initial commit",
+                        "summary": {
+                            "type": "rendered",
+                            "raw": "Initial commit",
+                            "markup": "markdown",
+                            "html": "<p>Initial commit</p>"
+                        },
+                        "links": {
+                            "self": {
+                                "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/commit/8d0fa145bde5151f1d103ab1c3dc1033e6ec4ac1"
+                            },
+                            "html": {
+                                "href": "https://bitbucket.org/amuniz/test-repos/commits/8d0fa145bde5151f1d103ab1c3dc1033e6ec4ac1"
+                            },
+                            "diff": {
+                                "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/diff/8d0fa145bde5151f1d103ab1c3dc1033e6ec4ac1"
+                            },
+                            "approve": {
+                                "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/commit/8d0fa145bde5151f1d103ab1c3dc1033e6ec4ac1/approve"
+                            },
+                            "comments": {
+                                "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/commit/8d0fa145bde5151f1d103ab1c3dc1033e6ec4ac1/comments"
+                            },
+                            "statuses": {
+                                "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/commit/8d0fa145bde5151f1d103ab1c3dc1033e6ec4ac1/statuses"
+                            },
+                            "patch": {
+                                "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/patch/8d0fa145bde5151f1d103ab1c3dc1033e6ec4ac1"
+                            }
+                        },
+                        "parents": [],
+                        "rendered": {},
+                        "properties": {}
+                    }
+                ]
+            }
+        ]
+    },
+    "repository": {
+        "type": "repository",
+        "full_name": "amuniz/test-repos",
+        "links": {
+            "self": {
+                "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos"
+            },
+            "html": {
+                "href": "https://bitbucket.org/amuniz/test-repos"
+            },
+            "avatar": {
+                "href": "https://bytebucket.org/ravatar/%7B3deb8c29-778a-450c-8f69-3e50a18079df%7D?ts=3693474"
+            }
+        },
+        "name": "test-repos",
+        "scm": "git",
+        "website": null,
+        "owner": {
+            "display_name": "Nikolas Falco",
+            "links": {
+                "self": {
+                    "href": "https://api.bitbucket.org/2.0/users/%7B7d3a178a-a087-4756-b2da-2f9eadf50ba8%7D"
+                },
+                "avatar": {
+                    "href": "https://secure.gravatar.com/avatar/9979052fd773fbc9c0d94be07bbc8b5d?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FNF-3.png"
+                },
+                "html": {
+                    "href": "https://bitbucket.org/%7B7d3a178a-a087-4756-b2da-2f9eadf50ba8%7D/"
+                }
+            },
+            "type": "user",
+            "uuid": "{7d3a178a-a087-4756-b2da-2f9eadf50ba8}",
+            "account_id": "557058:270a1f96-cd27-4013-ade6-85df2ab9820c",
+            "nickname": "Nikolas Falco"
+        },
+        "workspace": {
+            "type": "workspace",
+            "uuid": "{7d3a178a-a087-4756-b2da-2f9eadf50ba8}",
+            "name": "Nikolas Falco",
+            "slug": "nfalco79",
+            "links": {
+                "avatar": {
+                    "href": "https://bitbucket.org/workspaces/nfalco79/avatar/?ts=1737924067"
+                },
+                "html": {
+                    "href": "https://bitbucket.org/nfalco79/"
+                },
+                "self": {
+                    "href": "https://api.bitbucket.org/2.0/workspaces/nfalco79"
+                }
+            }
+        },
+        "is_private": true,
+        "project": {
+            "type": "project",
+            "key": "PUB",
+            "uuid": "{ef731d07-06e0-46d2-9b56-2674649b0655}",
+            "name": "public",
+            "links": {
+                "self": {
+                    "href": "https://api.bitbucket.org/2.0/workspaces/nfalco79/projects/PUB"
+                },
+                "html": {
+                    "href": "https://bitbucket.org/nfalco79/workspace/projects/PUB"
+                },
+                "avatar": {
+                    "href": "https://bitbucket.org/nfalco79/workspace/projects/PUB/avatar/32?ts=1738923688"
+                }
+            }
+        },
+        "uuid": "{3deb8c29-778a-450c-8f69-3e50a18079df}",
+        "parent": null
+    },
+    "actor": {
+        "display_name": "Nikolas Falco",
+        "links": {
+            "self": {
+                "href": "https://api.bitbucket.org/2.0/users/%7B7d3a178a-a087-4756-b2da-2f9eadf50ba8%7D"
+            },
+            "avatar": {
+                "href": "https://secure.gravatar.com/avatar/9979052fd773fbc9c0d94be07bbc8b5d?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FNF-3.png"
+            },
+            "html": {
+                "href": "https://bitbucket.org/%7B7d3a178a-a087-4756-b2da-2f9eadf50ba8%7D/"
+            }
+        },
+        "type": "user",
+        "uuid": "{7d3a178a-a087-4756-b2da-2f9eadf50ba8}",
+        "account_id": "557058:270a1f96-cd27-4013-ade6-85df2ab9820c",
+        "nickname": "Nikolas Falco"
+    }
+}

--- a/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/impl/webhook/cloud/branch_deleted.json
+++ b/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/impl/webhook/cloud/branch_deleted.json
@@ -1,0 +1,194 @@
+{
+    "push": {
+        "changes": [
+            {
+                "old": {
+                    "name": "feature/test",
+                    "target": {
+                        "type": "commit",
+                        "hash": "174561d625c9623b60d8aba09b7f08ddc9df45cd",
+                        "date": "2025-04-26T09:43:26+00:00",
+                        "author": {
+                            "type": "author",
+                            "raw": "Nikolas Falco <email@domain.com>",
+                            "user": {
+                                "display_name": "Nikolas Falco",
+                                "links": {
+                                    "self": {
+                                        "href": "https://api.bitbucket.org/2.0/users/%7B7d3a178a-a087-4756-b2da-2f9eadf50ba8%7D"
+                                    },
+                                    "avatar": {
+                                        "href": "https://secure.gravatar.com/avatar/9979052fd773fbc9c0d94be07bbc8b5d?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FNF-3.png"
+                                    },
+                                    "html": {
+                                        "href": "https://bitbucket.org/%7B7d3a178a-a087-4756-b2da-2f9eadf50ba8%7D/"
+                                    }
+                                },
+                                "type": "user",
+                                "uuid": "{7d3a178a-a087-4756-b2da-2f9eadf50ba8}",
+                                "account_id": "557058:270a1f96-cd27-4013-ade6-85df2ab9820c",
+                                "nickname": "Nikolas Falco"
+                            }
+                        },
+                        "committer": {},
+                        "message": "Add simple pipeline\n",
+                        "summary": {
+                            "type": "rendered",
+                            "raw": "Add simple pipeline\n",
+                            "markup": "markdown",
+                            "html": "<p>Add simple pipeline</p>"
+                        },
+                        "links": {
+                            "self": {
+                                "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/commit/174561d625c9623b60d8aba09b7f08ddc9df45cd"
+                            },
+                            "html": {
+                                "href": "https://bitbucket.org/amuniz/test-repos/commits/174561d625c9623b60d8aba09b7f08ddc9df45cd"
+                            }
+                        },
+                        "parents": [
+                            {
+                                "hash": "e43fdffe2def75053da30efa8204d0317a0b932a",
+                                "links": {
+                                    "self": {
+                                        "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/commit/e43fdffe2def75053da30efa8204d0317a0b932a"
+                                    },
+                                    "html": {
+                                        "href": "https://bitbucket.org/amuniz/test-repos/commits/e43fdffe2def75053da30efa8204d0317a0b932a"
+                                    }
+                                },
+                                "type": "commit"
+                            }
+                        ],
+                        "rendered": {},
+                        "properties": {}
+                    },
+                    "links": {
+                        "self": {
+                            "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/refs/branches/feature/test"
+                        },
+                        "commits": {
+                            "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/commits/feature/test"
+                        },
+                        "html": {
+                            "href": "https://bitbucket.org/amuniz/test-repos/branch/feature/test"
+                        },
+                        "pullrequest_create": {
+                            "href": "https://bitbucket.org/amuniz/test-repos/pull-requests/new?source=feature/test&t=1"
+                        }
+                    },
+                    "type": "branch",
+                    "merge_strategies": [
+                        "merge_commit",
+                        "squash",
+                        "fast_forward",
+                        "squash_fast_forward",
+                        "rebase_fast_forward",
+                        "rebase_merge"
+                    ],
+                    "sync_strategies": [
+                        "merge_commit",
+                        "rebase"
+                    ],
+                    "default_merge_strategy": "merge_commit"
+                },
+                "new": null,
+                "truncated": false,
+                "created": false,
+                "forced": false,
+                "closed": true
+            }
+        ]
+    },
+    "repository": {
+        "type": "repository",
+        "full_name": "amuniz/test-repos",
+        "links": {
+            "self": {
+                "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos"
+            },
+            "html": {
+                "href": "https://bitbucket.org/amuniz/test-repos"
+            },
+            "avatar": {
+                "href": "https://bytebucket.org/ravatar/%7B3deb8c29-778a-450c-8f69-3e50a18079df%7D?ts=3693474"
+            }
+        },
+        "name": "test-repos",
+        "scm": "git",
+        "website": null,
+        "owner": {
+            "display_name": "Nikolas Falco",
+            "links": {
+                "self": {
+                    "href": "https://api.bitbucket.org/2.0/users/%7B7d3a178a-a087-4756-b2da-2f9eadf50ba8%7D"
+                },
+                "avatar": {
+                    "href": "https://secure.gravatar.com/avatar/9979052fd773fbc9c0d94be07bbc8b5d?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FNF-3.png"
+                },
+                "html": {
+                    "href": "https://bitbucket.org/%7B7d3a178a-a087-4756-b2da-2f9eadf50ba8%7D/"
+                }
+            },
+            "type": "user",
+            "uuid": "{7d3a178a-a087-4756-b2da-2f9eadf50ba8}",
+            "account_id": "557058:270a1f96-cd27-4013-ade6-85df2ab9820c",
+            "nickname": "Nikolas Falco"
+        },
+        "workspace": {
+            "type": "workspace",
+            "uuid": "{7d3a178a-a087-4756-b2da-2f9eadf50ba8}",
+            "name": "Nikolas Falco",
+            "slug": "nfalco79",
+            "links": {
+                "avatar": {
+                    "href": "https://bitbucket.org/workspaces/nfalco79/avatar/?ts=1737924067"
+                },
+                "html": {
+                    "href": "https://bitbucket.org/nfalco79/"
+                },
+                "self": {
+                    "href": "https://api.bitbucket.org/2.0/workspaces/nfalco79"
+                }
+            }
+        },
+        "is_private": true,
+        "project": {
+            "type": "project",
+            "key": "PUB",
+            "uuid": "{ef731d07-06e0-46d2-9b56-2674649b0655}",
+            "name": "public",
+            "links": {
+                "self": {
+                    "href": "https://api.bitbucket.org/2.0/workspaces/nfalco79/projects/PUB"
+                },
+                "html": {
+                    "href": "https://bitbucket.org/nfalco79/workspace/projects/PUB"
+                },
+                "avatar": {
+                    "href": "https://bitbucket.org/nfalco79/workspace/projects/PUB/avatar/32?ts=1738923688"
+                }
+            }
+        },
+        "uuid": "{3deb8c29-778a-450c-8f69-3e50a18079df}",
+        "parent": null
+    },
+    "actor": {
+        "display_name": "Nikolas Falco",
+        "links": {
+            "self": {
+                "href": "https://api.bitbucket.org/2.0/users/%7B7d3a178a-a087-4756-b2da-2f9eadf50ba8%7D"
+            },
+            "avatar": {
+                "href": "https://secure.gravatar.com/avatar/9979052fd773fbc9c0d94be07bbc8b5d?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FNF-3.png"
+            },
+            "html": {
+                "href": "https://bitbucket.org/%7B7d3a178a-a087-4756-b2da-2f9eadf50ba8%7D/"
+            }
+        },
+        "type": "user",
+        "uuid": "{7d3a178a-a087-4756-b2da-2f9eadf50ba8}",
+        "account_id": "557058:270a1f96-cd27-4013-ade6-85df2ab9820c",
+        "nickname": "Nikolas Falco"
+    }
+}

--- a/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/impl/webhook/cloud/tag_deleted.json
+++ b/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/impl/webhook/cloud/tag_deleted.json
@@ -1,0 +1,181 @@
+{
+    "push": {
+        "changes": [
+            {
+                "old": {
+                    "name": "test",
+                    "type": "tag",
+                    "message": null,
+                    "date": null,
+                    "tagger": null,
+                    "target": {
+                        "type": "commit",
+                        "hash": "174561d625c9623b60d8aba09b7f08ddc9df45cd",
+                        "date": "2025-04-26T09:43:26+00:00",
+                        "author": {
+                            "type": "author",
+                            "raw": "Nikolas Falco <email@domain.com>",
+                            "user": {
+                                "display_name": "Nikolas Falco",
+                                "links": {
+                                    "self": {
+                                        "href": "https://api.bitbucket.org/2.0/users/%7B7d3a178a-a087-4756-b2da-2f9eadf50ba8%7D"
+                                    },
+                                    "avatar": {
+                                        "href": "https://secure.gravatar.com/avatar/9979052fd773fbc9c0d94be07bbc8b5d?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FNF-3.png"
+                                    },
+                                    "html": {
+                                        "href": "https://bitbucket.org/%7B7d3a178a-a087-4756-b2da-2f9eadf50ba8%7D/"
+                                    }
+                                },
+                                "type": "user",
+                                "uuid": "{7d3a178a-a087-4756-b2da-2f9eadf50ba8}",
+                                "account_id": "557058:270a1f96-cd27-4013-ade6-85df2ab9820c",
+                                "nickname": "Nikolas Falco"
+                            }
+                        },
+                        "committer": {},
+                        "message": "Add simple pipeline\n",
+                        "summary": {
+                            "type": "rendered",
+                            "raw": "Add simple pipeline\n",
+                            "markup": "markdown",
+                            "html": "<p>Add simple pipeline</p>"
+                        },
+                        "links": {
+                            "self": {
+                                "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/commit/174561d625c9623b60d8aba09b7f08ddc9df45cd"
+                            },
+                            "html": {
+                                "href": "https://bitbucket.org/amuniz/test-repos/commits/174561d625c9623b60d8aba09b7f08ddc9df45cd"
+                            }
+                        },
+                        "parents": [
+                            {
+                                "hash": "e43fdffe2def75053da30efa8204d0317a0b932a",
+                                "links": {
+                                    "self": {
+                                        "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/commit/e43fdffe2def75053da30efa8204d0317a0b932a"
+                                    },
+                                    "html": {
+                                        "href": "https://bitbucket.org/amuniz/test-repos/commits/e43fdffe2def75053da30efa8204d0317a0b932a"
+                                    }
+                                },
+                                "type": "commit"
+                            }
+                        ],
+                        "rendered": {},
+                        "properties": {}
+                    },
+                    "links": {
+                        "self": {
+                            "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/refs/tags/test"
+                        },
+                        "commits": {
+                            "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos/commits/test"
+                        },
+                        "html": {
+                            "href": "https://bitbucket.org/amuniz/test-repos/commits/tag/test"
+                        }
+                    }
+                },
+                "new": null,
+                "truncated": false,
+                "created": false,
+                "forced": false,
+                "closed": true
+            }
+        ]
+    },
+    "repository": {
+        "type": "repository",
+        "full_name": "amuniz/test-repos",
+        "links": {
+            "self": {
+                "href": "https://api.bitbucket.org/2.0/repositories/amuniz/test-repos"
+            },
+            "html": {
+                "href": "https://bitbucket.org/amuniz/test-repos"
+            },
+            "avatar": {
+                "href": "https://bytebucket.org/ravatar/%7B3deb8c29-778a-450c-8f69-3e50a18079df%7D?ts=3693474"
+            }
+        },
+        "name": "test-repos",
+        "scm": "git",
+        "website": null,
+        "owner": {
+            "display_name": "Nikolas Falco",
+            "links": {
+                "self": {
+                    "href": "https://api.bitbucket.org/2.0/users/%7B7d3a178a-a087-4756-b2da-2f9eadf50ba8%7D"
+                },
+                "avatar": {
+                    "href": "https://secure.gravatar.com/avatar/9979052fd773fbc9c0d94be07bbc8b5d?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FNF-3.png"
+                },
+                "html": {
+                    "href": "https://bitbucket.org/%7B7d3a178a-a087-4756-b2da-2f9eadf50ba8%7D/"
+                }
+            },
+            "type": "user",
+            "uuid": "{7d3a178a-a087-4756-b2da-2f9eadf50ba8}",
+            "account_id": "557058:270a1f96-cd27-4013-ade6-85df2ab9820c",
+            "nickname": "Nikolas Falco"
+        },
+        "workspace": {
+            "type": "workspace",
+            "uuid": "{7d3a178a-a087-4756-b2da-2f9eadf50ba8}",
+            "name": "Nikolas Falco",
+            "slug": "nfalco79",
+            "links": {
+                "avatar": {
+                    "href": "https://bitbucket.org/workspaces/nfalco79/avatar/?ts=1737924067"
+                },
+                "html": {
+                    "href": "https://bitbucket.org/nfalco79/"
+                },
+                "self": {
+                    "href": "https://api.bitbucket.org/2.0/workspaces/nfalco79"
+                }
+            }
+        },
+        "is_private": true,
+        "project": {
+            "type": "project",
+            "key": "PUB",
+            "uuid": "{ef731d07-06e0-46d2-9b56-2674649b0655}",
+            "name": "public",
+            "links": {
+                "self": {
+                    "href": "https://api.bitbucket.org/2.0/workspaces/nfalco79/projects/PUB"
+                },
+                "html": {
+                    "href": "https://bitbucket.org/nfalco79/workspace/projects/PUB"
+                },
+                "avatar": {
+                    "href": "https://bitbucket.org/nfalco79/workspace/projects/PUB/avatar/32?ts=1738923688"
+                }
+            }
+        },
+        "uuid": "{3deb8c29-778a-450c-8f69-3e50a18079df}",
+        "parent": null
+    },
+    "actor": {
+        "display_name": "Nikolas Falco",
+        "links": {
+            "self": {
+                "href": "https://api.bitbucket.org/2.0/users/%7B7d3a178a-a087-4756-b2da-2f9eadf50ba8%7D"
+            },
+            "avatar": {
+                "href": "https://secure.gravatar.com/avatar/9979052fd773fbc9c0d94be07bbc8b5d?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FNF-3.png"
+            },
+            "html": {
+                "href": "https://bitbucket.org/%7B7d3a178a-a087-4756-b2da-2f9eadf50ba8%7D/"
+            }
+        },
+        "type": "user",
+        "uuid": "{7d3a178a-a087-4756-b2da-2f9eadf50ba8}",
+        "account_id": "557058:270a1f96-cd27-4013-ade6-85df2ab9820c",
+        "nickname": "Nikolas Falco"
+    }
+}


### PR DESCRIPTION
When a tag or branch is deleted the event must return the list of deleted tag and or branches and they must be added to the current request with current available informations.
Differently from PRs that can not be deleted but only closed tags and branches can be deleted and are not more available on remote.