### PR TITLE
[JENKINS-76519] Automatic builds are no longer triggered after push commit on branch

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/impl/webhook/server/ServerPushEvent.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/impl/webhook/server/ServerPushEvent.java
@@ -404,20 +404,7 @@ final class ServerPushEvent extends AbstractNativeServerSCMHeadEvent<Collection<
 
             if (TYPE_BRANCH.equals(refType)) {
                 String name = change.getRef().getDisplayId();
-                String hash;
-                switch (change.getType()) {
-                case "ADD": {
-                    hash = change.getToHash();
-                    break;
-                }
-                case "DELETE": {
-                    hash = null;
-                    break;
-                }
-                default:
-                    throw new UnsupportedOperationException("Tag event of type " + change.getType()
-                        + " is not supported.\nPlease fill an issue at https://issues.jenkins.io to the bitbucket-branch-source-plugin component.");
-                }
+                String hash = "DELETE".equals(change.getType()) ? null : change.getToHash();
                 BitbucketServerBranch head = new BitbucketServerBranch(name, hash);
                 if (refCommit != null) {
                     // the annotated tag hash it's an alias of a real commit and it's the refCommit (new head commit)


### PR DESCRIPTION
Fix ServerPushEvent.getBranches in case of update commit on branch