### PR TITLE
[JENKINS-76514] Bitbucket tag deletion event webhook no longer removes jobs

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSourceRequest.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/BitbucketSCMSourceRequest.java
@@ -117,9 +117,6 @@ public class BitbucketSCMSourceRequest extends SCMSourceRequest {
                 @Override
                 public SCMProbeStat stat(@NonNull String path) throws IOException {
                     if (hash == null) {
-                        listener().getLogger() //
-                                .format("Can not resolve path for hash [%s] on repository %s/%s%n", //
-                                        hash, client.getOwner(), client.getRepositoryName());
                         return SCMProbeStat.fromType(Type.NONEXISTENT);
                     }
 

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/impl/webhook/cloud/CloudPushEvent.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/impl/webhook/cloud/CloudPushEvent.java
@@ -121,7 +121,9 @@ final class CloudPushEvent extends AbstractSCMHeadEvent<BitbucketPushEvent> impl
                     // fall back to the jenkins time when the request is processed
                     tagDate = new Date();
                 }
-                BitbucketCloudBranch tagRef = new BitbucketCloudBranch(changeRef.getName(), target.getHash(), tagDate.getTime());
+                // if it is a deletetion than hash does not exists and should be set to null or the job try to get Jenkinsfile of that branch and the Jenkins job is not deleted
+                String hash = change.isCreated() ? target.getHash() : null;
+                BitbucketCloudBranch tagRef = new BitbucketCloudBranch(changeRef.getName(), hash, tagDate.getTime());
                 tagRef.setAuthor(target.getAuthor());
                 tags.add(tagRef);
             }
@@ -149,7 +151,9 @@ final class CloudPushEvent extends AbstractSCMHeadEvent<BitbucketPushEvent> impl
                     // fall back to the jenkins time when the request is processed
                     commitDate = new Date();
                 }
-                branches.add(new BitbucketCloudBranch(changeRef.getName(), target.getHash(), commitDate.getTime()));
+                // if it is a deletetion than hash does not exists and should be set to null or the job try to get Jenkinsfile of that branch and the Jenkins job is not deleted
+                String hash = change.isCreated() ? target.getHash() : null;
+                branches.add(new BitbucketCloudBranch(changeRef.getName(), hash, commitDate.getTime()));
             }
         }
         return branches;

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/impl/webhook/cloud/CloudPushWebhookProcessorTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/impl/webhook/cloud/CloudPushWebhookProcessorTest.java
@@ -183,7 +183,7 @@ class CloudPushWebhookProcessorTest {
             .element(0)
             .satisfies(branch -> {
                 assertThat(branch.getName()).isEqualTo("feature/test");
-                assertThat(branch.getRawNode()).isEqualTo("174561d625c9623b60d8aba09b7f08ddc9df45cd");
+                assertThat(branch.getRawNode()).isNull();
                 assertThat(branch.getDateMillis()).isEqualTo(1745660606000L);
             });
         assertThat(scmEvent.getTags(scmSource)).isEmpty();
@@ -213,6 +213,7 @@ class CloudPushWebhookProcessorTest {
             .satisfies(tag -> {
                 assertThat(tag.getAuthor()).isEqualTo("Nikolas Falco <email@domain.com>");
                 assertThat(tag.getName()).isEqualTo("test");
+                assertThat(tag.getRawNode()).isNull();
             });
         assertThat(scmEvent.getBranches(scmSource)).isEmpty();
         assertThat(scmEvent.getPullRequests(scmSource)).isEmpty();


### PR DESCRIPTION
Fix CloudPushEvent getTag and getBranch when tag and branches has been removed. In these cases the hash is not populated (beccause does not exists anymore) this allow Jenkins to not observe anymore the Item and mark as deleted.