### PR TITLE
[JENKINS-76514] Bitbucket tag deletion event webhook no longer removes jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,11 +80,11 @@ Support to run Server under Windows has been dismissed since version 7.14+
 
 ### Run inside docker
 
-1. run `docker pull nolddor/atlassian-sdk:17-jdk`
+1. run `docker pull nolddor/atlassian-sdk:21-jdk`
 2. run `docker run -it -p 7990:7990 -p 7999:7999 -v %USER%\.m2:/root/.m2 nolddor/atlassian-sdk:21-jdk`
 3. Inside the container:
    - install a compatible version of git 2.49 ~ 2.51 (not supported for Alpine image 2.33)
      - download git binary apk with `wget http://dl-cdn.alpinelinux.org/alpine/v3.22/main/x86_64/git-2.49.1-r0.apk`
-     - download git git binary support for http `wget http://dl-cdn.alpinelinux.org/alpine/v3.22/main/x86_64/git-daemon-2.49.1-r0.apk`
+     - download git binary support for http `wget http://dl-cdn.alpinelinux.org/alpine/v3.22/main/x86_64/git-daemon-2.49.1-r0.apk`
    - install with `apk add --allow-untrusted git-2.49.1-r0.apk git-daemon-2.49.1-r0.apk`
    - run `/opt/atlassian-plugin-sdk/bin/atlas-run-standalone --product bitbucket --version 10.3.0 --data-version 10.3.0 "-Dfeature.public.access=true"`

--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/impl/webhook/server/ServerPushEvent.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/impl/webhook/server/ServerPushEvent.java
@@ -35,6 +35,7 @@ import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketAuthenticator;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketBranch;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketCommit;
 import com.cloudbees.jenkins.plugins.bitbucket.api.BitbucketPullRequest;
+import com.cloudbees.jenkins.plugins.bitbucket.api.HasBranches;
 import com.cloudbees.jenkins.plugins.bitbucket.api.HasPullRequests;
 import com.cloudbees.jenkins.plugins.bitbucket.api.HasTags;
 import com.cloudbees.jenkins.plugins.bitbucket.server.client.BitbucketServerAPIClient;
@@ -72,7 +73,10 @@ import org.apache.commons.lang3.Strings;
 
 import static java.util.Objects.requireNonNull;
 
-final class ServerPushEvent extends AbstractNativeServerSCMHeadEvent<Collection<NativeServerChange>> implements HasPullRequests, HasTags {
+final class ServerPushEvent extends AbstractNativeServerSCMHeadEvent<Collection<NativeServerChange>> implements HasPullRequests, HasTags, HasBranches {
+
+    private static final String TYPE_TAG = "TAG";
+    private static final String TYPE_BRANCH = "BRANCH";
 
     private static final class CacheKey {
         @NonNull
@@ -147,12 +151,12 @@ final class ServerPushEvent extends AbstractNativeServerSCMHeadEvent<Collection<
         for (final NativeServerChange change : getPayload()) {
             String refType = change.getRef().getType();
 
-            if ("BRANCH".equals(refType)) {
+            if (TYPE_BRANCH.equals(refType)) {
                 final BranchSCMHead head = new BranchSCMHead(change.getRef().getDisplayId());
                 final SCMRevision revision = getType() == SCMEvent.Type.REMOVED ? null
                         : new AbstractGitSCMSource.SCMRevisionImpl(head, change.getToHash());
                 result.put(head, revision);
-            } else if ("TAG".equals(refType)) {
+            } else if (TYPE_TAG.equals(refType)) {
                 String tagName = change.getRef().getDisplayId();
                 long tagTimestamp = 0L;
                 try (BitbucketApi client = getClient(src)) {
@@ -231,7 +235,7 @@ final class ServerPushEvent extends AbstractNativeServerSCMHeadEvent<Collection<
             ? ctx.originPRStrategies() : ctx.forkPRStrategies();
 
         for (final NativeServerChange change : getPayload()) {
-            if (!"BRANCH".equals(change.getRef().getType())) {
+            if (!TYPE_BRANCH.equals(change.getRef().getType())) {
                 LOGGER.log(Level.INFO, "Received event for unknown ref type {0} of ref {1}",
                     new Object[] { change.getRef().getType(), change.getRef().getDisplayId() });
                 continue;
@@ -347,7 +351,7 @@ final class ServerPushEvent extends AbstractNativeServerSCMHeadEvent<Collection<
         for (final NativeServerChange change : getPayload()) {
             String refType = change.getRef().getType();
 
-            if ("TAG".equals(refType)) {
+            if (TYPE_TAG.equals(refType)) {
                 String tagName = change.getRef().getDisplayId();
                 String tagHash;
                 switch (change.getType()) {
@@ -356,7 +360,7 @@ final class ServerPushEvent extends AbstractNativeServerSCMHeadEvent<Collection<
                     break;
                 }
                 case "DELETE": {
-                    tagHash = !NULL_HASH.equals(change.getFromHash()) ? change.getFromHash() : change.getToHash();
+                    tagHash = null;
                     break;
                 }
                 default:
@@ -372,7 +376,7 @@ final class ServerPushEvent extends AbstractNativeServerSCMHeadEvent<Collection<
                             .orElse(0L);
                     tagHead.setTimestamp(tagTimestamp);
                     tagHead.setAuthor(refCommit.getAuthor());
-                } else {
+                } else if (tagHash != null) {
                     try (BitbucketApi client = getClient(src)) {
                         BitbucketCommit tag = client.resolveCommit(tagHash);
                         if (tag != null) {
@@ -390,6 +394,57 @@ final class ServerPushEvent extends AbstractNativeServerSCMHeadEvent<Collection<
             }
         }
         return tags;
+    }
+
+    @Override
+    public Iterable<BitbucketBranch> getBranches(BitbucketSCMSource src) {
+        List<BitbucketBranch> branches = new ArrayList<>();
+        for (final NativeServerChange change : getPayload()) {
+            String refType = change.getRef().getType();
+
+            if (TYPE_BRANCH.equals(refType)) {
+                String name = change.getRef().getDisplayId();
+                String hash;
+                switch (change.getType()) {
+                case "ADD": {
+                    hash = change.getToHash();
+                    break;
+                }
+                case "DELETE": {
+                    hash = null;
+                    break;
+                }
+                default:
+                    throw new UnsupportedOperationException("Tag event of type " + change.getType()
+                        + " is not supported.\nPlease fill an issue at https://issues.jenkins.io to the bitbucket-branch-source-plugin component.");
+                }
+                BitbucketServerBranch head = new BitbucketServerBranch(name, hash);
+                if (refCommit != null) {
+                    // the annotated tag hash it's an alias of a real commit and it's the refCommit (new head commit)
+                    // it's not needed check if refCommit and tagCommit are equals
+                    long tagTimestamp = Optional.ofNullable(refCommit.getCommitterDate())
+                            .map(Date::getTime)
+                            .orElse(0L);
+                    head.setTimestamp(tagTimestamp);
+                    head.setAuthor(refCommit.getAuthor());
+                } else if (hash != null) {
+                    try (BitbucketApi client = getClient(src)) {
+                        BitbucketCommit tag = client.resolveCommit(hash);
+                        if (tag != null) {
+                            long tagTimestamp = Optional.ofNullable(tag.getCommitterDate())
+                                    .map(Date::getTime)
+                                    .orElse(0L);
+                            head.setTimestamp(tagTimestamp);
+                            head.setAuthor(tag.getAuthor());
+                        }
+                    } catch (IOException e) {
+                        LOGGER.log(Level.SEVERE, "Fail to retrive the timestamp for tag event {0}", name);
+                    }
+                }
+                branches.add(head);
+            }
+        }
+        return branches;
     }
 
 }

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/impl/webhook/server/ServerPushWebhookProcessorTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/impl/webhook/server/ServerPushWebhookProcessorTest.java
@@ -32,6 +32,7 @@ import com.cloudbees.jenkins.plugins.bitbucket.api.endpoint.BitbucketEndpoint;
 import com.cloudbees.jenkins.plugins.bitbucket.client.BitbucketIntegrationClientFactory;
 import com.cloudbees.jenkins.plugins.bitbucket.hooks.HookEventType;
 import com.cloudbees.jenkins.plugins.bitbucket.impl.util.JsonParser;
+import com.cloudbees.jenkins.plugins.bitbucket.server.client.branch.BitbucketServerBranch;
 import com.cloudbees.jenkins.plugins.bitbucket.server.events.NativeServerRefsChangedEvent;
 import com.cloudbees.jenkins.plugins.bitbucket.test.util.HookProcessorTestUtil;
 import hudson.scm.SCM;
@@ -210,6 +211,16 @@ class ServerPushWebhookProcessorTest {
             .first()
             .usingRecursiveComparison()
             .isEqualTo(new BitbucketTagSCMHead("simple-tag", 1537538991000L));
+
+        Iterable<BitbucketBranch> tags = scmEvent.getTags(scmSource);
+        assertThat(tags).isNotEmpty()
+            .hasSize(1)
+            .first()
+            .satisfies(tag -> {
+                assertThat(tag.getName()).isEqualTo("simple-tag");
+                assertThat(tag.getRawNode()).isNull(); // JENKINS-76514
+                assertThat(tag.getAuthor()).isNull(); // JENKINS-76514
+            });
     }
 
     @Test
@@ -240,6 +251,25 @@ class ServerPushWebhookProcessorTest {
             .first()
             .usingRecursiveComparison()
             .isEqualTo(new AbstractGitSCMSource.SCMRevisionImpl(new BranchSCMHead("main"), "9fdd7b96d3f5c276d0b9e0bf38c879eb112d889a"));
+    }
+
+    @Test
+    @Issue("JENKINS-76514")
+    void test_create_branch() throws Exception {
+        sut.process(HookEventType.SERVER_REFS_CHANGED.getKey(), loadResource("branch_deleted.json"), Collections.emptyMap(), endpoint);
+
+        ServerPushEvent event = (ServerPushEvent) scmEvent;
+        assertThat(event).isNotNull();
+        assertThat(event.getSourceName()).isEqualTo("test-repos");
+        assertThat(event.getType()).isEqualTo(SCMEvent.Type.REMOVED);
+        assertThat(event.isMatch(mock(SCM.class))).isFalse();
+
+        BitbucketSCMSource scmSource = new BitbucketSCMSource("ASMUNIZ", "test-repos");
+        Iterable<BitbucketBranch> branches = event.getBranches(scmSource);
+        assertThat(branches).hasSize(1)
+            .first()
+            .usingRecursiveComparison()
+            .isEqualTo(new BitbucketServerBranch("feature/BB-1", null));
     }
 
     @Test

--- a/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/server/events/BitbucketServerPushEventTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/bitbucket/server/events/BitbucketServerPushEventTest.java
@@ -64,6 +64,7 @@ class BitbucketServerPushEventTest {
             .isEqualTo("http://local.example.com:7990/bitbucket/projects/PROJECT_1/repos/rep_1/browse");
         assertThat(event.getChanges()).hasSize(1);
     }
+
     @Test
     void legacyPayload() throws Exception {
         BitbucketPushEvent event = BitbucketServerWebhookPayload.pushEventFromPayload(payload);

--- a/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/impl/webhook/server/branch_deleted.json
+++ b/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/impl/webhook/server/branch_deleted.json
@@ -1,0 +1,58 @@
+{
+    "date": "2026-08-19T17:19:10+0000",
+    "actor": {
+        "emailAddress": "admin@example.com",
+        "displayName": "Administrator",
+        "name": "admin",
+        "active": true,
+        "links": {"self": [{"href": "http://localhost:7990/bitbucket/users/admin"}]},
+        "id": 2,
+        "type": "NORMAL",
+        "slug": "admin"
+    },
+    "eventKey": "repo:refs_changed",
+    "changes": [{
+        "ref": {
+            "id": "refs/heads/feature/BB-1",
+            "displayId": "feature/BB-1",
+            "type": "BRANCH"
+        },
+        "fromHash": "fb522a6f08c7c7df337312e4e65ec1b57710672e",
+        "toHash": "0000000000000000000000000000000000000000",
+        "refId": "refs/heads/feature/BB-1",
+        "type": "DELETE"
+    }],
+    "repository": {
+        "archived": false,
+        "public": false,
+        "hierarchyId": "e09ea1ec1e0b9858be28",
+        "name": "test-repos",
+        "forkable": true,
+        "project": {
+            "public": false,
+            "name": "AMUNIZ",
+            "links": {"self": [{"href": "http://localhost:7990/bitbucket/projects/AMUNIZ"}]},
+            "id": 2,
+            "type": "NORMAL",
+            "key": "AMUNIZ"
+        },
+        "links": {
+            "clone": [
+                {
+                    "name": "http",
+                    "href": "http://localhost:7990/bitbucket/scm/amuniz/test-repos.git"
+                },
+                {
+                    "name": "ssh",
+                    "href": "ssh://git@localhost:7999/amuniz/test-repos.git"
+                }
+            ],
+            "self": [{"href": "http://localhost:7990/bitbucket/projects/AMUNIZ/repos/test-repos/browse"}]
+        },
+        "id": 2,
+        "scmId": "git",
+        "state": "AVAILABLE",
+        "slug": "test-repos",
+        "statusMessage": "Available"
+    }
+}

--- a/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/server/events/BitbucketServerPullRequestEventTest/deletePRPayload.json
+++ b/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/server/events/BitbucketServerPullRequestEventTest/deletePRPayload.json
@@ -1,0 +1,123 @@
+{
+    "date": "2026-08-19T17:28:47+0000",
+    "actor": {
+        "emailAddress": "admin@example.com",
+        "displayName": "Administrator",
+        "name": "admin",
+        "active": true,
+        "links": {"self": [{"href": "http://localhost:7990/bitbucket/users/admin"}]},
+        "id": 2,
+        "type": "NORMAL",
+        "slug": "admin"
+    },
+    "eventKey": "pr:deleted",
+    "pullRequest": {
+        "author": {
+            "approved": false,
+            "role": "AUTHOR",
+            "user": {
+                "emailAddress": "admin@example.com",
+                "displayName": "Administrator",
+                "name": "admin",
+                "active": true,
+                "links": {"self": [{"href": "http://localhost:7990/bitbucket/users/admin"}]},
+                "id": 2,
+                "type": "NORMAL",
+                "slug": "admin"
+            },
+            "status": "UNAPPROVED"
+        },
+        "description": "* Provide some change to work diffstats:\n    * add a new\n    * modify a file\n    * rename a file\n* Provide some change to work diffstats:\n    * add a new",
+        "updatedDate": "2026-08-19T17:27:55.266Z",
+        "title": "Feature/diffstat",
+        "version": 0,
+        "reviewers": [],
+        "toRef": {
+            "latestCommit": "174561d625c9623b60d8aba09b7f08ddc9df45cd",
+            "id": "refs/heads/master",
+            "displayId": "master",
+            "type": "BRANCH",
+            "repository": {
+                "archived": false,
+                "public": false,
+                "hierarchyId": "e09ea1ec1e0b9858be28",
+                "name": "test-repos",
+                "forkable": true,
+                "project": {
+                    "public": false,
+                    "name": "AMUNIZ",
+                    "links": {"self": [{"href": "http://localhost:7990/bitbucket/projects/AMUNIZ"}]},
+                    "id": 2,
+                    "type": "NORMAL",
+                    "key": "AMUNIZ"
+                },
+                "links": {
+                    "clone": [
+                        {
+                            "name": "http",
+                            "href": "http://localhost:7990/bitbucket/scm/amuniz/test-repos.git"
+                        },
+                        {
+                            "name": "ssh",
+                            "href": "ssh://git@localhost:7999/amuniz/test-repos.git"
+                        }
+                    ],
+                    "self": [{"href": "http://localhost:7990/bitbucket/projects/AMUNIZ/repos/test-repos/browse"}]
+                },
+                "id": 2,
+                "scmId": "git",
+                "state": "AVAILABLE",
+                "slug": "test-repos",
+                "statusMessage": "Available"
+            }
+        },
+        "createdDate": "2026-08-19T17:27:55.266Z",
+        "draft": false,
+        "closed": false,
+        "fromRef": {
+            "latestCommit": "251fce291f086cdde68ae2a896148abb5b58033e",
+            "id": "refs/heads/feature/diffstat",
+            "displayId": "feature/diffstat",
+            "type": "BRANCH",
+            "repository": {
+                "archived": false,
+                "public": false,
+                "hierarchyId": "e09ea1ec1e0b9858be28",
+                "name": "test-repos",
+                "forkable": true,
+                "project": {
+                    "public": false,
+                    "name": "AMUNIZ",
+                    "links": {"self": [{"href": "http://localhost:7990/bitbucket/projects/AMUNIZ"}]},
+                    "id": 2,
+                    "type": "NORMAL",
+                    "key": "AMUNIZ"
+                },
+                "links": {
+                    "clone": [
+                        {
+                            "name": "http",
+                            "href": "http://localhost:7990/bitbucket/scm/amuniz/test-repos.git"
+                        },
+                        {
+                            "name": "ssh",
+                            "href": "ssh://git@localhost:7999/amuniz/test-repos.git"
+                        }
+                    ],
+                    "self": [{"href": "http://localhost:7990/bitbucket/projects/AMUNIZ/repos/test-repos/browse"}]
+                },
+                "id": 2,
+                "scmId": "git",
+                "state": "AVAILABLE",
+                "slug": "test-repos",
+                "statusMessage": "Available"
+            }
+        },
+        "links": {"self": [{"href": "http://localhost:7990/bitbucket/projects/AMUNIZ/repos/test-repos/pull-requests/1"}]},
+        "id": 1,
+        "state": "OPEN",
+        "locked": false,
+        "open": true,
+        "participants": []
+    }
+}

--- a/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/server/events/BitbucketServerPullRequestEventTest/newPRPayload.json
+++ b/src/test/resources/com/cloudbees/jenkins/plugins/bitbucket/server/events/BitbucketServerPullRequestEventTest/newPRPayload.json
@@ -1,0 +1,123 @@
+{
+    "date": "2026-08-19T17:27:55+0000",
+    "actor": {
+        "emailAddress": "admin@example.com",
+        "displayName": "Administrator",
+        "name": "admin",
+        "active": true,
+        "links": {"self": [{"href": "http://localhost:7990/bitbucket/users/admin"}]},
+        "id": 2,
+        "type": "NORMAL",
+        "slug": "admin"
+    },
+    "eventKey": "pr:opened",
+    "pullRequest": {
+        "author": {
+            "approved": false,
+            "role": "AUTHOR",
+            "user": {
+                "emailAddress": "admin@example.com",
+                "displayName": "Administrator",
+                "name": "admin",
+                "active": true,
+                "links": {"self": [{"href": "http://localhost:7990/bitbucket/users/admin"}]},
+                "id": 2,
+                "type": "NORMAL",
+                "slug": "admin"
+            },
+            "status": "UNAPPROVED"
+        },
+        "description": "* Provide some change to work diffstats:\n    * add a new\n    * modify a file\n    * rename a file\n* Provide some change to work diffstats:\n    * add a new",
+        "updatedDate": "2026-08-19T17:27:55.266Z",
+        "title": "Feature/diffstat",
+        "version": 0,
+        "reviewers": [],
+        "toRef": {
+            "latestCommit": "174561d625c9623b60d8aba09b7f08ddc9df45cd",
+            "id": "refs/heads/master",
+            "displayId": "master",
+            "type": "BRANCH",
+            "repository": {
+                "archived": false,
+                "public": false,
+                "hierarchyId": "e09ea1ec1e0b9858be28",
+                "name": "test-repos",
+                "forkable": true,
+                "project": {
+                    "public": false,
+                    "name": "AMUNIZ",
+                    "links": {"self": [{"href": "http://localhost:7990/bitbucket/projects/AMUNIZ"}]},
+                    "id": 2,
+                    "type": "NORMAL",
+                    "key": "AMUNIZ"
+                },
+                "links": {
+                    "clone": [
+                        {
+                            "name": "http",
+                            "href": "http://localhost:7990/bitbucket/scm/amuniz/test-repos.git"
+                        },
+                        {
+                            "name": "ssh",
+                            "href": "ssh://git@localhost:7999/amuniz/test-repos.git"
+                        }
+                    ],
+                    "self": [{"href": "http://localhost:7990/bitbucket/projects/AMUNIZ/repos/test-repos/browse"}]
+                },
+                "id": 2,
+                "scmId": "git",
+                "state": "AVAILABLE",
+                "slug": "test-repos",
+                "statusMessage": "Available"
+            }
+        },
+        "createdDate": "2026-08-19T17:27:55.266Z",
+        "draft": false,
+        "closed": false,
+        "fromRef": {
+            "latestCommit": "251fce291f086cdde68ae2a896148abb5b58033e",
+            "id": "refs/heads/feature/diffstat",
+            "displayId": "feature/diffstat",
+            "type": "BRANCH",
+            "repository": {
+                "archived": false,
+                "public": false,
+                "hierarchyId": "e09ea1ec1e0b9858be28",
+                "name": "test-repos",
+                "forkable": true,
+                "project": {
+                    "public": false,
+                    "name": "AMUNIZ",
+                    "links": {"self": [{"href": "http://localhost:7990/bitbucket/projects/AMUNIZ"}]},
+                    "id": 2,
+                    "type": "NORMAL",
+                    "key": "AMUNIZ"
+                },
+                "links": {
+                    "clone": [
+                        {
+                            "name": "http",
+                            "href": "http://localhost:7990/bitbucket/scm/amuniz/test-repos.git"
+                        },
+                        {
+                            "name": "ssh",
+                            "href": "ssh://git@localhost:7999/amuniz/test-repos.git"
+                        }
+                    ],
+                    "self": [{"href": "http://localhost:7990/bitbucket/projects/AMUNIZ/repos/test-repos/browse"}]
+                },
+                "id": 2,
+                "scmId": "git",
+                "state": "AVAILABLE",
+                "slug": "test-repos",
+                "statusMessage": "Available"
+            }
+        },
+        "links": {"self": [{"href": "http://localhost:7990/bitbucket/projects/AMUNIZ/repos/test-repos/pull-requests/1"}]},
+        "id": 1,
+        "state": "OPEN",
+        "locked": false,
+        "open": true,
+        "participants": []
+    }
+}


### PR DESCRIPTION
Fix ServerPushEvent getTag and getBranch when tag and branches has been removed.